### PR TITLE
Select named functional tests in a suite

### DIFF
--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -45,6 +45,25 @@ reason, we recommend to use it before doing a commit when changes only the funct
 just test-functional
 ```
 
+Furthermore, you can only specific tests, rather than all at once.
+
+```bash
+# runs all tests in 'floresta-cli' suite
+just test-functional-run "--test-suite floresta-cli"
+
+# same as above
+just test-functional-run "-t floresta-cli"
+
+# run the stop and ping tests in the floresta-cli suite
+just test-functional-run "--test-suite floresta-cli --test-name stop --test-name ping"
+
+# same as above
+just test-functional-run "-t floresta-cli -k stop -k ping"
+
+# run many tests that start with the word `getblock` (getblockhash, getblockheader, etc...)
+just test-functional-run "-t floresta-cli -k getblock"
+```
+
 #### From helper scripts
 
 We provide two helper scripts to support our functional tests in this process and guarantee isolation and reproducibility.
@@ -78,6 +97,25 @@ UTREEXO_REVISION=0.1.0 ./tests/prepare.sh --build && ./tests/run.sh --preserve-d
 The `--build` argument will force the script to build `utreexod` even if it is already built.
 The `--preserve-data-dir` argument will keep the data and logs directories after running the tests
 (this is useful if you want to keep the data for debugging purposes).
+
+Furthermore, you can only specific tests, rather than all at once.
+
+```bash
+# runs all tests in 'floresta-cli' suite
+./tests/run.sh --test-suite floresta-cli
+
+# same as above
+./tests/run.sh -t floresta-cli
+
+# run the stop and ping tests in the floresta-cli suite
+./tests/run.sh --test-suite floresta-cli --test-name stop --test-name ping
+
+# same as above
+./tests/run.sh -t floresta-cli -k stop -k ping
+
+# run many tests that start with the word `getblock` (getblockhash, getblockheader, etc...)
+./tests/run.sh -t floresta-cli -k getblock
+```
 
 #### From python utility directly
 Additional functional tests are available (minimum python version: 3.12).

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,11 +29,24 @@ fi
 # Clean existing data/logs directories before running the tests
 rm -rf "$FLORESTA_TEMP_DIR/data"
 
+# Detect if --preserve-data-dir is among args
+# and forward args to uv
+PRESERVE_DATA=false
+UV_ARGS=()
+
+for arg in "$@"; do
+    if [[ "$arg" == "--preserve-data-dir" ]]; then
+        PRESERVE_DATA=true
+    else
+        UV_ARGS+=("$arg")
+    fi
+done
+
 # Run the re-freshed tests
-uv run ./tests/run_tests.py
+uv run ./tests/run_tests.py "${UV_ARGS[@]}"
 
 # Clean up the data dir if we succeeded and --preserve-data-dir was not passed
-if [ $? -eq 0 ] && [ "$1" != "--preserve-data-dir" ];
+if [ $? -eq 0 ] && [ "$PRESERVE_DATA" = false ];
 then
     echo "Tests passed, cleaning up the data dir at $FLORESTA_TEMP_DIR"
     rm -rf $FLORESTA_TEMP_DIR/data $FLORESTA_TEMP_DIR/logs


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: test folder <!-- Please describe it -->

### Description

Fix #514

### Notes to the reviewers

* add `--test-name` option to `tests/run_tests.py`;
* adapt `tests/run.sh` to accept `--test-name` argument;
* add information about `--test-name` in `doc/running-tests.md`

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
