### PR TITLE
Expose fields in `GetMemInfoStats`, `MemInfoLocked`, `ActiveCommand`, and `GetRpcInfoRes` structs

### DIFF
--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -380,14 +380,14 @@ pub enum GetMemInfoRes {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ActiveCommand {
-    method: String,
-    duration: u64,
+    pub method: String,
+    pub duration: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetRpcInfoRes {
-    active_commands: Vec<ActiveCommand>,
-    logpath: String,
+    pub active_commands: Vec<ActiveCommand>,
+    pub logpath: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-node
- [x] floresta-rpc
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] bin/florestad
- [ ] bin/floresta-cli
- [ ] Other: <!-- Please describe it -->

### Description and Notes

Exposes the internal fields of the following structs:
- `GetMemInfoStats`
- `MemInfoLocked`
- `ActiveCommand`
- `GetRpcInfoRes`

These fields were **previously private**, which made it **impossible to access RPC** responses when calling the `getmemoryinfo` and `getrpcinfo` endpoints through the `floresta-rpc` library. As a result, those RPC methods could not be effectively used. Making these fields public allows proper access to their responses for external use.
### How to verify the changes you have done?
Use the `floresta-rpc` library to connect to a running **Floresta node** and call:
- `get_memory_info()`
- `get_rpc_info()`
Check that both methods return the correct data and that all **response fields are accessible**.
