### PR TITLE
Fix unused `slip132` warnings

### DIFF
--- a/florestad/src/slip132.rs
+++ b/florestad/src/slip132.rs
@@ -136,6 +136,7 @@ impl From<base58::Error> for Error {
 
 /// SLIP 132-defined key applications defining types of scriptPubKey descriptors
 /// in which they can be used
+#[allow(dead_code)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum KeyApplication {
@@ -165,6 +166,7 @@ pub enum KeyApplication {
 }
 
 /// Unknown string representation of [`KeyApplication`] enum
+#[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct UnknownKeyApplicationError;
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

We are getting a new clippy warning:

```bash
warning: enum `KeyApplication` is never used

warning: struct `UnknownKeyApplicationError` is never constructed
```

### Notes to the reviewers

This `slip132` module is not public and we never use such functionality, but I guess this is there to be used in the future.