### PR TITLE
feat(node): add `getmemoryinfo` RPC support on MacOS

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -300,7 +300,9 @@ pub enum Methods {
         height_hint: Option<u32>,
     },
 
-    /// Returns stats about our memory usage
+    /// Returns statistics about Floresta's memory usage.
+    ///
+    /// Returns zeroed values for all runtimes that are not *-gnu or MacOS.
     #[command(name = "getmemoryinfo")]
     GetMemoryInfo { mode: Option<String> },
 

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -36,6 +36,9 @@ pretty_assertions = "1.4"
 [target.'cfg(target_env = "gnu")'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [features]
 compact-filters = ["dep:floresta-compact-filters"]
 zmq-server = ["dep:zmq"]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -125,7 +125,9 @@ pub trait FlorestaRPC {
         script: String,
         height_hint: u32,
     ) -> Result<Value>;
-    /// Returns stats about our memory usage
+    /// Returns statistics about Floresta's memory usage.
+    ///
+    /// Returns zeroed values for all runtimes that are not *-gnu or MacOS.
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
     /// Returns stats about our RPC server
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;


### PR DESCRIPTION
This PR adds support for the `getmemoryinfo` RPC on MacOS.

```
./target/release/floresta-cli -n signet getmemoryinfo 
{
  "locked": {
    "used": 31176208,
    "free": 47090160,
    "total": 78266368,
    "locked": 78266368,
    "chunks_used": 11855,
    "chunks_free": 0
 }
 ```
 
 AFAIK there's no support for `chunks_free` on MacOS.