### PR TITLE
fuzz: FlatChainstore targets

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -10,3 +10,6 @@ Available fuzz targets:
 - `local_address_str`
 - `utreexo_block_des`
 - `addrman`
+- `flat_chainstore_header_insertion`
+- `flat_chainstore_memory_access`
+- `flat_chainstore_reorg`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 bitcoin = { version = "0.32", features = ["serde", "std"] }
 floresta-wire = { path = "../crates/floresta-wire" }
-floresta-chain = { path = "../crates/floresta-chain" }
+floresta-chain = { path = "../crates/floresta-chain", features = ["experimental-db"] }
 
 [[bin]]
 name = "local_address_str"
@@ -30,6 +30,27 @@ bench = false
 [[bin]]
 name = "addrman"
 path = "fuzz_targets/addrman.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "flat_chainstore_header_insertion"
+path = "fuzz_targets/flat_chainstore_header_insertion.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "flat_chainstore_reorg"
+path = "fuzz_targets/flat_chainstore_reorg.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "flat_chainstore_memory_access"
+path = "fuzz_targets/flat_chainstore_memory_access.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/flat_chainstore_header_insertion.rs
+++ b/fuzz/fuzz_targets/flat_chainstore_header_insertion.rs
@@ -1,0 +1,102 @@
+#![no_main]
+
+use std::fs;
+use std::path::PathBuf;
+
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::consensus::deserialize;
+use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStore;
+use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStoreConfig;
+use floresta_chain::pruned_utreexo::ChainStore;
+use floresta_chain::DiskBlockHeader;
+use libfuzzer_sys::fuzz_target;
+
+// Create a unique temporary directory for each fuzzing run
+fn create_temp_dir(test_id: u32) -> PathBuf {
+    let temp_dir: PathBuf = format!("./tmp/fuzz-{}", test_id).into();
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    temp_dir
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Don't process too small inputs
+    if data.len() < 80 {
+        return;
+    }
+
+    // Try to deserialize header data
+    let header = match deserialize::<BlockHeader>(data) {
+        Ok(header) => header,
+        Err(_) => return, // Invalid header data, skip
+    };
+
+    // Create a temporary directory for our chainstore
+    let mut id: [u8; 4] = [0; 4];
+    id.copy_from_slice(&data[0..4]);
+    let id = u32::from_be_bytes(id);
+
+    let temp_dir = create_temp_dir(id);
+    let config = FlatChainStoreConfig {
+        block_index_size: Some(128), // Use small values for fuzzing
+        headers_file_size: Some(128),
+        fork_file_size: Some(64),
+        cache_size: Some(10),
+        file_permission: Some(0o666),
+        path: temp_dir.to_str().unwrap().to_string(),
+    };
+
+    // Initialize the chainstore
+    let mut store = match FlatChainStore::new(config) {
+        Ok(store) => store,
+        Err(_) => return, // If we can't create store, skip
+    };
+
+    // Create random block heights to test
+    let heights = [
+        0,                   // Genesis
+        1,                   // Next block
+        data[0] as u32 % 64, // Random height based on data
+        127,                 // Near file size limit
+    ];
+
+    // Try saving the header at different heights
+    for height in heights {
+        // Try to save the header with different status
+        let variants = [
+            DiskBlockHeader::FullyValid(header, height),
+            DiskBlockHeader::HeadersOnly(header, height),
+            DiskBlockHeader::AssumedValid(header, height),
+            DiskBlockHeader::InFork(header, height),
+            DiskBlockHeader::Orphan(header),
+            DiskBlockHeader::InvalidChain(header),
+        ];
+
+        for variant in variants {
+            // Save header
+            let _ = store.save_header(&variant);
+
+            // If it's a header with height, update the block index
+            if let Some(height) = variant.height() {
+                let _ = store.update_block_index(height, header.block_hash());
+            }
+
+            // Try to retrieve the header
+            let _ = store.get_header(&header.block_hash());
+
+            // Try to get block hash by height
+            if let Some(height) = variant.height() {
+                let _ = store.get_block_hash(height);
+            }
+
+            // Flush to disk
+            let _ = store.flush();
+
+            // Check integrity
+            let _ = store.check_integrity();
+        }
+    }
+
+    // Clean up
+    let _ = fs::remove_dir_all(temp_dir);
+});

