### PR TITLE
[Chore] use uptime to check if server is alive instead of getblockchaininfo

### DIFF
--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -109,14 +109,14 @@ mod tests {
             // Wait some time for florestad to start
             sleep(Duration::from_secs(3));
 
-            match client.get_blockchain_info() {
+            match client.uptime() {
                 Ok(_) => break,
                 Err(_) if retries > 1 => retries -= 1,
                 Err(e) => {
-                    println!("Asked florestad for blockchain info, got: {e:?}");
+                    println!("Got error {e:?}, sending kill signal...");
                     fld.kill().unwrap();
 
-                    panic!("Florestad didn't start after 30 seconds");
+                    panic!("Could not communicate with florestad after 30 seconds");
                 }
             }
         }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-node
- [X] floresta-rpc
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] bin/florestad
- [ ] bin/floresta-cli
- [ ] Other: <!-- Please describe it -->

### Description and Notes

if `getblockchaininfo` is somehow broken itll fail all the other rpc tests under `crates/floresta-rpc/src/lib.rs` when it should fail only its own test.

This pr changes the command that we use to check wheter florestad is alive, instead of using `getblockchaininfo` we now use `uptime`  expecting it to be enough to tell wheter the server is alive while being simple enough to not fail.

* NOTE: maybe a better approach to comunicate between binaries and doing these kind of checks, getting ports and etc.. would be a realtime lockfile under datadir that writes some info there ?

### How to verify the changes you have done?

cargo build --bin florestad 

cargo test --package floresta-rpc

all the tests should run fine, exactly like before.

### Contributor Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
