### PR TITLE
wire: demote some logs to debug rather than info

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/macros.rs
+++ b/crates/floresta-wire/src/p2p_wire/macros.rs
@@ -1,0 +1,53 @@
+/// Run a task and warn any errors that might occur.
+///
+/// `try_and_log!` variant for tasks that can fail safely.
+macro_rules! try_and_warn {
+    ($exerpt: literal, $what:expr) => {
+        if let Err(warning) = $what {
+            tracing::warn!("{}: {warning}", $exerpt);
+        }
+    };
+}
+
+/// Run a task and log any errors that might occur with `Debug` level
+macro_rules! try_and_debug {
+    ($excerpt: literal, $what:expr) => {
+        if let Err(error) = $what {
+            tracing::debug!("{}: {error:?}" , $excerpt);
+        }
+    };
+}
+
+/// Run a task and warn any errors that might occur.
+///
+/// `try_and_log!` variant for tasks that can fail safely.
+macro_rules! try_and_error {
+    ($excerpt: literal, $what:expr) => {
+        if let Err(warning) = $what {
+            tracing::error!("{}: {}", $excerpt, warning);
+        }
+    };
+}
+
+
+macro_rules! periodic_job {
+    ($what:expr, $timer:expr, $interval:ident, $context:ty) => {
+        if $timer.elapsed() > Duration::from_secs(<$context>::$interval) {
+            if let Err(error) = $what {
+                tracing::debug!("Periodic job error ({}): {:?}", stringify!($what), error);
+            }
+            $timer = Instant::now();
+        }
+    };
+    ($what:expr, $timer:expr, $interval:ident, $context:ty, $no_log:literal) => {
+        if $timer.elapsed() > Duration::from_secs(<$context>::$interval) {
+            $what;
+            $timer = Instant::now();
+        }
+    };
+}
+
+pub(crate) use periodic_job;
+pub(crate) use try_and_debug;
+pub(crate) use try_and_warn;
+pub(crate) use try_and_error;

--- a/crates/floresta-wire/src/p2p_wire/mempool.rs
+++ b/crates/floresta-wire/src/p2p_wire/mempool.rs
@@ -4,6 +4,7 @@
 //! Once our transaction is included in a block, we remove it from the mempool.
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -111,6 +112,29 @@ pub enum AcceptToMempoolError {
     /// The transaction has duplicate inputs.
     DuplicateInput,
     BlockNotFound,
+}
+
+impl Display for AcceptToMempoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptToMempoolError::InvalidProof => write!(f, "Invalid proof"),
+            AcceptToMempoolError::InvalidPrevout => write!(f, "Invalid prevout"),
+            AcceptToMempoolError::MemoryUsageTooHigh => write!(f, "Memory usage too high"),
+            AcceptToMempoolError::PrevoutNotFound => write!(f, "Prevout not found"),
+            AcceptToMempoolError::ConflictingTransaction => {
+                write!(f, "Conflicting transaction in mempool")
+            }
+            AcceptToMempoolError::Rustreexo(err) => {
+                write!(f, "Rustreexo error: {}", err)
+            }
+            AcceptToMempoolError::DuplicateInput => {
+                write!(f, "Transaction has duplicate inputs")
+            }
+            AcceptToMempoolError::BlockNotFound => {
+                write!(f, "Block not found for prevout")
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -109,3 +109,4 @@ pub mod sync_node;
 #[doc(hidden)]
 pub mod tests;
 pub mod transport;
+mod macros;


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: Log management

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [X] floresta-node
- [ ] floresta-rpc
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] bin/florestad
- [ ] bin/floresta-cli
- [ ] Other: <!-- Please describe it -->

### Description and Notes

We have some logs that don't really give our users that much useful info, but overwealms them with too much information. This commit demotes them to debug, so we can still see them if we want (just run with -d), but users won't.