### PR TITLE
chore(wire): re-export `rustreexo`

### DIFF
--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -12,11 +12,12 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(not(target_arch = "wasm32"))]
-mod p2p_wire;
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::Block;
 use bitcoin::Transaction;
+pub use rustreexo;
+#[cfg(not(target_arch = "wasm32"))]
+mod p2p_wire;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::address_man;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Closes #662.

This PR re-rexports `rustreexo` on `floresta-wire`.