### PR TITLE
Enable feature-gate banners in docs

### DIFF
--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -10,6 +10,8 @@
 //! All data is stored in a `ChainStore` implementation, which is generic over the
 //! underlying database. See the ChainStore trait for more information. For a
 //! ready-to-use implementation, see the [KvChainStore] struct.
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 #![allow(clippy::manual_is_multiple_of)]

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -8,6 +8,8 @@
 //! ready-to-use library for interacting with florestad's json-rpc interface in your rust
 //! application.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[cfg(feature = "with-jsonrpc")]
 pub mod jsonrpc_client;
 

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -4,6 +4,7 @@
 //! Provides utility functions, macros and modules to be
 //! used in other Floresta crates.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 
 use bitcoin::hashes::sha256;

--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -9,6 +9,8 @@
 //! This module should receive blocks as we download them, it'll create a filter
 //! for it. Therefore, you can't use this to speedup wallet sync **before** IBD,
 //! since we wouldn't have the filter for all blocks yet.
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::manual_is_multiple_of)]
 
 use core::fmt::Debug;

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::manual_is_multiple_of)]
 
 use serde::Deserialize;

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::manual_is_multiple_of)]
 
 use core::cmp::Ordering;

--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -10,6 +10,8 @@
 //! like requesting blocks, mempool transactions or asking to connect with a given
 //! peer.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[cfg(not(target_arch = "wasm32"))]
 mod p2p_wire;
 use bitcoin::block::Header as BlockHeader;

--- a/crates/floresta/src/lib.rs
+++ b/crates/floresta/src/lib.rs
@@ -28,6 +28,9 @@
 //! # Name
 //! Floresta is the Portuguese word for forest. It is a reference to the Utreexo accumulator,
 //! which is a forest of Merkle trees. It's pronounced /floˈɾɛstɐ/.
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 /// Components to build a utreexo-aware, consensus enforcing Bitcoin node.
 pub use floresta_chain as chain;
 /// Useful data structures and traits used by the other crates.

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -25,7 +25,7 @@ use floresta_chain::ChainState;
 use floresta_chain::FlatChainStore as ChainStore;
 #[cfg(feature = "flat-chainstore")]
 use floresta_chain::FlatChainStoreConfig;
-#[cfg(feature = "kv-chainstore")]
+#[cfg(all(feature = "kv-chainstore", not(doc)))]
 use floresta_chain::KvChainStore as ChainStore;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
@@ -73,7 +73,7 @@ use crate::wallet_input::InitialWalletSetup;
 use crate::zmq::ZMQServer;
 
 // flat-chainstore and kv-chainstore are mutually exclusive
-#[cfg(all(feature = "flat-chainstore", feature = "kv-chainstore"))]
+#[cfg(all(feature = "flat-chainstore", feature = "kv-chainstore", not(doc)))]
 compile_error!(
     "You cannot use both flat-chainstore and kv-chainstore at the same time. Please choose one."
 );
@@ -795,7 +795,7 @@ impl Florestad {
         ChainStore::new(config).expect("failure while creating chainstate")
     }
 
-    #[cfg(feature = "kv-chainstore")]
+    #[cfg(all(feature = "kv-chainstore", not(doc)))]
     fn load_chain_state(
         data_dir: String,
         network: Network,

--- a/florestad/src/lib.rs
+++ b/florestad/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 mod config_file;
 mod error;
 mod florestad;

--- a/justfile
+++ b/justfile
@@ -66,11 +66,11 @@ bench:
 
 # Generate documentation for all crates
 doc:
-    cargo +nightly doc --workspace --no-deps
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --workspace --no-deps --all-features
 
 # Generate and open documentation for all crates
 open-doc:
-    cargo +nightly doc --workspace --no-deps --open
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --workspace --no-deps --all-features --open
 
 # Format code and run configured linters
 lint:


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [x] floresta-cli
- [x] floresta-common
- [x] floresta-compact-filters
- [x] floresta-electrum
- [x] floresta-watch-only
- [x] floresta-wire
- [x] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

I have added `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to each lib.rs to enable such banners in our docs (to generate them we require the `--cfg docsrs` flag).

I have also updated our `just` recipe accordingly, which now documents all features. This is nice to show the users all options available under each feature.

Because we document all features I had to do an exception for the florestad `kv-chainstore` one to avoid a compiler error.

### Notes to the reviewers

You can run `just doc`, navigate to the crates docs and easily verify there are feature badges:

<img width="938" height="281" alt="Captura de pantalla 2025-07-11 a las 22 55 56" src="https://github.com/user-attachments/assets/09c49140-3a10-4d3c-9cf1-c219b9d89368" />
