### PR TITLE
chore(chain): replace xxhash-rust with twox-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -991,7 +990,7 @@ dependencies = [
  "spin",
  "tempfile",
  "tracing",
- "xxhash-rust",
+ "twox-hash",
  "zstd",
 ]
 
@@ -1122,14 +1121,12 @@ name = "floresta-wire"
 version = "0.4.0"
 dependencies = [
  "ahash",
- "aws-lc-rs",
  "bip324",
  "bitcoin",
  "dns-lookup",
  "floresta-chain",
  "floresta-common",
  "floresta-compact-filters",
- "home",
  "metrics",
  "rand",
  "rustls",
@@ -2382,7 +2379,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2451,7 +2448,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3197,6 +3194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,12 +3210,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3774,12 +3771,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true, optional = true }
 sha2 = { workspace = true, features = ["std"] }
 spin = { workspace = true }
 tracing = { workspace = true }
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
+twox-hash = { version = "2.1", default-features = false, features = ["xxhash3_64", "std"], optional = true }
 
 # Local dependencies
 floresta-common = { workspace = true, features = ["std"] }
@@ -47,7 +47,7 @@ default = []
 bitcoinconsensus = ["bitcoin/bitcoinconsensus", "dep:bitcoinconsensus"]
 metrics = ["dep:metrics"]
 test-utils = ["dep:serde"]
-flat-chainstore = ["dep:memmap2", "dep:lru"]
+flat-chainstore = ["dep:memmap2", "dep:lru", "dep:twox-hash"]
 
 [[bench]]
 name = "chain_state_bench"

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -16,11 +16,9 @@ categories = ["cryptography::cryptocurrencies", "network-programming"]
 
 [dependencies]
 ahash = "0.8"
-aws-lc-rs = "=1.13.1" # need due to Nix incompatibility with newer versions of aws-lc-rs
 bip324 = { version = "=0.7.0", features = [ "tokio" ] }
 bitcoin = { workspace = true, features = ["serde", "std", "bitcoinconsensus"] }
 dns-lookup = { workspace = true }
-home = "=0.5.11" # need due to Nix incompatibility with newer versions of home
 rand = { workspace = true }
 rustls = "=0.23.27"
 rustreexo = { workspace = true }


### PR DESCRIPTION
### Description and Notes

`twox-hash` seems a more long-term maintained crate, with similar performance, and we can just compile the `xxhash3` version for 64 bits.

I have made this dependency only be compiled for `flat-chainstore` (previously we were always compiling it, even if unused).

`test_migrate_v0_to_v1` had a pre-computed checksum and so we are testing this is backwards compatible.
