### PR TITLE
[RPC] Test uptime rpc to be compliant with Bitcoin Core

### DIFF
--- a/tests/floresta-cli/uptime-test.py
+++ b/tests/floresta-cli/uptime-test.py
@@ -4,12 +4,12 @@ floresta_cli_uptime.py
 This functional test cli utility to interact with a Floresta node with `uptime`
 """
 
-import os
-import tempfile
 import time
-
 from test_framework import FlorestaTestFramework
-from test_framework.rpc.floresta import REGTEST_RPC_SERVER
+from test_framework.rpc.floresta import REGTEST_RPC_SERVER as florestad_conf
+from test_framework.rpc.bitcoin import REGTEST_RPC_SERVER as bitcoind_conf
+
+DATA_DIR = FlorestaTestFramework.get_integration_test_dir()
 
 
 class UptimeTest(FlorestaTestFramework):
@@ -19,54 +19,59 @@ class UptimeTest(FlorestaTestFramework):
     equal to how long florestad has been running
     """
 
-    nodes = [-1]
-
-    # pylint: disable=duplicate-code
-    data_dir = os.path.normpath(
-        os.path.join(
-            FlorestaTestFramework.get_integration_test_dir(),
-            "data",
-            "florestacli-uptime-test",
-            "node-0",
-        )
-    )
+    nodes = [-1, -1]
 
     def set_test_params(self):
         """
         Setup the two node florestad process with different data-dirs, electrum-addresses
         and rpc-addresses in the same regtest network
         """
-        UptimeTest.nodes[0] = self.add_node(
-            extra_args=[
-                f"--data-dir={UptimeTest.data_dir}",
-            ],
-            rpcserver=REGTEST_RPC_SERVER,
+        data_dirs = UptimeTest.create_data_dirs(
+            DATA_DIR, self.__class__.__name__.lower(), nodes=2
         )
+
+        UptimeTest.nodes[0] = self.add_node(
+            variant="florestad",
+            extra_args=[
+                f"--data-dir={data_dirs[0]}",
+            ],
+            rpcserver=florestad_conf,
+        )
+
+        UptimeTest.nodes[1] = self.add_node(
+            variant="bitcoind",
+            extra_args=[
+                f"-datadir={data_dirs[1]}",
+            ],
+            rpcserver=bitcoind_conf,
+        )
+
+    def test_node_uptime(self, index: int, test_time: int, margin: int):
+        """
+        Test the uptime of a node, given an index
+        by checking if the uptime matches the elapsed
+        time after starting the node with a grace period
+        for startup and function call times
+        """
+        self.run_node(UptimeTest.nodes[index])
+        node = self.get_node(UptimeTest.nodes[index])
+        before = time.time()
+        time.sleep(test_time)
+        result = node.rpc.uptime()
+        after = time.time()
+        elapsed = int(after - before)
+
+        self.assertTrue(result >= elapsed and result <= elapsed + margin)
+        return result
 
     def run_test(self):
         """
         Run JSONRPC server on first, wait to connect, then call `addnode ip[:port]`
         """
-        # Start node
-        self.run_node(UptimeTest.nodes[0])
+        for i in range(len(UptimeTest.nodes)):
+            self.test_node_uptime(index=i, test_time=5, margin=5)
 
-        # wait for some seconds before get the uptime
-        # and get the current time
-        before = time.time()
-        time.sleep(5)
-
-        # Test assertions
-        node = self.get_node(UptimeTest.nodes[0])
-        uptime = node.rpc.uptime()
-
-        # calculate the elapsed time
-        after = time.time()
-        elapsed = int(after - before)
-
-        self.assertEqual(uptime, elapsed)
-
-        # stop the node
-        self.stop_node(UptimeTest.nodes[0])
+        self.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_framework/rpc/bitcoin.py
+++ b/tests/test_framework/rpc/bitcoin.py
@@ -53,3 +53,9 @@ class BitcoinRPC(BaseRPC):
         `perform_request('getrpcinfo')`
         """
         return self.perform_request("getrpcinfo")
+
+    def uptime(self) -> int:
+        """
+        Get the uptime of the node by performing `perform_request('uptime')`
+        """
+        return self.perform_request("uptime")


### PR DESCRIPTION

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: test framework <

### Description

* added `uptime` helper for Bitcoin Core rpc helper;
* included Bitcoin Core to `tests/floresta-cli/uptime-test.py` test.

### Notes to the reviewers

This PR compares the RPC `uptime` outputs of both Floresta and Bitcoin Core and with it was found that outputs can have little differences in seconds, respecting some threshold limit. 

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
