### PR TITLE
Simplify scriptPubKey reconstruction, fix naming

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -602,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    // Bitcoin Consensus rules dictate that a scriptPubkey that's more than 10_000 bytes long
+    // Bitcoin Consensus rules dictate that a scriptPubKey that's more than 10_000 bytes long
     // won't be spendable. However, such an output **can** be created. We only check those
     // sizes when it gets spent.
     //

--- a/florestad/src/slip132.rs
+++ b/florestad/src/slip132.rs
@@ -147,32 +147,32 @@ pub struct KeyVersion([u8; 4]);
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct DefaultResolver;
 
-/// SLIP 132-defined key applications defining types of scriptPubkey descriptors
+/// SLIP 132-defined key applications defining types of scriptPubKey descriptors
 /// in which they can be used
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum KeyApplication {
     /// xprv/xpub: keys that can be used for P2PKH and multisig P2SH
-    /// scriptPubkey descriptors.
+    /// scriptPubKey descriptors.
     #[serde(rename = "bip44")]
     Hashed,
 
-    /// zprv/zpub: keys that can be used for P2WPKH scriptPubkey descriptors
+    /// zprv/zpub: keys that can be used for P2WPKH scriptPubKey descriptors
     #[serde(rename = "bip84")]
     SegWit,
 
-    /// Zprv/Zpub: keys that can be used for multisig P2WSH scriptPubkey
+    /// Zprv/Zpub: keys that can be used for multisig P2WSH scriptPubKey
     /// descriptors
     #[serde(rename = "bip48-native")]
     SegWitMultisig,
 
-    /// yprv/ypub: keys that can be used for P2WPKH-in-P2SH scriptPubkey
+    /// yprv/ypub: keys that can be used for P2WPKH-in-P2SH scriptPubKey
     /// descriptors
     #[serde(rename = "bip49")]
     Nested,
 
     /// Yprv/Ypub: keys that can be used for multisig P2WSH-in-P2SH
-    /// scriptPubkey descriptors
+    /// scriptPubKey descriptors
     #[serde(rename = "bip48-nested")]
     NestedMultisig,
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Simplification and renaming

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Some small changes. I have replaced

```rust
ScriptBuf::from_bytes(bytes.as_bytes().to_vec()).script_hash()
```

by

```rust
ScriptHash::hash(bytes.as_bytes())
```

Which must be fully equivalent since the `script_hash` method is calling the same `ScriptHash::hash(self.as_bytes())`, see https://docs.rs/bitcoin/0.32.5/bitcoin/struct.ScriptBuf.html#method.script_hash.

Then I fixed the `scriptPubkey` mentions to the correct `scriptPubKey` nomenclature (capital K), and renamed `ScriptPubkeyType` to `ScriptPubKeyKind` which is a bit more idiomatic.