### PR TITLE
chore(slip132): remove unused KeyApplication

### DIFF
--- a/crates/floresta-node/src/slip132.rs
+++ b/crates/floresta-node/src/slip132.rs
@@ -8,14 +8,11 @@
 //! formats
 
 use std::fmt::Debug;
-use std::str::FromStr;
 
 use bitcoin::base58;
 use bitcoin::bip32;
 use bitcoin::bip32::Xpriv;
 use bitcoin::bip32::Xpub;
-use serde::Deserialize;
-use serde::Serialize;
 
 /// Magical version bytes for xpub: bitcoin mainnet public key for P2PKH or P2SH
 pub const VERSION_MAGIC_XPUB: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
@@ -131,57 +128,6 @@ impl From<bip32::Error> for Error {
 impl From<base58::Error> for Error {
     fn from(err: base58::Error) -> Self {
         Error::Base58(err)
-    }
-}
-
-/// SLIP 132-defined key applications defining types of scriptPubKey descriptors
-/// in which they can be used
-#[allow(dead_code)]
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum KeyApplication {
-    /// xprv/xpub: keys that can be used for P2PKH and multisig P2SH
-    /// scriptPubKey descriptors.
-    #[serde(rename = "bip44")]
-    Hashed,
-
-    /// zprv/zpub: keys that can be used for P2WPKH scriptPubKey descriptors
-    #[serde(rename = "bip84")]
-    SegWit,
-
-    /// Zprv/Zpub: keys that can be used for multisig P2WSH scriptPubKey
-    /// descriptors
-    #[serde(rename = "bip48-native")]
-    SegWitMultisig,
-
-    /// yprv/ypub: keys that can be used for P2WPKH-in-P2SH scriptPubKey
-    /// descriptors
-    #[serde(rename = "bip49")]
-    Nested,
-
-    /// Yprv/Ypub: keys that can be used for multisig P2WSH-in-P2SH
-    /// scriptPubKey descriptors
-    #[serde(rename = "bip48-nested")]
-    NestedMultisig,
-}
-
-/// Unknown string representation of [`KeyApplication`] enum
-#[allow(dead_code)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct UnknownKeyApplicationError;
-
-impl FromStr for KeyApplication {
-    type Err = UnknownKeyApplicationError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s.to_lowercase().as_str() {
-            "bip44" => KeyApplication::Hashed,
-            "bip84" => KeyApplication::SegWit,
-            "bip48-native" => KeyApplication::SegWitMultisig,
-            "bip49" => KeyApplication::Nested,
-            "bip48-nested" => KeyApplication::NestedMultisig,
-            _ => return Err(UnknownKeyApplicationError),
-        })
     }
 }
 


### PR DESCRIPTION
### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

KeyApplication is unused since commit da138ebe22db7ba352bf91633221d7f28f5925ad "remove unused from slip132 (#129)", 2024‑03‑06
In that commit florestad/src/slip132.rs dropped the VersionResolver trait and the DefaultResolver impl (where KeyApplication was used), leaving the enum defined but no longer referenced anywhere else.

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

```
nix build
```

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
