### PR TITLE
feat: add variants to `ConnectionKind` enum in floresta-wire

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -88,6 +88,9 @@ pub enum WireError {
 
     /// Couldn't find the leaf data for a block
     LeafDataNotFound,
+
+    /// Exceeded the max number of outbound peers
+    OutboundPeersExceeded,
 }
 
 impl std::fmt::Display for WireError {
@@ -132,6 +135,9 @@ impl std::fmt::Display for WireError {
                 "We tried to work on a block that we don't have a proof for yet"
             ),
             WireError::LeafDataNotFound => write!(f, "Couldn't find the leaf data for a block"),
+            WireError::OutboundPeersExceeded => {
+                write!(f, "Exceeded the max number of outbound peers")
+            }
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -564,15 +564,17 @@ where
     /// This function checks how many time has passed since our last tip update, if it's
     /// been more than 15 minutes, try to update it.
     fn check_for_stale_tip(&mut self) -> Result<(), WireError> {
-        warn!("Potential stale tip detected, trying extra peers");
+        warn!("Potential stale tip detected, will try using extra outbound peer");
 
         // this catches an edge-case where all our utreexo peers are gone, and the GetData
         // times-out. That yields an error, but doesn't ask the block again. Our last_block_request
         // will be pointing to a block that will never arrive, so we basically deadlock.
-        self.last_block_request = self.chain.get_validation_index().unwrap();
+        self.last_block_request = self.chain.get_validation_index()?;
+
         // update this or we'll get this warning every second after 15 minutes without a block,
         // until we get a new block.
         self.last_tip_update = Instant::now();
+
         self.create_connection(ConnectionKind::Extra)?;
         self.send_to_random_peer(
             NodeRequest::GetHeaders(self.chain.get_block_locator().unwrap()),
@@ -675,7 +677,11 @@ where
                         );
                         self.inflight.remove(&InflightRequests::Headers);
 
-                        let peer_info = self.peers.get(&peer).cloned().expect("Peer not found");
+                        let peer_info = match self.peers.get(&peer).cloned() {
+                            Some(peer) => peer,
+                            None => return Err(WireError::PeerNotFound),
+                        };
+
                         let is_extra = matches!(peer_info.kind, ConnectionKind::Extra);
 
                         if is_extra {
@@ -685,24 +691,47 @@ where
                                 return Ok(());
                             }
 
-                            // this peer got us a new block, we should disconnect one of our regular peers
-                            // and keep this one.
-                            let peer_to_disconnect = self
+                            // this peer got us a new block, we should disconnect one
+                            // of our OutboundFullRelay/BlockRelayOnly peers
+                            let full_relay_count = self
                                 .peers
                                 .iter()
-                                .filter(|(_, info)| matches!(info.kind, ConnectionKind::Regular(_)))
+                                .filter(|(_, info)| {
+                                    matches!(info.kind, ConnectionKind::OutboundFullRelay(_))
+                                })
+                                .count();
+
+                            // If we have space for OutboundFullRelay, use it
+                            let wants_full = full_relay_count < RunningNode::MAX_FULL_RELAY_PEERS;
+
+                            match self
+                                .peers
+                                .iter()
+                                .filter(|(_, info)| {
+                                    if wants_full {
+                                        matches!(info.kind, ConnectionKind::OutboundFullRelay(_))
+                                    } else {
+                                        matches!(info.kind, ConnectionKind::BlockRelayOnly(_))
+                                    }
+                                })
                                 .min_by_key(|(k, _)| self.get_peer_score(**k))
-                                .map(|(peer, _)| *peer);
+                                .map(|(peer, _)| *peer)
+                            {
+                                Some(extra_peer_id) => {
+                                    // disconnect the peer with the lowest score
+                                    self.send_to_peer(extra_peer_id, NodeRequest::Shutdown)?;
 
-                            // disconnect the peer with the lowest score
-                            if let Some(peer) = peer_to_disconnect {
-                                self.send_to_peer(peer, NodeRequest::Shutdown)?;
+                                    // update the peer info
+                                    self.peers.entry(peer).and_modify(|info| {
+                                        info.kind = if wants_full {
+                                            ConnectionKind::OutboundFullRelay(peer_info.services)
+                                        } else {
+                                            ConnectionKind::BlockRelayOnly(peer_info.services)
+                                        }
+                                    });
+                                }
+                                None => return Err(WireError::PeerNotFound),
                             }
-
-                            // update the peer info
-                            self.peers.entry(peer).and_modify(|info| {
-                                info.kind = ConnectionKind::Regular(peer_info.services);
-                            });
                         }
 
                         for header in headers.iter() {
@@ -721,7 +750,7 @@ where
 
                         // update the peer info
                         self.peers.entry(peer).and_modify(|info| {
-                            info.kind = ConnectionKind::Regular(peer_info.services);
+                            info.kind = ConnectionKind::OutboundFullRelay(peer_info.services);
                         });
                     }
 

--- a/crates/floresta-wire/src/p2p_wire/node_context.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_context.rs
@@ -37,6 +37,16 @@ pub trait NodeContext {
     /// Max number of simultaneous connections we initiates we are willing to hold
     const MAX_OUTGOING_PEERS: usize = 10;
 
+    /// Max number of simultaneous outbound-full-relay connections we initiates that are willing to hold
+    const MAX_FULL_RELAY_PEERS: usize = 8;
+
+    /// Max number of simultaneous block-only connections we initiates that are willing to hold
+    const MAX_BLOCK_RELAY_ONLY_ANCHORS: usize = 2;
+
+    /// Addnode connections are limited to 8 at a time
+    /// see <https://bitcoincore.org/en/doc/29.0.0/rpc/network/addnode>
+    const MAX_MANUAL_PEERS: usize = 8;
+
     /// We ask for peers every ASK_FOR_PEERS_INTERVAL seconds
     const ASK_FOR_PEERS_INTERVAL: u64 = 60 * 60; // One hour
 

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -58,10 +58,18 @@ const UTREEXO_PROOF_CMD_STRING: &str = "uproof";
 const GET_UTREEXO_PROOF_CMD: &str = "getuproof";
 
 #[derive(Debug, PartialEq)]
+/// Enum to classify the state of a peer
 enum State {
+    /// Handshake haven't stated yet
     None,
+
+    /// Peer sent version message at some time
     SentVersion(Instant),
+
+    /// Peer sent verack message
     SentVerack,
+
+    /// Peer made a handshake and is connected
     Connected,
 }
 
@@ -738,10 +746,10 @@ pub struct Version {
     pub transport_protocol: TransportProtocol,
 }
 
+#[derive(Debug)]
 /// Messages passed from different modules to the main node to process. They should minimal
 /// and only if it requires global states, everything else should be handled by the module
 /// itself.
-#[derive(Debug)]
 pub enum PeerMessages {
     /// A new block just arrived, we should ask for it and update our chain
     NewBlock(BlockHash),

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -79,7 +79,7 @@ impl SimulatedPeer {
                 | ServiceFlags::WITNESS
                 | ServiceFlags::COMPACT_FILTERS
                 | ServiceFlags::from(1 << 25),
-            kind: ConnectionKind::Regular(UTREEXO.into()),
+            kind: ConnectionKind::OutboundFullRelay(UTREEXO.into()),
             transport_protocol: TransportProtocol::V2,
         };
 
@@ -179,7 +179,7 @@ pub fn create_peer(
         state: PeerStatus::Ready,
         channel: sender,
         port: 8333,
-        kind: ConnectionKind::Regular(UTREEXO.into()),
+        kind: ConnectionKind::OutboundFullRelay(UTREEXO.into()),
         banscore: 0,
         address_id: 0,
         _last_message: Instant::now(),

--- a/tests/florestad/node-info.py
+++ b/tests/florestad/node-info.py
@@ -10,7 +10,6 @@ from test_framework.node import NodeType
 
 
 class NodeInfoTest(FlorestaTestFramework):
-
     def set_test_params(self):
         """
         Setup a florestad and a bitcoind node
@@ -43,7 +42,7 @@ class NodeInfoTest(FlorestaTestFramework):
 
         peer_info = self.florestad.rpc.get_peerinfo()
         self.assertEqual(peer_info[0]["address"], self.bitcoind.p2p_url)
-        self.assertEqual(peer_info[0]["kind"], "regular")
+        self.assertEqual(peer_info[0]["kind"], "manual")
         self.assertEqual(
             peer_info[0]["services"],
             "ServiceFlags(NETWORK|WITNESS|NETWORK_LIMITED|P2P_V2)",

--- a/tests/test_framework/electrum/client.py
+++ b/tests/test_framework/electrum/client.py
@@ -18,7 +18,7 @@ class ElectrumClient(BaseClient):
 
     def block_header(self, block_hash: str):
         """
-        Return a block header, given its hash.
+        Return the hash of a block, given it's hash.
         """
         return self.request("blockchain.block.header", [block_hash])
 

--- a/tests/test_framework/node.py
+++ b/tests/test_framework/node.py
@@ -10,7 +10,7 @@ import os
 import signal
 import contextlib
 from enum import Enum
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Literal
 
 from test_framework.daemon import ConfigP2P
 from test_framework.daemon.bitcoin import BitcoinDaemon
@@ -300,7 +300,10 @@ class Node:
         return response
 
     def connect_node(
-        self, node: "Node", method: str = "add", v2transport: bool = False
+        self,
+        node: Literal[NodeType.FLORESTAD, NodeType.UTREEXOD, NodeType.BITCOIND],
+        method: str = "add",
+        v2transport: bool = False,
     ):
         """
         Connect to another node.


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes

This PR is a partial fix of #622, in the sense to define enum variants compliant to the `"connection_type"` field returned by the bitcoin-core's `getpeerinfo` rpc. 

### How to verify the changes you have done?

It add to the `ConnectionKind::Regular`, `ConnectionKind::Extra` and `ConnectionKind::Manual` variants 2 new subvariants `OutboundKind::OutboundFullRelay` and `OutboundKind::BlockRelayOnly`, as well add a `AddrFetch` (the `Inbound` type is excluded since this one do not make sense in Floresta).
