### PR TITLE
Fuzz and test chainstore types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,12 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arrayvec"
@@ -916,6 +919,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1182,7 @@ dependencies = [
 name = "floresta-fuzz"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "bitcoin 0.32.6",
  "floresta-chain",
  "floresta-wire",

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -1,5 +1,6 @@
 # Fuzzing
 This project uses `cargo-fuzz` (libfuzzer) for fuzzing, you can run a fuzz target with:
+
 ```bash
 cargo +nightly fuzz run local_address_str
 ```
@@ -7,6 +8,11 @@ cargo +nightly fuzz run local_address_str
 You can replace `local_address_str` with the name of any other target you want to run.
 
 Available fuzz targets:
+
+- `addrman`
+- `best_chain_decode`
+- `best_chain_roundtrip`
+- `disk_block_header_decode`
+- `disk_block_header_roundtrip`
 - `local_address_str`
 - `utreexo_block_des`
-- `addrman`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+arbitrary = { version = "1.4.2", features = ["derive"] }
 bitcoin = { version = "0.32", features = ["serde", "std"] }
 floresta-wire = { path = "../crates/floresta-wire" }
 floresta-chain = { path = "../crates/floresta-chain" }
@@ -30,6 +31,34 @@ bench = false
 [[bin]]
 name = "addrman"
 path = "fuzz_targets/addrman.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "best_chain_decode"
+path = "fuzz_targets/best_chain_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "best_chain_roundtrip"
+path = "fuzz_targets/best_chain_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "disk_block_header_decode"
+path = "fuzz_targets/disk_block_header_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "disk_block_header_roundtrip"
+path = "fuzz_targets/disk_block_header_roundtrip.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/best_chain_decode.rs
+++ b/fuzz/fuzz_targets/best_chain_decode.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use floresta_chain::BestChain;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Try to decode from arbitrary bytes. Decoding must never panic.
+    if let Ok(dec) = BestChain::consensus_decode(&mut Cursor::new(data)) {
+        // Encode
+        let mut buf = Vec::new();
+        let written = dec.consensus_encode(&mut buf).expect("encode failed");
+        assert_eq!(written, buf.len(), "encode returned wrong length");
+
+        // Re-decode and compare
+        let dec2 = BestChain::consensus_decode(&mut Cursor::new(&buf)).expect("decode failed");
+        assert_eq!(dec2, dec, "encode/decode not stable");
+    }
+});

--- a/fuzz/fuzz_targets/best_chain_roundtrip.rs
+++ b/fuzz/fuzz_targets/best_chain_roundtrip.rs
@@ -1,0 +1,60 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+use floresta_chain::BestChain;
+use libfuzzer_sys::fuzz_target;
+
+fn gen_blockhash(u: &mut Unstructured<'_>) -> arbitrary::Result<BlockHash> {
+    let bytes: [u8; 32] = Arbitrary::arbitrary(u)?;
+    Ok(BlockHash::from_byte_array(bytes))
+}
+
+const MAX_TIPS: usize = 64;
+
+fn gen_alt_tips(u: &mut Unstructured<'_>) -> arbitrary::Result<Vec<BlockHash>> {
+    let hint: u8 = Arbitrary::arbitrary(u)?;
+    let len = (hint as usize) % (MAX_TIPS + 1);
+    let mut v = Vec::with_capacity(len);
+    for _ in 0..len {
+        v.push(gen_blockhash(u)?);
+    }
+    Ok(v)
+}
+
+#[derive(Arbitrary)]
+struct Inputs {
+    #[arbitrary(with = gen_blockhash)]
+    best_block: BlockHash,
+    depth: u32,
+    #[arbitrary(with = gen_blockhash)]
+    validation_index: BlockHash,
+    #[arbitrary(with = gen_alt_tips)]
+    alternative_tips: Vec<BlockHash>,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(inp) = Inputs::arbitrary(&mut Unstructured::new(data)) {
+        let best = BestChain {
+            best_block: inp.best_block,
+            depth: inp.depth,
+            validation_index: inp.validation_index,
+            alternative_tips: inp.alternative_tips,
+        };
+
+        // Encode
+        let mut buf = Vec::new();
+        let written = best.consensus_encode(&mut buf).expect("encode failed");
+        assert_eq!(written, buf.len(), "encode returned wrong length");
+
+        // Decode and compare
+        let decoded = BestChain::consensus_decode(&mut Cursor::new(&buf)).expect("decode failed");
+        assert_eq!(decoded, best, "roundtrip mismatch");
+    }
+});

