### PR TITLE
ci: check conventional commit messages

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,13 @@
+name: Conventional Commits
+
+on:
+  pull_request: # We only need to check commit messages in PRs
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          allowed-commit-types: "feat,fix,docs,style,refactor,test,perf,ci,chore,fuzz,bench"


### PR DESCRIPTION
### Description and Notes

We only check commits in PRs as it's pointless to check commit messages you have already pushed, or I think so (although it's inexpensive).

Closes #707.

### How to verify the changes you have done?

See this CI catch: https://github.com/JoseSK999/Floresta/actions/runs/19653340190/job/56284771594 (@Davidson-Souza your commit used `doc:` rather than `docs:`)

Also see the new CI job below in this PR