### PR TITLE
Update the last connection times

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1806,6 +1806,12 @@ where
             },
         );
 
+        match kind {
+            ConnectionKind::Feeler => self.last_feeler = Instant::now(),
+            ConnectionKind::Regular(_) => self.last_connection = Instant::now(),
+            _ => {}
+        }
+
         // Increment peer_id count and the list of peer ids
         // so we can get information about connected or
         // added peers when requesting with getpeerinfo command


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes

When testing the new utreexo workflow I found that if I only have one utreexo peer, I end up trying new connections almost in a loop, which makes the sync process much much slower.

The problem is that we don't actually update the `last_connection` (and also `last_feeler`) fields, so the `check_connections` function always runs, again and again. With this simple fix IBD was 5-6x faster in my case.
