### PR TITLE
[Doc] update usage section on MD rpc docs

### DIFF
--- a/doc/rpc/addnode.md
+++ b/doc/rpc/addnode.md
@@ -2,11 +2,32 @@
 
 Attempts to add or remove a node from the addnode list.
 
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli addnode <ip:[port]> <add|remove|onetry> [true|false]
+```
+
+### Examples
+
+```bash
+floresta-cli addnode 192.168.0.1 add true
+floresta-cli addnode 192.168.0.1 add false
+floresta-cli addnode 192.168.0.1 remove # does not accept the boolean for v2transport
+floresta-cli addnode 192.168.0.1 onetry true
+floresta-cli addnode 192.168.0.1 onetry false
+```
+
+
 ## Arguments
 
-* `node` - (string, required) The <IP:[PORT]> address of the peer to connect to
-* `command` - (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once
-* `v2transport` -(boolean, optional) Only tries to connect with this address using BIP0324 P2P V2 protocol--ignored for 'remove' command
+`node` - (string, required) The <IP:[PORT]> address of the peer to connect to.
+
+`command` - (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once.
+
+`v2transport` - (boolean, optional) Only tries to connect with this address using BIP0324 P2P V2 protocol. ignored for 'remove' command.
 
 ## Returns
 
@@ -16,22 +37,7 @@ Attempts to add or remove a node from the addnode list.
 
 ### Error Enum `CommandError`
 
-Any of the error types on `rpc_types::Error`
-
-## Usage Examples
-
-* General usage:
-```bash
-floresta-cli addnode <ip:[port]> <add|remove|onetry> [true|false]
-```
-
-```bash
-floresta-cli addnode 192.168.0.1 add true
-floresta-cli addnode 192.168.0.1 add false
-floresta-cli addnode 192.168.0.1 remove #does not accept the boolean for v2transport
-floresta-cli addnode 192.168.0.1 onetry true
-floresta-cli addnode 192.168.0.1 onetry false
-```
+Any of the error types on `rpc_types::Error`.
 
 ## Notes
 

--- a/doc/rpc/gettxout.md
+++ b/doc/rpc/gettxout.md
@@ -2,56 +2,52 @@
 
 Returns details about an unspent transaction output.
 
-## Arguments
+## Usage
 
-* `txid` - (string, required) The transaction id;
-* `command` - (string, required) vout number;
-* `include_mempool` - (not implemented).
-
-## Returns
-
-### Ok Response
-
-* `"bestblock"`: (String) The hash of the block at the tip of the chain;
-* `"confirmations"`: (Numeric) The number of confirmations;
-* `"value"` : (Numeric) The transaction value in BTC;
-* `"scriptPubKey"` : (json)
-  * `"asm"` : (String) The assembled scriptPubKey
-  * `"hex"` : (String) The raw scriptPubKey
-  * `"type"` : (String) The type, eg pubkeyhash
-  * `"addresses"` : (String) bitcoin addresses
-* `"coinbase"` : (Boolean) Coinbase or not.
-
-### Error Enum `CommandError`
-
-* `JsonRpcError::BlockNotFound`;
-* `JsonRpcError::InvalidScript`;
-* `JsonRpcError::InvalidDescriptor`;
-* `JsonRpcError::Encode`
-
-## Usage Examples
-
-* General usage:
+### Synopsis
 
 ```bash
 floresta-cli gettxout <txid> <n> (include_mempool)
 ```
 
-* Examples:
+### Examples
 
 ```bash
-# gettxout with a txid, vout 0 and include_mempool is false by default
+# gettxout with a txid, vout 0
 floresta-cli gettxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0
