### PR TITLE
florestad: fix the version string for consistency

### DIFF
--- a/bin/florestad/build.rs
+++ b/bin/florestad/build.rs
@@ -17,8 +17,11 @@ fn main() {
         .expect("Failed to run rustc --version. Is rustc installed?");
 
     let long_version = format!("version {version} compiled for {arch}-{os}-{runtime} with {rustc}");
+    let user_agent = format!("/Floresta/{}/", version.replace("v", ""));
+
     println!("cargo:rustc-env=LONG_VERSION={long_version}");
     println!("cargo:rustc-env=GIT_DESCRIBE={version}");
+    println!("cargo:rustc-env=USER_AGENT={user_agent}");
 
     // re-run if either the build script or the git HEAD changes
     println!("cargo:rerun-if-changed=../.git/HEAD");
@@ -28,7 +31,7 @@ fn main() {
 fn get_version_from_manifest() -> Result<String, std::io::Error> {
     let manifest = std::fs::read_to_string("Cargo.toml")?;
     let toml: toml::Value = toml::from_str(&manifest).unwrap();
-    Ok(toml["package"]["version"].as_str().unwrap().to_string())
+    Ok(format!("v{}", toml["package"]["version"].as_str().unwrap()))
 }
 
 fn get_version_from_git() -> Option<String> {
@@ -41,6 +44,12 @@ fn get_version_from_git() -> Option<String> {
             }
             let mut git_description = String::from_utf8(output.stdout).unwrap();
             git_description.pop(); // remove the trailing newline
+
+            // If we don't pull tags, git will return the short commit id, which breaks the functional tests
+            if !git_description.starts_with("v") {
+                return None;
+            }
+
             Some(git_description)
         })
         .ok()?

--- a/bin/florestad/src/main.rs
+++ b/bin/florestad/src/main.rs
@@ -17,6 +17,7 @@
 #![deny(non_upper_case_globals)]
 
 mod cli;
+use std::env;
 use std::process::exit;
 use std::sync::Arc;
 use std::time::Duration;
@@ -65,7 +66,7 @@ fn main() {
         generate_cert: params.generate_cert,
         wallet_descriptor: params.wallet_descriptor,
         filters_start_height: params.filters_start_height,
-        user_agent: format!("/Floresta:{}/", env!("GIT_DESCRIBE")),
+        user_agent: env!("USER_AGENT").to_owned(),
         assumeutreexo_value: None,
         electrum_address: params.electrum_address,
         enable_electrum_tls: params.enable_electrum_tls,

--- a/tests/floresta-cli/addnode-v1.py
+++ b/tests/floresta-cli/addnode-v1.py
@@ -126,7 +126,7 @@ class AddnodeTestV1(FlorestaTestFramework):
         self.assertEqual(peer_info[0]["services"], "0000000001000009")
         self.assertMatch(
             peer_info[0]["subver"],
-            re.compile(r"\/Floresta:.*\/"),
+            re.compile(r"\/Floresta\/\d\.\d\.\d\/"),
         )
         self.assertEqual(peer_info[0]["inbound"], True)
 

--- a/tests/floresta-cli/addnode-v2.py
+++ b/tests/floresta-cli/addnode-v2.py
@@ -121,7 +121,7 @@ class AddnodeTestV2(FlorestaTestFramework):
         self.assertEqual(peer_info[0]["services"], "0000000001000009")
         self.assertMatch(
             peer_info[0]["subver"],
-            re.compile(r"\/Floresta:.*\/"),
+            re.compile(r"\/Floresta\/\d\.\d\.\d\/"),
         )
         self.assertEqual(peer_info[0]["inbound"], True)
 


### PR DESCRIPTION
- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes

Before this commit, if we build from a git repository, the user string would be something like "v0.8.0". However, if you build from an archive, it would be "0.8.0".

The user agent is also different: "/Floresta/v0.8.0/" and "/Floresta/0.8.0/" respectively. This commit makes sure the version always have the 'v' prefix, but user agents don't, as user agent's versions are usually numerical.

### What is the purpose of this pull request?