--- a/fuzz/fuzz_targets/disk_block_header_decode.rs
+++ b/fuzz/fuzz_targets/disk_block_header_decode.rs
@@ -1,0 +1,23 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use floresta_chain::DiskBlockHeader;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Try to decode from arbitrary bytes. Decoding must never panic.
+    if let Ok(dec) = DiskBlockHeader::consensus_decode(&mut Cursor::new(data)) {
+        // Encode
+        let mut buf = Vec::new();
+        let written = dec.consensus_encode(&mut buf).expect("encode failed");
+        assert_eq!(written, buf.len(), "encode returned wrong length");
+
+        // Re-decode and compare
+        let dec2 =
+            DiskBlockHeader::consensus_decode(&mut Cursor::new(&buf)).expect("decode failed");
+        assert_eq!(dec2, dec, "encode/decode not stable");
+    }
+});

--- a/fuzz/fuzz_targets/disk_block_header_roundtrip.rs
+++ b/fuzz/fuzz_targets/disk_block_header_roundtrip.rs
@@ -1,0 +1,66 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use bitcoin::block::Version;
+use bitcoin::blockdata::block::Header as BlockHeader;
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+use bitcoin::CompactTarget;
+use bitcoin::TxMerkleNode;
+use floresta_chain::DiskBlockHeader;
+use libfuzzer_sys::fuzz_target;
+
+fn gen_header(u: &mut Unstructured<'_>) -> arbitrary::Result<BlockHeader> {
+    // Pull primitives from the fuzzer:
+    let version = i32::arbitrary(u)?;
+    let prev: [u8; 32] = Arbitrary::arbitrary(u)?;
+    let merkle: [u8; 32] = Arbitrary::arbitrary(u)?;
+    let time = u32::arbitrary(u)?;
+    let bits = u32::arbitrary(u)?;
+    let nonce = u32::arbitrary(u)?;
+
+    Ok(BlockHeader {
+        version: Version::from_consensus(version),
+        prev_blockhash: BlockHash::from_byte_array(prev),
+        merkle_root: TxMerkleNode::from_byte_array(merkle),
+        time,
+        bits: CompactTarget::from_consensus(bits),
+        nonce,
+    })
+}
+
+#[derive(Arbitrary)]
+struct Inputs {
+    #[arbitrary(with = gen_header)]
+    header: BlockHeader,
+    height: u32,
+    tag: u8,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(inp) = Inputs::arbitrary(&mut Unstructured::new(data)) {
+        let header = match inp.tag % 6 {
+            0 => DiskBlockHeader::FullyValid(inp.header, inp.height),
+            1 => DiskBlockHeader::AssumedValid(inp.header, inp.height),
+            2 => DiskBlockHeader::HeadersOnly(inp.header, inp.height),
+            3 => DiskBlockHeader::InFork(inp.header, inp.height),
+            4 => DiskBlockHeader::Orphan(inp.header),
+            _ => DiskBlockHeader::InvalidChain(inp.header),
+        };
+
+        // Encode
+        let mut buf = Vec::new();
+        let written = header.consensus_encode(&mut buf).expect("encode failed");
+        assert_eq!(written, buf.len(), "encode returned wrong length");
+
+        // Decode and compare
+        let decoded =
+            DiskBlockHeader::consensus_decode(&mut Cursor::new(&buf)).expect("decode failed");
+        assert_eq!(decoded, header, "roundtrip mismatch");
+    }
+});


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

I have added some straightforward tests for the `DiskBlockHeader` and `BestChain` types. Also improved the `accept_mainnet_headers` test.

I have removed the `impl From<(BlockHash, u32)> for BestChain {`, which was only used in `chain_state_builder.rs`. Instead of using the same "best block" as validation index (which is confusing), I set the genesis block as validation index.
