### PR TITLE
HOTFIX: RescanConfidence parsing now uses serdejson and some typos

### DIFF
--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -40,7 +40,7 @@ pub enum RescanConfidence {
     /// `low`: 90% confidence interval. Returning 23 minutes in seconds for `val`.
     Low,
 
-    /// `raw`: Removes any lookback addition. Returning 0 for `val`
+    /// `exact`: Removes any lookback addition. Returning 0 for `val`
     Exact,
 }
 
@@ -316,7 +316,7 @@ impl Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             JsonRpcError::InvalidTimestamp => write!(f, "Invalid timestamp, ensure that it is between the genesis and the tip."),
-            JsonRpcError::InvalidRescanVal => write!(f, "You rescan request contains invalid values"),
+            JsonRpcError::InvalidRescanVal => write!(f, "Your rescan request contains invalid values"),
             JsonRpcError::NoAddressesToRescan => write!(f, "You do not have any address to proceed with the rescan"),
             JsonRpcError::MissingParameter(opt) => write!(f, "Missing parameter: {opt}"),
             JsonRpcError::InvalidParameterType(opt) => write!(f, "Invalid parameter type for: {opt}"),

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -209,9 +209,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
                 Value::Number(Number::from(start_height)),
                 Value::Number(Number::from(stop_height)),
                 Value::Bool(use_timestamp),
-                Value::String(
-                    serde_json::to_string(&confidence).expect("RescanConfidence implements serde"),
-                ),
+                serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
             ],
         )
     }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes
For some dubious and misterious reasons #647 is happening even that we are using the same string matching pipeline handling the functions.

This PR present minimal changes that fix the parsing problem and some typos.

### How to verify the changes you have done?

Before this PR the rpc command `rescanblockchain` was failing even in it defaults so a proper way to verify this is by sucessfully executing any `rescanblockchain` command variant

### Contributor Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
