### PR TITLE
wire: fix a small bug with handle_disconnection

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -707,12 +707,17 @@ where
     ) -> Result<(), WireError> {
         match req {
             InflightRequests::Blocks(block) => {
+                if !self.has_utreexo_peers() {
+                    return Ok(());
+                }
+
                 let peer = self
                     .send_to_random_peer(
                         NodeRequest::GetBlock((vec![block], true)),
                         service_flags::UTREEXO.into(),
                     )
                     .await?;
+
                 self.inflight
                     .insert(InflightRequests::Blocks(block), (peer, Instant::now()));
             }
@@ -737,6 +742,9 @@ where
                     .insert(InflightRequests::UtreexoState(peer), (peer, Instant::now()));
             }
             InflightRequests::GetFilters => {
+                if !self.has_compact_filters_peer() {
+                    return Ok(());
+                }
                 let peer = self
                     .send_to_random_peer(
                         NodeRequest::GetFilter((self.chain.get_block_hash(0).unwrap(), 0)),

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -345,6 +345,13 @@ where
                     }
 
                     PeerMessages::Disconnected(idx) => {
+                        // check if this peer had inflight block requests, if so, bring our
+                        // `last_block_requested` back
+                        if self.inflight.values().any(|(peer_id, _)| *peer_id == peer) {
+                            self.context.last_block_requested =
+                                self.chain.get_validation_index()?;
+                        }
+
                         try_and_log!(self.handle_disconnection(peer, idx).await);
                     }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

If a peer disconnects, we re-do all inflight requests that we had with that peer. However, the code that does so may fail early if `redo_inflight_request` return an error. It is the case if we request for utreexo data or compact block filters without having a peer that supports those requests. This commit adds an early check that makes these functions act as a no-op in case we can't fulfill the request.

It is not a problem to not re-request stuff here, since we already have some fallback logic that will try it again.

