### PR TITLE
Added `is_running` flag

### DIFF
--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -43,6 +43,8 @@ class Node:
         """
         Start the node.
         """
+        if self.daemon.is_running:
+            raise RuntimeError(f"Node '{self.variant}' is already running.")
         self.daemon.start()
         self.rpc.wait_for_connections(opened=True)
 
@@ -50,10 +52,12 @@ class Node:
         """
         Stop the node.
         """
-        response = self.rpc.stop()
-        self.rpc.wait_for_connections(opened=False)
-        self.daemon.process.wait()
-        return response
+        if self.daemon.is_running:
+            response = self.rpc.stop()
+            self.rpc.wait_for_connections(opened=False)
+            self.daemon.process.wait()
+            return response
+        return None
 
 
 class FlorestaTestMetaClass(type):

--- a/tests/test_framework/daemon/base.py
+++ b/tests/test_framework/daemon/base.py
@@ -172,6 +172,11 @@ class BaseDaemon(metaclass=BaseDaemonMetaClass):
         """Setter for `settings` property"""
         self._settings = value
 
+    @property
+    def is_running(self) -> bool:
+        """Check if the daemon process is running"""
+        return self.process is not None and self.process.poll() is None
+
     def start(self):
         """
         Start the daemon process in regtest mode. If any extra-arg is needed,


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: test_framework.

### Description

* added `is_running` dynamic property to `BaseDaemon`;
* added a `is_running` check clause to `stop` method of `Node` class in `test_framework/__init__.py`.


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
