### PR TITLE
fix: asserting acc length only one time on load_acc

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -630,9 +630,9 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let (leaves, _) =
             deserialize_partial::<u64>(&leaves).expect("load_acc: Invalid num_leaves");
         let mut roots = Vec::new();
+        // Since we only expect hashes after the num_leaves, the length of the acc have to be a multiple of 32.
+        assert_eq!(acc.len() % 32, 0);
         while acc.len() >= 32 {
-            // Since we only expect hashes after the num_leaves, it should always align with 32 bytes
-            assert_eq!(acc.len() % 32, 0);
             let root = acc.drain(0..32).collect::<Vec<u8>>();
             let root = NodeHash::from(&*root);
             roots.push(root);


### PR DESCRIPTION
Removes the assertion from the while loop.

Logically, if you already have a length that initially is a multiple of 32 and is always removing 32 from the length, theres no need to check if its a multiple of 32 again.