### PR TITLE
fix: implement `getblock` and `getblockheader` compliant with core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tests/**/__pycache__/*
 
 # commitizen under nixdevshell
 .cz.toml
+
+# shit mac stuff
+**.DS_STORE

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -83,8 +83,9 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::SendRawTransaction { tx } => {
             serde_json::to_string_pretty(&client.send_raw_transaction(tx)?)?
         }
-        Methods::GetBlockHeader { hash } => {
-            serde_json::to_string_pretty(&client.get_block_header(hash)?)?
+        Methods::GetBlockHeader { hash, verbose } => {
+            let res = client.get_block_header(hash, verbose.unwrap_or(false))?;
+            serde_json::to_string_pretty(&res)?
         }
         Methods::LoadDescriptor { desc } => {
             serde_json::to_string_pretty(&client.load_descriptor(desc)?)?
@@ -256,9 +257,21 @@ pub enum Methods {
     )]
     SendRawTransaction { tx: String },
 
-    /// Returns the block header for the given block hash
-    #[command(name = "getblockheader")]
-    GetBlockHeader { hash: BlockHash },
+    #[command(
+        name = "getblockheader",
+        about = "Returns the header for a block with a given hash, with optional information about it.",
+        long_about = Some(include_str!("../../../doc/rpc/getblockheader.md")),
+        disable_help_subcommand = true
+    )]
+    GetBlockHeader {
+        #[arg(required = true)]
+        /// The block hash
+        hash: BlockHash,
+
+        #[arg(required = false)]
+        /// true for a json object, false for the hex-encoded data
+        verbose: Option<bool>,
+    },
 
     /// Loads a new descriptor to the watch only wallet
     #[doc = include_str!("../../../doc/rpc/loaddescriptor.md")]
@@ -283,7 +296,12 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetBlock {
+        #[arg(required = true)]
+        /// The block hash
         hash: BlockHash,
+
+        #[arg(required = false)]
+        /// 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data
         verbosity: Option<u32>,
     },
 

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use axum::response::IntoResponse;
+use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
 use floresta_chain::extensions::HeaderExtError;
 use floresta_common::impl_error_from;
@@ -126,6 +127,13 @@ pub enum GetBlockRes {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetBlockHeaderRes {
+    Zero(String),
+    One(Box<GetBlockHeaderVerbose>),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RpcError {
     pub code: i32,
     pub message: String,
@@ -220,6 +228,8 @@ pub enum JsonRpcError {
 
     /// Something went wrong when attempting to publish a transaction to mempool
     MempoolAccept(AcceptToMempoolError),
+
+    ToValue(serde_json::Error),
 }
 
 impl_error_from!(JsonRpcError, AcceptToMempoolError, MempoolAccept);
@@ -254,6 +264,7 @@ impl Display for JsonRpcError {
             JsonRpcError::InvalidDisconnectNodeCommand => write!(f, "Invalid disconnectnode command"),
             JsonRpcError::PeerNotFound => write!(f, "Peer not found in the peer list"),
             JsonRpcError::MempoolAccept(e) => write!(f, "Could not send transaction to mempool due to {e}"),
+            JsonRpcError::ToValue(e) => write!(f, "Failed to parse JSON: {e}")
         }
     }
 }

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -43,6 +43,7 @@ mod tests {
 
     use crate::jsonrpc_client::Client;
     use crate::rpc::FlorestaRPC;
+    use crate::rpc_types::GetBlockHeaderVerbose;
     use crate::rpc_types::GetBlockRes;
 
     struct Florestad {
@@ -222,13 +223,57 @@ mod tests {
     }
 
     #[test]
-    fn test_get_block_header() {
+    fn test_get_block_header_hex() {
         let (_proc, client) = start_florestad();
 
+        // First not verbose
         let blockhash = client.get_block_hash(0).expect("rpc not working");
-        let block_header = client.get_block_header(blockhash).expect("rpc not working");
+        let blockheader = client
+            .get_block_header(blockhash, false)
+            .expect("rpc not working");
 
-        assert_eq!(block_header.block_hash(), blockhash);
+        let blockheader_value = serde_json::to_value(blockheader).expect("serde not working");
+
+        assert_eq!(
+            "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2002000000",
+            blockheader_value
+        );
+    }
+
+    #[test]
+    fn test_get_block_header_json() {
+        let (_proc, client) = start_florestad();
+
+        // Then verbose
+        let blockhash = client.get_block_hash(0).expect("rpc not working");
+        let blockheader = client
+            .get_block_header(blockhash, true)
+            .expect("rpc not working");
+
+        let blockheader_value = serde_json::to_value(blockheader).expect("serde not working");
+        let expected = serde_json::to_value(GetBlockHeaderVerbose {
+            bits: "207fffff".to_string(),
+            chain_work: "0000000000000000000000000000000000000000000000000000000000000002"
+                .to_string(),
+            confirmations: 1,
+            difficulty: 4.6565423739069247e-10,
+            hash: "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206".to_string(),
+            height: 0,
+            median_time: 1296688602,
+            merkle_root: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+                .to_string(),
+            n_tx: 1,
+            nonce: 2,
+            target: "7fffff0000000000000000000000000000000000000000000000000000000000".to_string(),
+            time: 1296688602,
+            version: 1,
+            version_hex: "00000001".to_string(),
+            next_block_hash: None,
+            previous_block_hash: None,
+        })
+        .expect("serde_json not working");
+
+        assert_eq!(blockheader_value, expected);
     }
 
     #[test]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -1,9 +1,7 @@
 use std::fmt::Debug;
 
-use bitcoin::block::Header as BlockHeader;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
-use corepc_types::v29::GetTxOut;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -21,6 +19,7 @@ pub trait FlorestaRPC {
     /// for a given block height, encoded as a hexadecimal string.
     /// You need to have enabled block filters by setting the `blockfilters=1` option
     fn get_block_filter(&self, height: u32) -> Result<String>;
+
     /// Returns general information about the chain we are on
     ///
     /// This method returns a bunch of information about the chain we are on, including
@@ -34,24 +33,23 @@ pub trait FlorestaRPC {
     /// This method returns the hash of the block at the given height. If the height is
     /// invalid, an error is returned.
     fn get_block_hash(&self, height: u32) -> Result<BlockHash>;
-    /// Returns the block header for the given block hash
-    ///
-    /// This method returns the block header for the given block hash, as defined
-    /// in the Bitcoin protocol specification. A header contains the block's version,
-    /// the previous block hash, the merkle root, the timestamp, the difficulty target,
-    /// and the nonce.
-    fn get_block_header(&self, hash: BlockHash) -> Result<BlockHeader>;
+
+    #[doc = include_str!("../../../doc/rpc/getblockheader.md")]
+    fn get_block_header(&self, hash: BlockHash, verbose: bool) -> Result<Value>;
+
     /// Gets a transaction from the blockchain
     ///
     /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
     /// set to false, the transaction is returned as a hexadecimal string. If the verbosity
     /// flag is set to true, the transaction is returned as a json object.
     fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value>;
+
     /// Returns the proof that one or more transactions were included in a block
     ///
     /// This method returns the Merkle proof, showing that a transaction was included in a block.
     /// The pooof is returned as a vector hexadecimal string.
     fn get_txout_proof(&self, txids: Vec<Txid>, blockhash: Option<BlockHash>) -> Option<String>;
+
     /// Loads up a descriptor into the wallet
     ///
     /// This method loads up a descriptor into the wallet. If the rescan option is not None,
@@ -72,40 +70,47 @@ pub trait FlorestaRPC {
 
     /// Returns the current height of the blockchain
     fn get_block_count(&self) -> Result<u32>;
+
     /// Sends a hex-encoded transaction to the network
     ///
     /// This method sends a transaction to the network. The transaction should be encoded as a
     /// hexadecimal string. If the transaction is valid, it will be broadcast to the network, and
     /// return the transaction id. If the transaction is invalid, an error will be returned.
     fn send_raw_transaction(&self, tx: String) -> Result<Txid>;
+
     /// Gets the current accumulator for the chain we're on
     ///
     /// This method returns the current accumulator for the chain we're on. The accumulator is
     /// a set of roots, that let's us prove that a UTXO exists in the chain. This method returns
     /// a vector of hexadecimal strings, each of which is a root in the accumulator.
     fn get_roots(&self) -> Result<Vec<String>>;
+
     /// Gets information about the peers we're connected with
     ///
     /// This method returns information about the peers we're connected with. This includes
     /// the peer's IP address, the peer's version, the peer's user agent, the transport protocol
     /// and the peer's current height.
     fn get_peer_info(&self) -> Result<Vec<PeerInfo>>;
+
     /// Returns a block, given a block hash
     ///
     /// This method returns a block, given a block hash. If the verbosity flag is 0, the block
     /// is returned as a hexadecimal string. If the verbosity flag is 1, the block is returned
     /// as a json object.
     fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes>;
+
     /// Return a cached transaction output
     ///
     /// This method returns a cached transaction output. If the output is not in the cache,
     /// or is spent, an empty object is returned. If you want to find a utxo that's not in
     /// the cache, you can use the findtxout method.
-    fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut>;
+    fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<Value>;
+
     /// Stops the florestad process
     ///
     /// This can be used to gracefully stop the florestad process.
     fn stop(&self) -> Result<String>;
+
     /// Tells florestad to connect with a peer
     ///
     /// You can use this to connect with a given node, providing it's IP address and port.
@@ -134,12 +139,16 @@ pub trait FlorestaRPC {
     ///
     /// Returns zeroed values for all runtimes that are not *-gnu or MacOS.
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
+
     /// Returns stats about our RPC server
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
+
     /// Returns for how long florestad has been running, in seconds
     fn uptime(&self) -> Result<u32>;
+
     /// Returns a list of all descriptors currently loaded in the wallet
     fn list_descriptors(&self) -> Result<Vec<String>>;
+
     /// Sends a ping to all peers, checking if they are still alive
     fn ping(&self) -> Result<()>;
 }
@@ -257,7 +266,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockcount", &[])
     }
 
-    fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut> {
+    fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<Value> {
         let result: serde_json::Value = self.call(
             "gettxout",
             &[
@@ -315,8 +324,11 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockfilter", &[Value::Number(Number::from(height))])
     }
 
-    fn get_block_header(&self, hash: BlockHash) -> Result<BlockHeader> {
-        self.call("getblockheader", &[Value::String(hash.to_string())])
+    fn get_block_header(&self, hash: BlockHash, verbose: bool) -> Result<Value> {
+        self.call(
+            "getblockheader",
+            &[Value::String(hash.to_string()), Value::Bool(verbose)],
+        )
     }
 
     fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes> {

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+pub use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
 use serde::Deserialize;
 use serde::Serialize;
@@ -79,7 +80,7 @@ pub struct RawTx {
     pub vin: Vec<TxIn>,
     /// A list of outputs being created by this tx
     ///
-    /// Se [TxOut] for more information
+    /// See [TxOut] for more information
     pub vout: Vec<TxOut>,
     /// The hash of the block that included this tx, if any
     pub blockhash: String,
@@ -189,6 +190,13 @@ pub enum GetBlockRes {
     Zero(String),
 
     One(Box<GetBlockVerboseOne>),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetBlockheaderRes {
+    Zero(String),
+    One(Box<GetBlockHeaderVerbose>),
 }
 
 /// A confidence enum to auxiliate rescan timestamp values.

--- a/doc/rpc/getblockheader.md
+++ b/doc/rpc/getblockheader.md
@@ -1,0 +1,71 @@
+# `getblockheader`
+
+Returns the block header for the given block hash.
+
+This method returns the block header for the given block hash, as defined in the Bitcoin protocol specification.
+
+A raw header contains, in hex format, the block's version, the previous block hash, the merkle root, the timestamp, the difficulty target, and the nonce.
+
+A verbose header will show additional information about the block/blockheader: the blockhash itself, the number of confirmations, height, version (and its hexadecimal format),
+mediantime, chainwork, number of transactions, the previousblockhash and nextblockhash.
+
+If `verbose` is false (default), the command will return a string that is serialized, hex-encoded data for blockheader `hash`.
+
+If `verbose` is true, returns an Object with information about blockheader `hash`.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getblockheader <hash> [true|false]
+```
+
+### Examples
+
+```bash
+floresta-cli getblockheader 00000000ba63ae2eeb3d2371708291b90507c3317ef957f6fcba3811cc4fe0cc
+floresta-cli getblockheader 00000000ba63ae2eeb3d2371708291b90507c3317ef957f6fcba3811cc4fe0cc true
+floresta-cli getblockheader 00000000ba63ae2eeb3d2371708291b90507c3317ef957f6fcba3811cc4fe0cc false
+```
+
+## Arguments
+
+`hex` - (string, required) The block hash
+
+`verbose` - (boolean, optional) true for a json object, false for the hex-encoded data
+
+## Returns
+
+### Ok Response
+
+* `verbose = false`: (`serde_json::Value<String>`) -  A serialized hexadecimal string in the format `<version><previousblockhash><merkleroot><time><bits><nonce>`;
+* `verbose = true`: (`serde_json::Value<floresta_rpc::rpc_types::GetBlockResVerbose>`) with the format:
+
+```json5
+{
+  "hash": "hex",                  // (string) the block hash (same as provided)
+  "confirmations" : n,            // (numeric) The number of confirmations, or -1 if the block is not on the main chain
+  "height" : n,                   // (numeric) The block height or index
+  "version" : n,                  // (numeric) The block version
+  "versionHex" : "hex",           // (string) The block version formatted in hexadecimal
+  "merkleroot" : "hex",           /// (string) The merkle root
+  "time" : xxx,                   // (numeric) The block time expressed in UNIX epoch time
+  "mediantime" : xxx,             // (numeric) The median block time expressed in UNIX epoch time
+  "nonce" : n,                    // (numeric) The nonce
+  "bits" : "hex",                 // (string) The bits
+  "difficulty" : n,               // (numeric) The difficulty
+  "chainwork" : "hex",            // (string) Expected number of hashes required to produce the current chain
+  "nTx" : n,                      // (numeric) The number of transactions in the block
+  "previousblockhash" : "hex",    // (string) The hash of the previous block
+  "nextblockhash" : "hex"         // (string) The hash of the next block
+}
+```
+
+### Error 
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+Will print the hexadecimal format unless the parameter `verbose` is specified to `true`, else will print a json string.

--- a/tests/floresta-cli/getblockheader.py
+++ b/tests/floresta-cli/getblockheader.py
@@ -1,68 +1,136 @@
 """
-floresta_cli_getblockheader.py
+getblockheader.py
 
 This functional test cli utility to interact with a Floresta node with `getblockheader`
+compliant with Bitcoin-Core.
+
+It starts three nodes, one miner (utreexod) and two sync nodes (florestad and bitcoind).
+The miner is also a bridge node.
+
+The miner will mine 10 blocks, and the sync nodes will update their states. Once updated,
+the sync nodes  will call for `getblockheader` rpc command.
 """
 
+import re
+import time
 from test_framework import FlorestaTestFramework
 from test_framework.node import NodeType
 
 
-class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
-    """
-    Test `getblockheader` with a fresh node and expect a result like this:
+BLOCKS = 10
 
-    ````bash
-    $> ./target/release floresta_cli --network=regtest getblockheader \
-        0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
-    {
-       "version": 1,
-       "prev_blockhash": "0000000000000000000000000000000000000000000000000000000000000000",
-       "merkle_root": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
-       "time": 1296688602,
-       "bits": 545259519,
-       "nonce": 2
-    }
-    ```
-    """
 
-    nodes = [-1]
-    version = 1
-    blockhash = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
-    prev_blockhash = "0000000000000000000000000000000000000000000000000000000000000000"
-    merkle_root = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
-    time = 1296688602
-    bits = 545259519
-    nonce = 2
+class GetBlockheaderTest(FlorestaTestFramework):
+    """
+    Test florestad's `getblockheader` by running three nodes in
+    a "semi-triangle" network structure, where florestad and bitcoind
+    nodes are connected to utreexod, but not connected between them.
+    Then assert that the same get_blockheader between florestad and core
+    are equal.
+    """
 
     def set_test_params(self):
         """
-        Setup a single node
+        Setup a florestad/bitcoind peers and a utreexod mining node
         """
+        self.v2transport = False
         self.florestad = self.add_node_default_args(variant=NodeType.FLORESTAD)
+        self.utreexod = self.add_node_extra_args(
+            variant=NodeType.UTREEXOD,
+            extra_args=[
+                "--miningaddr=bcrt1q4gfcga7jfjmm02zpvrh4ttc5k7lmnq2re52z2y",
+                "--prune=0",
+            ],
+        )
+
+        self.bitcoind = self.add_node_default_args(variant=NodeType.BITCOIND)
 
     def run_test(self):
         """
-        Run JSONRPC and get the header of the genesis block
+        Run a florestad/bitcoind/utreexod nodes. Then mine some blocks
+        with utreexod. After that, connect the nodes and wait for them to sync.
+        Finally, test the `getblockheader` rpc command checking if it's
+        different from genesis one and equals to utreexod one.
         """
-        # Start node
         self.run_node(self.florestad)
+        self.run_node(self.utreexod)
+        self.run_node(self.bitcoind)
 
-        # Test assertions
-        response = self.florestad.rpc.get_blockheader(
-            GetBlockheaderHeightZeroTest.blockhash
+        self.log("=== Mining  with utreexod")
+        self.utreexod.rpc.generate(BLOCKS)
+        time.sleep(5)
+
+        self.log("=== Connect floresta to utreexod")
+        self.connect_nodes(self.florestad, self.utreexod)
+        peer_info = self.florestad.rpc.get_peerinfo()
+        self.assertMatch(
+            peer_info[0]["user_agent"],
+            re.compile(r"/btcwire:\d+\.\d+\.\d+/utreexod:\d+\.\d+\.\d+/"),
         )
-        self.assertEqual(response["version"], GetBlockheaderHeightZeroTest.version)
-        self.assertEqual(
-            response["prev_blockhash"], GetBlockheaderHeightZeroTest.prev_blockhash
+
+        self.log("=== Connect bitcoind to utreexod")
+        self.connect_nodes(self.bitcoind, self.utreexod)
+        peer_info = self.bitcoind.rpc.get_peerinfo()
+        self.assertMatch(
+            peer_info[0]["subver"],
+            re.compile(r"/btcwire:\d+\.\d+\.\d+/utreexod:\d+\.\d+\.\d+/"),
         )
-        self.assertEqual(
-            response["merkle_root"], GetBlockheaderHeightZeroTest.merkle_root
-        )
-        self.assertEqual(response["time"], GetBlockheaderHeightZeroTest.time)
-        self.assertEqual(response["bits"], GetBlockheaderHeightZeroTest.bits)
-        self.assertEqual(response["nonce"], GetBlockheaderHeightZeroTest.nonce)
+
+        for height in range(BLOCKS):
+            self.log(
+                f"=== Check floresta have the same blockheader as core for height {height}..."
+            )
+            floresta_hash = self.florestad.rpc.get_blockhash(height)
+            bitcoin_hash = self.bitcoind.rpc.get_blockhash(height)
+            self.assertEqual(floresta_hash, bitcoin_hash)
+
+            floresta_blk = self.florestad.rpc.get_blockheader(floresta_hash, False)
+            bitcoin_blk = self.bitcoind.rpc.get_blockheader(bitcoin_hash, False)
+            self.assertEqual(floresta_blk, bitcoin_blk)
+
+            floresta_verbose_blk = self.florestad.rpc.get_blockheader(
+                floresta_hash, True
+            )
+            bitcoin_verbose_blk = self.bitcoind.rpc.get_blockheader(bitcoin_hash, True)
+
+            # Not test in regtest network the "difficulty" field since
+            # rust-bitcoin apply correctly while core have a bug in this field
+            for key in (
+                "hash",
+                "confirmations",
+                "height",
+                "version",
+                "versionHex",
+                "merkleroot",
+                "time",
+                "mediantime",
+                "nonce",
+                "bits",
+                "target",
+                "chainwork",
+                "nTx",
+            ):
+                self.assertEqual(floresta_verbose_blk[key], bitcoin_verbose_blk[key])
+
+            # These assertions will run only in some
+            # general conditions like the height
+            if height != 0:
+                self.assertEqual(
+                    floresta_verbose_blk["previousblockhash"],
+                    bitcoin_verbose_blk["previousblockhash"],
+                )
+
+                if height > 1:
+                    self.assertAlmostEqual(
+                        floresta_verbose_blk["difficulty"],
+                        bitcoin_verbose_blk["difficulty"],
+                    )
+
+            self.assertEqual(
+                floresta_verbose_blk["nextblockhash"],
+                bitcoin_verbose_blk["nextblockhash"],
+            )
 
 
 if __name__ == "__main__":
-    GetBlockheaderHeightZeroTest().main()
+    GetBlockheaderTest().main()

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -13,25 +13,13 @@ The difference is that `florestad` will run under a `cargo run` subprocess, whic
 import os
 import re
 import sys
-import copy
-import random
-import socket
-import shutil
-import signal
-import contextlib
-import subprocess
 import time
+import math
 from datetime import datetime, timezone
-from enum import Enum
-from typing import Any, Dict, List, Pattern, Tuple, Optional
-
-from test_framework.crypto.pkcs8 import (
-    create_pkcs8_private_key,
-    create_pkcs8_self_signed_certificate,
-)
+from typing import Any, List, Pattern
 from test_framework.daemon import ConfigP2P
 from test_framework.rpc import ConfigRPC
-from test_framework.electrum import ConfigElectrum, ConfigTls
+from test_framework.electrum import ConfigElectrum
 from test_framework.node import Node, NodeType
 from test_framework.util import Utility
 

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -612,3 +612,13 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
             raise AssertionError(
                 f"Actual: any({values}) !~ {pattern}\n Expected: any({values}) ~ {pattern}"
             )
+
+    def assertAlmostEqual(self, actual: int | float, expected: int | float):
+        """
+        Assert if two numeric values are nearly equal
+        """
+        if not math.isclose(actual, expected):
+            self.stop()
+            raise AssertionError(
+                f"Actual: {actual} ~ {expected}\n Expected: {actual} ~ {expected}"
+            )

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -256,14 +256,17 @@ class BaseRPC(ABC):
         """
         return self.perform_request("getblockcount")
 
-    def get_blockheader(self, blockhash: str) -> dict:
+    def get_blockheader(self, blockhash: str, verbose: bool = True) -> dict:
         """
-        Get the header of a block
+        Get the header of a block.
+
+        When `verbose` is True (the default), returns a dict with block header
+        fields. When False, returns the hex-encoded serialized block header.
         """
         if not bool(re.fullmatch(r"^[a-f0-9]{64}$", blockhash)):
             raise ValueError(f"Invalid blockhash '{blockhash}'.")
 
-        return self.perform_request("getblockheader", params=[blockhash])
+        return self.perform_request("getblockheader", params=[blockhash, verbose])
 
     def get_block(self, blockhash: str, verbosity: int = 1):
         """


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [x] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?


- [ ] floresta-chain
- [x] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [x] floresta-node
- [x] floresta-rpc
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes

Fix #655

### How to verify the changes you have done?

Add a `verbose` paramenter to `getblockheader` command so it will comply with core wheather to return a "raw" blockheader (as a hexadecimal string) or a "verbose" blockheader (as a json object).

Due to this, it was also needed to fix `getblock` rpc method so it can, now, use verbosity levels `0` up to `2`.