### PR TITLE
Transport protocol visibility

### DIFF
--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -82,8 +82,8 @@ pub trait FlorestaRPC {
     /// Gets information about the peers we're connected with
     ///
     /// This method returns information about the peers we're connected with. This includes
-    /// the peer's IP address, the peer's version, the peer's user agent, and the peer's
-    /// current height.
+    /// the peer's IP address, the peer's version, the peer's user agent, the transport protocol
+    /// and the peer's current height.
     fn get_peer_info(&self) -> Result<Vec<PeerInfo>>;
     /// Returns a block, given a block hash
     ///

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -171,6 +171,8 @@ pub struct PeerInfo {
     ///
     /// Can be either Ready, Connecting or Banned
     pub state: String,
+    /// The transport protocol used with peer.
+    pub transport_protocol: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 
 use super::node::ConnectionKind;
 use super::node::PeerStatus;
+use super::transport::TransportProtocol;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UserRequest {
@@ -29,6 +30,7 @@ pub struct PeerInfo {
     pub initial_height: u32,
     pub state: PeerStatus,
     pub kind: ConnectionKind,
+    pub transport_protocol: TransportProtocol,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -32,6 +32,7 @@ use super::mempool::Mempool;
 use super::node::NodeNotification;
 use super::node::NodeRequest;
 use super::transport::TransportError;
+use super::transport::TransportProtocol;
 use super::transport::WriteTransport;
 use crate::node::ConnectionKind;
 use crate::p2p_wire::transport::ReadTransport;
@@ -114,6 +115,7 @@ pub struct Peer<T: AsyncWrite + Unpin + Send + Sync> {
     writer: WriteTransport<T>,
     our_user_agent: String,
     cancellation_sender: tokio::sync::oneshot::Sender<()>,
+    transport_protocol: TransportProtocol,
 }
 
 #[derive(Debug, Error)]
@@ -492,6 +494,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                         address_id: self.address_id,
                         services: self.services,
                         kind: self.kind,
+                        transport_protocol: self.transport_protocol,
                     }))
                     .await;
                 }
@@ -550,6 +553,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         writer: WriteTransport<W>,
         our_user_agent: String,
         cancellation_sender: tokio::sync::oneshot::Sender<()>,
+        transport_protocol: TransportProtocol,
     ) {
         let peer = Peer {
             address_id,
@@ -574,6 +578,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             writer,
             our_user_agent,
             cancellation_sender,
+            transport_protocol,
         };
 
         spawn(peer.read_loop());
@@ -670,6 +675,7 @@ pub struct Version {
     pub address_id: usize,
     pub services: ServiceFlags,
     pub kind: ConnectionKind,
+    pub transport_protocol: TransportProtocol,
 }
 /// Messages passed from different modules to the main node to process. They should minimal
 /// and only if it requires global states, everything else should be handled by the module

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -29,6 +29,7 @@ use crate::node::PeerStatus;
 use crate::p2p_wire::node::ConnectionKind;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
+use crate::p2p_wire::transport::TransportProtocol;
 use crate::UtreexoNodeConfig;
 
 /// A list of headers, used to represent the collection of headers.
@@ -101,6 +102,7 @@ impl TestPeer {
                 | ServiceFlags::COMPACT_FILTERS
                 | ServiceFlags::from(1 << 25),
             kind: ConnectionKind::Regular(UTREEXO.into()),
+            transport_protocol: TransportProtocol::V2,
         };
 
         self.node_tx
@@ -167,6 +169,7 @@ pub fn create_peer(
         banscore: 0,
         address_id: 0,
         _last_message: Instant::now(),
+        transport_protocol: TransportProtocol::V2,
     }
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

Part of the followup work in #416 for the V2 transport.

* Log the state of transport initialization for visibility.
* Plumb through the transport protocol version in order to expose to the user.

### Checklist

- [x] I've signed all my commits
- [x] I ran `just lint`
- [x] I ran `cargo test`
- [ ] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
