### PR TITLE
Move `BestChain` and `ChainStore` to chainstore.rs

### DIFF
--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -258,7 +258,7 @@ fn validate_many_inputs_block_benchmark(c: &mut Criterion) {
 
 #[cfg(feature = "flat-chainstore")]
 fn chainstore_checksum_benchmark(c: &mut Criterion) {
-    use floresta_chain::pruned_utreexo::ChainStore;
+    use floresta_chain::ChainStore;
     use floresta_chain::DiskBlockHeader;
 
     let headers = read_mainnet_headers();

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state_builder.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state_builder.rs
@@ -13,12 +13,12 @@ use bitcoin::BlockHash;
 use bitcoin::Network;
 use rustreexo::accumulator::stump::Stump;
 
-use super::chain_state::BestChain;
 use super::chain_state::ChainState;
 use super::chainparams::ChainParams;
-use super::ChainStore;
 use crate::pruned_utreexo::Box;
 use crate::AssumeValidArg;
+use crate::BestChain;
+use crate::ChainStore;
 use crate::DatabaseError;
 use crate::DiskBlockHeader;
 

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -1,3 +1,11 @@
+//! This module defines the [ChainStore] trait, which provides the Floresta node API
+//! for persisting and retrieving blockchain data (headers, block hashes linked to a
+//! height, the best chain data, and the accumulator for each block).
+//!
+//! It also defines two important types for our storage format:
+//! - [DiskBlockHeader]: A block header linked to its validation-state metadata
+//! - [BestChain]: Tracks the current best chain, last valid block, and fork tips
+
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::Encodable;
@@ -5,6 +13,67 @@ use bitcoin::BlockHash;
 
 use crate::prelude::*;
 use crate::BlockchainError;
+use crate::DatabaseError;
+
+/// A trait defining methods for interacting with our chain database. These methods will be used by
+/// the [ChainState](super::chain_state::ChainState) to save and retrieve data about the blockchain,
+/// likely on disk.
+///
+/// Right now, you can use the [FlatChainStore](super::flat_chain_store::FlatChainStore) or
+/// [KvChainStore](super::kv_chainstore::KvChainStore) implementations. The former is the store that
+/// we use at production, while the latter is a simpler key-value store.
+///
+/// This trait requires an associated error type that implements [DatabaseError]; a marker trait
+/// satisfied by any `T: std::error::Error + std::fmt::Display`. This is useful to abstract the
+/// database implementation from the blockchain.
+pub trait ChainStore {
+    type Error: DatabaseError;
+
+    /// Saves the accumulator state for a given block height.
+    fn save_roots_for_block(&mut self, roots: Vec<u8>, height: u32) -> Result<(), Self::Error>;
+
+    /// Loads the state of our accumulator for a given block height.
+    ///
+    /// This is the state of the resulting accumulator after we process the block at `height`. If you
+    /// need the accumulator used to validate a block at height `n`, you should get the accumulator
+    /// from block `n - 1`.
+    fn load_roots_for_block(&mut self, height: u32) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Loads the blockchain height
+    fn load_height(&self) -> Result<Option<BestChain>, Self::Error>;
+
+    /// Saves the blockchain height.
+    fn save_height(&mut self, height: &BestChain) -> Result<(), Self::Error>;
+
+    /// Get a block header from our database. See [DiskBlockHeader] for more info about
+    /// the data we save.
+    fn get_header(&self, block_hash: &BlockHash) -> Result<Option<DiskBlockHeader>, Self::Error>;
+
+    /// Get a block header by its height in our database.
+    fn get_header_by_height(&self, height: u32) -> Result<Option<DiskBlockHeader>, Self::Error>;
+
+    /// Saves a block header to our database. See [DiskBlockHeader] for more info about
+    /// the data we save.
+    fn save_header(&mut self, header: &DiskBlockHeader) -> Result<(), Self::Error>;
+
+    /// Returns the block hash for a given height.
+    fn get_block_hash(&self, height: u32) -> Result<Option<BlockHash>, Self::Error>;
+
+    /// Flushes write buffers to disk, this is called periodically by the [ChainState](crate::ChainState),
+    /// so in case of a crash, we don't lose too much data. If the database doesn't support
+    /// write buffers, this method can be a no-op.
+    fn flush(&mut self) -> Result<(), Self::Error>;
+
+    /// Associates a block hash with a given height, so we can retrieve it later.
+    fn update_block_index(&mut self, height: u32, hash: BlockHash) -> Result<(), Self::Error>;
+
+    /// Checks if our database didn't get corrupted, and if it has, it returns
+    /// an error.
+    ///
+    /// If you're using a database that already checks for integrity by itself,
+    /// this can safely be a no-op.
+    fn check_integrity(&self) -> Result<(), Self::Error>;
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// This enum is used to store a block header in the database. It contains the header along with
@@ -55,7 +124,7 @@ impl DiskBlockHeader {
     }
 }
 
-/// `DiskBlockHeader` dereferences to the inner header type.
+// `DiskBlockHeader` dereferences to the inner header type.
 impl Deref for DiskBlockHeader {
     type Target = BlockHeader;
     fn deref(&self) -> &Self::Target {
@@ -70,7 +139,6 @@ impl Deref for DiskBlockHeader {
     }
 }
 
-/// Decodable is a trait from bitcoin::consensus::encode that allows decoding of a type from a reader in a consistent manner.
 impl Decodable for DiskBlockHeader {
     /// Decodes a `DiskBlockHeader` from a reader.
     fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
@@ -146,5 +214,85 @@ impl Encodable for DiskBlockHeader {
             }
         };
         Ok(len)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// Internal representation of the chain we are in
+pub struct BestChain {
+    /// Hash of the last block in the chain we believe has more work on
+    pub best_block: BlockHash,
+
+    /// How many blocks are pilled on this chain?
+    pub depth: u32,
+
+    /// We actually validated blocks up to this point
+    pub validation_index: BlockHash,
+
+    /// Blockchains are not fast-forward only, they might have "forks", sometimes it's useful
+    /// to keep track of them, in case they become the best one. This keeps track of some
+    /// tips we know about, but are not the best one. We don't keep tips that are too deep
+    /// or have too little work if compared to our best one
+    pub alternative_tips: Vec<BlockHash>,
+
+    /// Saves the height occupied by the assume valid block
+    pub assume_valid_index: u32,
+}
+
+impl BestChain {
+    pub(super) fn new_block(&mut self, block_hash: BlockHash, height: u32) {
+        self.best_block = block_hash;
+        self.depth = height;
+    }
+
+    pub(super) fn valid_block(&mut self, block_hash: BlockHash) {
+        self.validation_index = block_hash;
+    }
+}
+
+impl From<(BlockHash, u32)> for BestChain {
+    fn from((best_block, depth): (BlockHash, u32)) -> Self {
+        Self {
+            best_block,
+            depth,
+            validation_index: best_block,
+            assume_valid_index: 0,
+            alternative_tips: Vec::new(),
+        }
+    }
+}
+
+impl Encodable for BestChain {
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> bitcoin::io::Result<usize> {
+        let mut len = 0;
+        len += self.best_block.consensus_encode(writer)?;
+        len += self.depth.consensus_encode(writer)?;
+        len += self.validation_index.consensus_encode(writer)?;
+        len += self.assume_valid_index.consensus_encode(writer)?;
+        len += self.alternative_tips.consensus_encode(writer)?;
+        Ok(len)
+    }
+}
+
+impl Decodable for BestChain {
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
+        reader: &mut R,
+    ) -> Result<Self, bitcoin::consensus::encode::Error> {
+        let best_block = BlockHash::consensus_decode(reader)?;
+        let depth = u32::consensus_decode(reader)?;
+        let validation_index = BlockHash::consensus_decode(reader)?;
+        let assume_valid_index = u32::consensus_decode(reader)?;
+
+        let alternative_tips = <Vec<BlockHash>>::consensus_decode(reader)?;
+        Ok(Self {
+            alternative_tips,
+            best_block,
+            depth,
+            validation_index,
+            assume_valid_index,
+        })
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -94,8 +94,8 @@ use memmap2::MmapMut;
 use memmap2::MmapOptions;
 use xxhash_rust::xxh3;
 
-use super::ChainStore;
 use crate::BestChain;
+use crate::ChainStore;
 use crate::DatabaseError;
 use crate::DiskBlockHeader;
 
@@ -898,7 +898,7 @@ impl FlatChainStore {
         Ok(&mut *ptr)
     }
 
-    unsafe fn do_save_height(&mut self, best_block: BestChain) -> Result<(), FlatChainstoreError> {
+    unsafe fn do_save_height(&mut self, best_block: &BestChain) -> Result<(), FlatChainstoreError> {
         let metadata = self.get_metadata_mut()?;
 
         metadata.assume_valid_index = best_block.assume_valid_index;
@@ -1191,7 +1191,7 @@ impl ChainStore for FlatChainStore {
     }
 
     fn save_height(&mut self, height: &crate::BestChain) -> Result<(), Self::Error> {
-        unsafe { self.do_save_height(height.clone()) }
+        unsafe { self.do_save_height(height) }
     }
 
     fn save_header(&mut self, header: &DiskBlockHeader) -> Result<(), Self::Error> {
@@ -1244,11 +1244,11 @@ mod tests {
     use super::FlatChainStore;
     use super::FlatChainstoreError;
     use super::Index;
-    use crate::pruned_utreexo::ChainStore;
     use crate::pruned_utreexo::UpdatableChainstate;
     use crate::AssumeValidArg;
     use crate::BestChain;
     use crate::ChainState;
+    use crate::ChainStore;
     use crate::DiskBlockHeader;
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/kv_chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/kv_chainstore.rs
@@ -12,8 +12,8 @@ use kv::Integer;
 use kv::Store;
 use spin::RwLock;
 
-use super::chain_state::BestChain;
-use super::ChainStore;
+use crate::BestChain;
+use crate::ChainStore;
 use crate::DiskBlockHeader;
 
 /// As for now we use a KV (key/value) database to store the chain data.


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

`BestChain` is defined at the very end of the crowded chain_state.rs, and it seems a type that we would want to put next to `DiskBlockHeader` (the two storage Floresta types).

Also perhaps it's a good idea to move the `ChainStore` trait definition to the file that has its name. Probably makes sense as in pruned_utreexo/mod.rs we define the two chain backend traits, which are higher level.