### PR TITLE
[NixShell] Include grafana for debugging and typos for development

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -195,6 +195,11 @@
               git
               rust-bin.stable.latest.default
               (rust-bin.selectLatestNightlyWith (toolchain: toolchain.default))
+              typos
+            ];
+
+            debugTools = with pkgs; [
+              grafana
             ];
             testBinaries = [
               self.packages.${system}.florestad
@@ -205,7 +210,7 @@
           in
           {
             default = mkShell {
-              buildInputs = basicDevTools;
+              buildInputs = basicDevTools ++ debugTools;
 
               shellHook = "";
             };


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: Adding tools to nix-shell

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-node
- [ ] floresta-rpc
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] bin/florestad
- [ ] bin/floresta-cli
- [X] Other: flake.nix

### Description and Notes
Partf of #661.

#639 introduce a grafana template so its nice to have grafana available right ?

Also, `typos`.

### Contributor Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