--- a/fuzz/fuzz_targets/flat_chainstore_memory_access.rs
+++ b/fuzz/fuzz_targets/flat_chainstore_memory_access.rs
@@ -1,0 +1,192 @@
+#![no_main]
+//! # FlatChainStore Memory Access Pattern Fuzzer
+//!
+//! This fuzzer is specifically designed to test the memory safety of the FlatChainStore
+//! implementation, with a focus on the memory-mapped file operations.
+//!
+//! ## Testing Strategy
+//!
+//! 1. **Small allocation sizes**: Uses especially small sizes for the memory-mapped files to
+//!    increase the likelihood of hitting boundary conditions.
+//!
+//! 2. **Data filling**: Fills the store up to capacity to test behavior when nearing limits.
+//!
+//! 3. **Random access patterns**: After filling the store, performs random access operations
+//!    to test memory safety when accessing previously written data.
+//!
+//! 4. **Concurrent access simulation**: Opens a second handle to the same store to simulate
+//!    potential concurrent access issues.
+//!
+//! 5. **Stress I/O operations**: Performs periodic flushes to stress the interaction between
+//!    in-memory operations and disk persistence.
+//!
+//! ## Memory Safety Concerns
+//!
+//! The FlatChainStore uses memory-mapped files for:
+//! - Headers file: Stores block headers sequentially
+//! - Index map: Maps block hashes to heights using open addressing
+//! - Fork headers file: Stores headers that aren't in the main chain
+//! - Accumulator file: Stores the utreexo accumulator state
+//!
+//! Unsafe operations in FlatChainStore that this fuzzer targets:
+//! - Pointer arithmetic in the header files
+//! - Hash map lookups in the index file
+//! - Memory access patterns in the flat files
+//! - Boundary checking for file limits
+
+use std::fs;
+use std::path::PathBuf;
+
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::consensus::deserialize;
+use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStore;
+use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStoreConfig;
+use floresta_chain::pruned_utreexo::ChainStore;
+use floresta_chain::DiskBlockHeader;
+use libfuzzer_sys::fuzz_target;
+
+// Create a unique temporary directory for each fuzzing run
+fn create_temp_dir(test_id: u32) -> PathBuf {
+    let temp_dir: PathBuf = format!("./tmp/fuzz-{}", test_id).into();
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    temp_dir
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Need enough data for header
+    if data.len() < 80 {
+        return;
+    }
+
+    // Try to deserialize header data
+    let header = match deserialize::<BlockHeader>(&data[..80]) {
+        Ok(header) => header,
+        Err(_) => return, // Invalid header data, skip
+    };
+
+    // Derive some parameters from the input data
+    let seed = if data.len() > 81 {
+        data[81] as usize
+    } else {
+        0
+    };
+
+    let mut id: [u8; 4] = [0; 4];
+    id.copy_from_slice(&data[0..4]);
+    let id = u32::from_be_bytes(id);
+
+    let temp_dir = create_temp_dir(id);
+    let config = FlatChainStoreConfig {
+        // Use especially small sizes to create boundary conditions
+        block_index_size: Some(16 + (seed % 16)),
+        headers_file_size: Some(16 + (seed % 16)),
+        fork_file_size: Some(8 + (seed % 8)),
+        cache_size: Some(4 + (seed % 4)),
+        file_permission: Some(0o666),
+        path: temp_dir.to_str().unwrap().to_string(),
+    };
+
+    // Initialize the chainstore
+    let mut store = match FlatChainStore::new(config) {
+        Ok(store) => store,
+        Err(_) => return, // If we can't create store, skip
+    };
+
+    // Fill the store with headers up to capacity
+    let max_headers = 16 + (seed % 16);
+
+    for i in 0..max_headers {
+        // Create a variant of the header
+        let height = i as u32;
+        let mut header_var = header;
+
+        // Modify the header slightly to make it unique
+        // Use a simple modification of the nonce
+        header_var.nonce = header.nonce.wrapping_add(i as u32);
+
+        // Save with different variants
+        let disk_header = if i % 3 == 0 {
+            DiskBlockHeader::FullyValid(header_var, height)
+        } else if i % 3 == 1 {
+            DiskBlockHeader::HeadersOnly(header_var, height)
+        } else {
+            DiskBlockHeader::InFork(header_var, height)
+        };
+
+        let _ = store.save_header(&disk_header);
+
+        // If it's a main chain header, update the index
+        if i % 3 != 2 {
+            // Not a fork
+            let _ = store.update_block_index(height, header_var.block_hash());
+        }
+
+        // Store some small accumulator data
+        if i % 2 == 0 {
+            let acc_size = (i % 33) as usize; // Create different sizes
+            let acc_data = vec![i as u8; acc_size];
+            let _ = store.save_roots_for_block(acc_data, height);
+        }
+
+        // Periodically flush to stress disk I/O and mmap
+        if i % 4 == 0 {
+            let _ = store.flush();
+        }
+    }
+
+    // Now perform a series of random access patterns to stress memory access
+    if data.len() > 100 {
+        // Use the extra data as indices to access
+        for i in 80..data.len().min(80 + max_headers) {
+            let index = data[i] as u32 % (max_headers as u32);
+
+            // Try to get a header by a reconstructed hash
+            let mut modified_header = header;
+            modified_header.nonce = header.nonce.wrapping_add(index);
+            let hash = modified_header.block_hash();
+
+            // Perform several access patterns
+            let _ = store.get_header(&hash);
+            let _ = store.get_block_hash(index);
+            let _ = store.load_roots_for_block(index);
+        }
+    }
+
+    // Test concurrent access to the same store (simulate multi-threading)
+    // by creating another handle to the same store
+    let config2 = FlatChainStoreConfig {
+        block_index_size: None, // Use defaults
+        headers_file_size: None,
+        fork_file_size: None,
+        cache_size: None,
+        file_permission: None,
+        path: temp_dir.to_str().unwrap().to_string(),
+    };
+
+    // Try to open the existing store
+    if let Ok(store2) = FlatChainStore::new(config2) {
+        // Perform some operations with the second handle
+        for i in 0..max_headers {
+            let height = i as u32;
+            let _ = store2.get_block_hash(height);
+
+            // Modify header nonce to get its hash
+            let mut modified_header = header;
+            modified_header.nonce = header.nonce.wrapping_add(i as u32);
+            let hash = modified_header.block_hash();
+
+            let _ = store2.get_header(&hash);
+        }
+
+        // Final integrity check
+        let _ = store2.check_integrity();
+    }
+
+    // Final flush and integrity check on the original store
+    let _ = store.flush();
+    let _ = store.check_integrity();
+
+    // Clean up
+    let _ = fs::remove_dir_all(temp_dir);
+});

