### PR TITLE
ci: install boost in preparation for bitcoinkernel

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -71,6 +71,11 @@ jobs:
             ./.apt-state
           key: ${{ runner.os }}-apt-${{ env.APT_HASH }}
 
+      - name: Install Boost
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
       # Install system dependencies only if cache miss
       - name: Install libfuzzer dependencies
         if: steps.cache-apt.outputs.cache-hit != 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install Boost
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
       - name: Spell check
         uses: crate-ci/typos@v1
 
@@ -47,6 +52,37 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: taiki-e/install-action@cargo-hack
+
+      - name: Install Boost (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
+      - name: Install Boost (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install boost
+
+      - name: Install Boost (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          triplet=x64-windows
+          vcpkgRoot="${VCPKG_INSTALLATION_ROOT:-C:/vcpkg}"
+
+          "$vcpkgRoot/vcpkg.exe" install \
+            boost-system \
+            boost-filesystem \
+            boost-thread \
+            boost-multi-index \
+            --triplet "$triplet" \
+            --clean-after-build \
+            --disable-metrics
+
+          boostRoot="$vcpkgRoot/installed/$triplet"
+          echo "BOOST_ROOT=$boostRoot" >> "$GITHUB_ENV"
 
       # Bi-weekly numbers to refresh caches every two weeks, ensuring recent project changes are cached
       - name: Set bi-weekly cache key

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ ARG BUILD_FEATURES=""
 
 RUN apt-get update && apt-get install -y \
     build-essential \
-    cmake \
+    cmake-latest \
+    clang \
+    libclang-dev \
     curl \
     git \
     libssl-dev \
-    pkg-config
+    pkg-config \
+    libboost-all-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: CI

### Description and Notes

Installing boost at CI, which is needed for bitcoinkernel compilation. In Ubuntu and MacOS the installation takes less than a minute (using the "native" installation way), in Windows 2 minutes.

Updated the Dockerfile with stuff needed for libbitcoinkernel + boost.

This should enable #456.

### How to verify the changes you have done?

CI ran successfully in my fork, with a change that included `bitcoinkernel` as dependency: https://github.com/JoseSK999/Floresta/commit/24a4e4fa86356cb9d4fe7cfd278da6465533263d