### PR TITLE
Updated build and run instructions 

### DIFF
--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -49,9 +49,9 @@ and build with cargo build
 ```bash
 cargo build --release
 
-# Optionally, you can add florestad and floresta-cli to the path with
-cargo install --path ./florestad
-cargo install --path ./crates/floresta-cli
+# Alternatively, you can add florestad and floresta-cli to the path with
+cargo install --path ./bin/florestad --locked
+cargo install --path ./bin/floresta-cli --locked
 ```
 
 If you are using Nix, you can add Florestad to your system following the instructions [here](nix.md).

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -27,9 +27,9 @@ and build with cargo build
 ```bash
 cargo build --release
 
-# Optionally, you can add florestad and floresta-cli to the path with
-cargo install --path ./florestad
-cargo install --path ./crates/floresta-cli
+# Alternatively, you can add florestad and floresta-cli to the path with
+cargo install --path ./bin/florestad --locked
+cargo install --path ./bin/floresta-cli --locked
 ```
 
 If you are using Nix, you can add Florestad to your system following the instructions [here](nix.md).

--- a/doc/run.md
+++ b/doc/run.md
@@ -94,7 +94,7 @@ floresta-cli help <command>
 
 Floresta comes with a watch-only wallet that you can use to track your transactions. You just need to provide the wallet
 information, either as a configuration file or as a command line argument. See the [sample configuration file](../config.toml.sample) for an example config. Floresta supports SLIP-132 extended public keys (xpubs) and output descriptors. You can add new wallets to follow at any time, just
-call the `rescan` rpc after adding the wallet.
+call the `rescanblockchain` rpc after adding the wallet.
 
 You can add new descriptors to the wallet with the `importdescriptor` rpc.
 
@@ -110,10 +110,10 @@ using the `--filters-start-height` option. Let's you know that none of your wall
 ./target/release/florestad --filters-start-height 800000
 ```
 
-if you add a wallet and want to rescan the blocks from 800,000 to the current height, you can use the `rescan` rpc.
+if you add a wallet and want to rescan the blocks from 800,000 to the current height, you can use the `rescanblockchain` rpc.
 
 ```bash
-floresta-cli rescan 800000
+floresta-cli rescanblockchain 800000
 ```
 
 Once you have a transaction cached in your watch-only, you can use either the rpc or integrated electrum server to retrieve information about your wallet. You can use wallets like Electrum or Sparrow to connect to your node and retrieve information about your wallet. Just connect with the server running at `127.0.0.1:50001:t`. On electrum you may want to use the `--oneserver` flag to connect to a single server, for better privacy.


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [X] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: <!-- Please describe it --> ~/Floresta/doc/

### Description and Notes

This PR updates the documentation to build and run `florestad` and `floresta-cli` after #619

It also adds the `--locked` flag to avoid issues like the one reported by @luisschwab 
```bash
root@floresta:~/Floresta# cargo install --path ./florestad
  Installing florestad v0.8.0 (/root/Floresta/florestad)
    Updating crates.io index
  Downloaded dns-lookup v2.1.1
  Downloaded 1 crate (15.5 KB) in 0.21s
error: failed to compile `florestad v0.8.0 (/root/Floresta/florestad)`, intermediate artifacts can be found at `/root/Floresta/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  package `deranged v0.5.3` cannot be built because it requires rustc 1.81.0 or newer, while the currently active rustc version is 1.74.1
  Either upgrade to rustc 1.81.0 or newer, or use
  cargo update deranged@0.5.3 --precise ver
  where `ver` is the latest version of `deranged` supporting rustc 1.74.1
  ```
  
  It renames the `rescan` to `rescanblockchain` in the docs to be compliant with the merged #558
<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->
