### PR TITLE
chore(ci): underscore `default` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,4 @@
-# List the available commands
-default:
+_default:
   @just --list
 
 # Checks whether a command is available.


### PR DESCRIPTION
This PR underscores the `default` recipe on the justfile. Running `just` will run the first recipe, which is `just --list`. There's no need to make it explicit.