### PR TITLE
Move logging subscriber to `bin/florestad`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,9 +575,7 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1167,10 +1165,7 @@ version = "0.8.0"
 dependencies = [
  "axum",
  "bitcoin 0.32.7",
- "chrono",
- "console-subscriber",
  "corepc-types",
- "dirs",
  "dns-lookup 2.0.4",
  "floresta-chain",
  "floresta-common",
@@ -1192,8 +1187,6 @@ dependencies = [
  "toml 0.8.22",
  "tower-http",
  "tracing",
- "tracing-appender",
- "tracing-subscriber",
  "zmq",
 ]
 
@@ -1258,10 +1251,13 @@ dependencies = [
  "clap",
  "console-subscriber",
  "daemonize",
+ "dirs",
  "floresta-node",
  "tokio",
  "toml 0.8.22",
  "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/florestad/Cargo.toml
+++ b/bin/florestad/Cargo.toml
@@ -25,6 +25,9 @@ console-subscriber = { version = "0.4.1", optional = true }
 floresta-node = { path = "../../crates/floresta-node", default-features = false }
 bitcoin = "0.32"
 tracing = "0.1.41"
+tracing-appender = "0.2.3"
+tracing-subscriber = { version = "0.3.20", features = ["chrono", "ansi", "env-filter"] }
+dirs = "4.0.0"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -13,9 +13,7 @@ serde_json = "1.0"
 kv = "0.24.0"
 miniscript = "12"
 toml = "0.8.20"
-dirs = "4.0.0"
 bitcoin = { version = "0.32", features = ["serde", "std", "bitcoinconsensus"] }
-chrono = "0.4.19"
 floresta-compact-filters = { path = "../floresta-compact-filters", optional = true }
 floresta-chain = { path = "../floresta-chain" }
 floresta-common = { path = "../floresta-common" }
@@ -28,10 +26,7 @@ zmq = { version = "0.10.0", optional = true }
 dns-lookup = "=2.0.4"
 tower-http = { version = "0.6.2", optional = true, features = ["cors"] }
 rcgen = "0.13.2"
-tracing-subscriber = { version = "0.3.20", features = ["chrono", "ansi", "env-filter"] }
-console-subscriber = { version = "0.4", optional = true }
 tracing = "0.1.41"
-tracing-appender = "0.2.3"
 corepc-types = "0.10.1"
 
 [target.'cfg(target_env = "gnu")'.dependencies]
@@ -48,4 +43,3 @@ zmq-server = ["dep:zmq"]
 json-rpc = ["dep:axum", "dep:tower-http", "compact-filters"]
 default = ["json-rpc", "flat-chainstore"]
 metrics = ["dep:metrics", "floresta-wire/metrics", "floresta-chain/metrics"]
-tokio-console = ["dep:console-subscriber"]

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -74,8 +74,8 @@ pub enum FlorestadError {
     /// Writing a file to the filesystem.
     CouldNotWriteFile(String, std::io::Error),
 
-    /// Creating the data directory.
-    CouldNotCreateDataDir(String, std::io::Error),
+    /// Data directory doesn't exist or is not writable.
+    InvalidDataDir(String),
 
     /// Obtaining a lock on the data directory.
     CouldNotOpenKvDatabase(KvDatabaseError),
@@ -106,7 +106,7 @@ pub enum FlorestadError {
     CouldNotCreateTLSDataDir(String, std::io::Error),
 
     /// Failed to provide a valid xpub.
-    InvalidProvidedXpub(String, crate::slip132::Error),
+    InvalidProvidedXpub(String, slip132::Error),
 
     /// Failed to obtain the wallet cache.
     CouldNotObtainWalletCache(WatchOnlyError<KvDatabaseError>),
@@ -182,8 +182,8 @@ impl std::fmt::Display for FlorestadError {
             FlorestadError::CouldNotWriteFile(path, err) => {
                 write!(f, "Error while creating file {path}: {err}")
             }
-            FlorestadError::CouldNotCreateDataDir(path, err) => {
-                write!(f, "Error while creating data directory {path}: {err}")
+            FlorestadError::InvalidDataDir(path) => {
+                write!(f, "Data directory doesn't exist or is not writable: {path}")
             }
             FlorestadError::CouldNotOpenKvDatabase(err) => {
                 write!(f, "Cannot open a key-value database: {err}")


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Refactor

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [x] floresta-node
- [ ] floresta-rpc
- [ ] floresta-watch-only
- [ ] floresta-wire
- [x] bin/florestad
- [ ] bin/floresta-cli
- [ ] Other: <!-- Please describe it -->

### Description and Notes

Closes #659. The library shouldn't initialize a global subscriber, which is a binary responsibility.

- I have moved the `data_dir_path` function to `main.rs`, as we need it to set up the logger (file log), and its tests.
- I am also creating the directory in the binary, and the library code only receives the path and validates the directory.

So `Florestad::Config` now requires a value for the `data_dir`. `Florestad::new` now requires a `data_dir` and `Network`, and I removed `Florestad::default()`.