-
-# gettxout with a txid, vout 0 and include_mempool is false
-floresta-cli gettxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 false
-
-# gettxout with a txid, vout 0 and include_mempool is true
-floresta-cli gettxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 true
 ```
+
+## Arguments
+
+`txid` - (string, required) The transaction id.
+
+`n` - (numeric, required) vout number.
+
+`include_mempool` - (not implemented, the argument is available to maintain API consistency but it value will be ignored).
+
+## Returns
+
+### Ok Response
+
+* `bestblock`: (string) The hash of the block at the tip of the chain;
+* `confirmations`: (numeric) The number of confirmations;
+* `value` : (numeric) The transaction value in BTC;
+* `scriptPubKey` : (json object)
+  * `asm` : (string) The assembled scriptPubKey
+  * `hex` : (string) The raw scriptPubKey
+  * `type` : (string) The type, eg pubkeyhash
+  * `addresses` : (string) bitcoin addresses
+* `coinbase` : (boolean) Coinbase or not.
+
+### Error Enum `CommandError`
+
+* `JsonRpcError::BlockNotFound`
+* `JsonRpcError::InvalidScript`
+* `JsonRpcError::InvalidDescriptor`
+* `JsonRpcError::Encode`
 
 ## Notes
 
-This `rpc` isn't fully implemented mostly because we need to implement mempool. For more information see [RPC Saga](https://github.com/orgs/vinteumorg/projects/5):
+* This `rpc` isn't fully implemented mostly because we need to implement a mempool. For more information see [RPC Saga](https://github.com/orgs/vinteumorg/projects/5):
 
-* It accept the `include_mempool` option, but for now, it do nothing;
+* The API accept the `include_mempool` argument but, for now, it does nothing.

--- a/doc/rpc/rescanblockchain.md
+++ b/doc/rpc/rescanblockchain.md
@@ -2,15 +2,45 @@
 
 Sends a request to the node for rescan the blockchain searching for transactions related to the wallet's cached addresses.
 
+## Usage
+
+### Synopsis
+
+```Bash
+floresta-cli rescanblockchain <--t or --timestamp> <start_block> <stop_block> <high|medium|low|exact)>
+```
+
+### Examples
+
+```bash
+
+# Rescan from height 100 to 200
+
+floresta-cli rescanblockchain 100 200
+
+# Rescan from height 100 to tip
+
+floresta-cli rescanblockchain 100
+
+# Rescan from timestamp 1231006505 (genesis) until 133456789
+
+floresta-cli rescanblockchain -t 1231006505 1752516460 --confidence high
+
+# Rescan from timestamp 0 (alias for genesis) until the tip
+
+floresta-cli rescanblockchain --timestamp 0 1752516460 -c high
+
+ ```
+
 ## Arguments
 
-* `start_block` (numeric, optional, default=`0`): The initial block to start the blockchain rescan.
+`start_block` (numeric, optional, default=`0`): The initial block to start the blockchain rescan.
 
-* `stop_block` (numeric, optional, default=`0`): The block limit to stop rescanning.
+`stop_block` (numeric, optional, default=`0`): The block limit to stop rescanning. (0 disables it)
 
-* `use_timestamp` (boolean flag, optional, default=`false`): When present in the command the provided values will be treated as UNIX timestamps. These timestamps do not need to be directly from a block and can be used for finding addresses and UTXOs from meaningful timestamp values.
+`use_timestamp` (boolean flag, optional, default=`false`): When present in the command the provided values will be treated as UNIX timestamps. These timestamps do not need to be directly from a block and can be used for finding addresses and UTXOs from meaningful timestamp values.
 
-* `confidence` (string, optional, default=`medium`): In cases where `use_timestamp` is set, tells how much confidence the user wants for finding its addresses from this rescan request, a higher confidence will add more lookback seconds to the targeted timestamp and rescanning more blocks.
+`confidence` (string, optional, default=`medium`): In cases where `use_timestamp` is set, tells how much confidence the user wants for finding its addresses from this rescan request, a higher confidence will add more lookback seconds to the targeted timestamp and rescanning more blocks.
 
 Under the hood this uses an [Exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution) [cumulative distribution function (CDF)](https://en.wikipedia.org/wiki/Cumulative_distribution_function) where the parameter $\lambda$ (rate) is $\frac{1}{600}$ (1 block every 600 seconds, 10 minutes).
   The supplied string can be one of:
@@ -36,28 +66,6 @@ This RPC command can only fail if:
 If `timestamp` is true, apart the previous rules, if any of the values is smaller than the genesis block (1231006505 for mainnet) or greater than the tip time, the execution will also fail.
 
 Furthermore, the request will be aborted if the node still syncing with the blockchain.
-
-## Usage Examples
-
-```bash
-
-# Rescan from height 100 to 200
-
-floresta-cli rescanblockchain 100 200
-
-# Rescan from height 100 to tip
-
-floresta-cli rescanblockchain 100
-
-# Rescan from timestamp 1231006505 (genesis) until 133456789
-
-floresta-cli rescanblockchain -t 1231006505 1752516460 --confidence high
-
-# Rescan from timestamp 0 (alias for genesis) until the tip
-
-floresta-cli rescanblockchain --timestamp 0 1752516460 -c high
-
- ```
 
 ## Notes
 

--- a/doc/rpc/template.md
+++ b/doc/rpc/template.md
@@ -2,30 +2,32 @@
 
 Brief description of what this RPC does and its primary purpose.
 
-## Arguments
+## Usage
 
-* `param1` - (type, required or optional) Description of the first parameter
+### Synopsis
 
-Please, always skip a line to render properly on man-pages.
+floresta-cli <command> <param1, parameter_type> <param2> [<optional_flag, (-f or --flag)>]
 
-```json5
-// Wrap with `[` and `]` to indicate an array of objects
-[
+### Examples
 
-  {
-
-    "json_string": "str", // (String, required) Description about the expected JSON object.
-
-    "numeric_field": 123, // (Numeric, optional) Describes an optional field.
-
-    "boolean_field": true // (Boolean, required) Describes an obligatory boolean.
-
-  }
-
-]
+```bash
+floresta-cli templatecommand -f "data"
+floresta-cli templatecommand --flag "moredata"
+floresta-cli templatecommand  123
 ```
 
-* `param2`  - Description of optional parameter (default: value) (type)
+## Arguments
+
+`param1` - (type, required or optional) Description of the first parameter
+
+  * `json_string` (string, required) Description about the expected JSON object.
+
+  * `numeric_field` (numeric, optional) Describes an optional field.
+
+  * `boolean_field`(boolean, required) Describes an obligatory boolean.
+
+
+`param2`  - (type, required or optional) Description of optional parameter 
 
 ## Returns
 
@@ -37,12 +39,6 @@ Please, always skip a line to render properly on man-pages.
 ### Error Enum `CommandError`
 
 (Command error is a well documented enum returned client side)
-
-## Usage Examples
-
-```bash
-floresta-cli <command> <param1> <param2> <optional_param>
-```
 
 ## Notes
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [X] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: All the docs at `/doc/rpc`

### Description and Notes

The `addnode.md` documentation had some kind of a "general usage" that demonstrated how a command should look like, positioning the arguments with some default alternatives, #609 also demonstrated something alike and i tried to formalize it in this PR.

I also moved the usage section up, the logic is to define the camps and later explaining what they are doing.

You can consider this totally aesthetics related, the rendered version also looked better btw,

### Contributor Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