--- a/fuzz/fuzz_targets/flat_chainstore_reorg.rs
+++ b/fuzz/fuzz_targets/flat_chainstore_reorg.rs
@@ -1,0 +1,211 @@
+#![no_main]
+
+use std::fs;
+use std::path::PathBuf;
+
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::block::Version;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+use bitcoin::CompactTarget;
+use bitcoin::TxMerkleNode;
+use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStore;
+use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStoreConfig;
+use floresta_chain::pruned_utreexo::ChainStore;
+use floresta_chain::BestChain;
+use floresta_chain::DiskBlockHeader;
+use libfuzzer_sys::fuzz_target;
+
+// Create a unique temporary directory for each fuzzing run
+fn create_temp_dir(test_id: u32) -> PathBuf {
+    let temp_dir: PathBuf = format!("./tmp/fuzz-{}", test_id).into();
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+    temp_dir
+}
+
+// Construct headers with given prev_hash
+fn create_header_with_prev(prev_hash: BlockHash, nonce: u32) -> BlockHeader {
+    BlockHeader {
+        version: Version::from_consensus(1),
+        prev_blockhash: prev_hash,
+        merkle_root: TxMerkleNode::all_zeros(), // all zeros for simplicity
+        time: 1231006505,                       // Genesis block timestamp
+        bits: CompactTarget::from_consensus(0x1d00ffff), // Genesis difficulty
+        nonce,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Need enough data for simulating a chain and reorgs
+    if data.len() < 32 {
+        return;
+    }
+
+    let mut id: [u8; 4] = [0; 4];
+    id.copy_from_slice(&data[0..4]);
+    let id = u32::from_be_bytes(id);
+
+    let temp_dir = create_temp_dir(id);
+    let config = FlatChainStoreConfig {
+        block_index_size: Some(256),
+        headers_file_size: Some(256),
+        fork_file_size: Some(128),
+        cache_size: Some(32),
+        file_permission: Some(0o666),
+        path: temp_dir.to_str().unwrap().to_string(),
+    };
+
+    // Initialize the chainstore
+    let mut store = match FlatChainStore::new(config) {
+        Ok(store) => store,
+        Err(_) => return, // If we can't create store, skip
+    };
+
+    // Create a chain of headers where each one points to the previous
+    let mut headers = Vec::new();
+    let mut fork_headers: Vec<BlockHeader> = Vec::new();
+
+    // Genesis header
+    let genesis = BlockHeader {
+        version: Version::from_consensus(1),
+        prev_blockhash: BlockHash::all_zeros(), // Genesis block has no previous hash
+        merkle_root: TxMerkleNode::all_zeros(), // all zeros for simplicity
+        time: 1231006505,                       // Genesis block timestamp
+        bits: CompactTarget::from_consensus(0x1d00ffff), // Genesis difficulty
+        nonce: data[0] as u32,                  // Use first byte of data as nonce
+    };
+
+    headers.push(genesis);
+
+    // Create a chain of headers (height 0 to 9)
+    let chain_length = 10.min(data.len() / 3);
+    for i in 1..chain_length {
+        let prev_hash = headers[i - 1].block_hash();
+        let header = create_header_with_prev(prev_hash, data[i] as u32);
+        headers.push(header);
+    }
+
+    // Create a fork starting from height 3 (if we have enough headers)
+    if headers.len() > 3 {
+        let fork_point = 3;
+        let prev_hash = headers[fork_point].block_hash();
+
+        // Create a fork chain
+        let fork_length = 5.min(data.len() / 4);
+        for i in 0..fork_length {
+            let prev = if i == 0 {
+                prev_hash
+            } else {
+                fork_headers[i - 1].block_hash()
+            };
+
+            let nonce = data[i + chain_length] as u32;
+            let header = create_header_with_prev(prev, nonce);
+            fork_headers.push(header);
+        }
+    }
+
+    // First save all main chain headers
+    for (i, header) in headers.iter().enumerate() {
+        let height = i as u32;
+        let variant = DiskBlockHeader::FullyValid(*header, height);
+
+        // Save header and update index
+        if store.save_header(&variant).is_err() {
+            continue;
+        }
+
+        if store
+            .update_block_index(height, header.block_hash())
+            .is_err()
+        {
+            continue;
+        }
+
+        // Create some accumulator data
+        let acc_data = vec![i as u8; 32]; // Simple mock data
+        let _ = store.save_roots_for_block(acc_data, height);
+    }
+
+    // Set the best chain
+    if !headers.is_empty() {
+        let last_header = headers.last().unwrap();
+        let best_chain = BestChain {
+            best_block: last_header.block_hash(),
+            depth: (headers.len() - 1) as u32,
+            validation_index: last_header.block_hash(),
+            alternative_tips: vec![],
+            assume_valid_index: 0,
+        };
+
+        let _ = store.save_height(&best_chain);
+        let _ = store.flush();
+    }
+
+    // Now save fork headers
+    for (i, header) in fork_headers.iter().enumerate() {
+        let height = (i + 3) as u32; // Fork starts at height 3
+
+        // First save as a fork
+        let variant = DiskBlockHeader::InFork(*header, height);
+        let _ = store.save_header(&variant);
+
+        // Then try to switch to this chain by saving as fully valid and updating the index
+        let variant2 = DiskBlockHeader::FullyValid(*header, height);
+        let _ = store.save_header(&variant2);
+        let _ = store.update_block_index(height, header.block_hash());
+
+        // Create some accumulator data for the fork
+        let acc_data = vec![(i + 100) as u8; 32]; // Different mock data
+        let _ = store.save_roots_for_block(acc_data, height);
+    }
+
+    // If we have fork headers, try to make it the best chain
+    if !fork_headers.is_empty() {
+        let last_fork_header = fork_headers.last().unwrap();
+        let best_chain = BestChain {
+            best_block: last_fork_header.block_hash(),
+            depth: (fork_headers.len() + 2) as u32, // +2 for the shared history
+            validation_index: last_fork_header.block_hash(),
+            alternative_tips: if !headers.is_empty() {
+                vec![headers.last().unwrap().block_hash()]
+            } else {
+                vec![]
+            },
+            assume_valid_index: 0,
+        };
+
+        let _ = store.save_height(&best_chain);
+    }
+
+    // Final flush
+    let _ = store.flush();
+
+    // Now do some random queries to test memory safety
+    if !headers.is_empty() {
+        for header in headers {
+            let _ = store.get_header(&header.block_hash());
+        }
+    }
+
+    if !fork_headers.is_empty() {
+        for header in fork_headers {
+            let _ = store.get_header(&header.block_hash());
+        }
+    }
+
+    // Query some random heights
+    if !data.is_empty() {
+        for i in 0..data.len().min(20) {
+            let height = data[i] as u32 % 20;
+            let _ = store.get_block_hash(height);
+            let _ = store.load_roots_for_block(height);
+        }
+    }
+
+    // Final integrity check
+    let _ = store.check_integrity();
+
+    // Clean up
+    let _ = fs::remove_dir_all(temp_dir);
+});


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: New fuzz target

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: fuzz

### Description

This commit adds three fuzz targets for `FlatChainstore`, that makes sure our code memory access is sane. We insert, retrieve headers and reorg the chain to stress multiple code paths and check their soundness.

PSA: These targets were generated by A.I. O.o I was testing some A.I. tool and the end result was actually great, so I've decided to fix some minor problems I've found and make a PR with it.
