### PR TITLE
Use `doc_cfg` feature gate for cargo doc

### DIFF
--- a/bin/florestad/src/cli.rs
+++ b/bin/florestad/src/cli.rs
@@ -1,6 +1,4 @@
 use bitcoin::Network;
-use clap::arg;
-use clap::command;
 use clap::Parser;
 
 #[derive(Parser)]

--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -11,7 +11,7 @@
 //! underlying database. See the ChainStore trait for more information. For a
 //! ready-to-use implementation, see the [`FlatChainStore`] struct.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 #![allow(clippy::manual_is_multiple_of)]

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -4,7 +4,7 @@
 //! Provides utility functions, macros and modules to be
 //! used in other Floresta crates.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 use bitcoin::consensus::encode;

--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -10,7 +10,7 @@
 //! for it. Therefore, you can't use this to speedup wallet sync **before** IBD,
 //! since we wouldn't have the filter for all blocks yet.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::manual_is_multiple_of)]
 
 use core::fmt::Debug;

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::manual_is_multiple_of)]
 
 use serde::Deserialize;

--- a/crates/floresta-node/src/lib.rs
+++ b/crates/floresta-node/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod config_file;
 mod error;

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -8,7 +8,7 @@
 //! ready-to-use library for interacting with florestad's json-rpc interface in your rust
 //! application.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "with-jsonrpc")]
 pub mod jsonrpc_client;

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::manual_is_multiple_of)]
 
 use core::cmp::Ordering;

--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -10,7 +10,7 @@
 //! like requesting blocks, mempool transactions or asking to connect with a given
 //! peer.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(not(target_arch = "wasm32"))]
 mod p2p_wire;

--- a/crates/floresta/src/lib.rs
+++ b/crates/floresta/src/lib.rs
@@ -29,7 +29,7 @@
 //! Floresta is the Portuguese word for forest. It is a reference to the Utreexo accumulator,
 //! which is a forest of Merkle trees. It's pronounced /floˈɾɛstɐ/.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// Components to build a utreexo-aware, consensus enforcing Bitcoin node.
 pub use floresta_chain as chain;


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [x] floresta-cli
- [x] floresta-common
- [x] floresta-compact-filters
- [x] floresta-electrum
- [x] floresta-watch-only
- [x] floresta-wire
- [x] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes

Docs.rs feature badges (documenting which items/modules are  feature-gated) are part of `doc_cfg` now.

Also removing two unused macro imports that clippy has detected now.