### PR TITLE
chore!: match JSON-RPC feature naming

### DIFF
--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -27,8 +27,8 @@ rand = { workspace = true }
 rcgen = { workspace = true }
 
 [features]
-default = ["with-jsonrpc"]
-with-jsonrpc = ["dep:jsonrpc"]
+default = ["json-rpc"]
+json-rpc = ["dep:jsonrpc"]
 clap = ["dep:clap"]
 
 [lints]

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(feature = "with-jsonrpc")]
+#[cfg(feature = "json-rpc")]
 pub mod jsonrpc_client;
 
 pub mod rpc;
@@ -19,7 +19,7 @@ pub mod rpc_types;
 // Those tests doesn't work on windowns
 // TODO (Davidson): work on windows?
 
-#[cfg(all(test, feature = "with-jsonrpc", not(target_os = "windows")))]
+#[cfg(all(test, feature = "json-rpc", not(target_os = "windows")))]
 mod tests {
     use std::fs;
     use std::net::TcpListener;

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -302,7 +302,7 @@ pub enum Error {
     /// An error while deserializing our response
     Serde(serde_json::Error),
 
-    #[cfg(feature = "with-jsonrpc")]
+    #[cfg(feature = "json-rpc")]
     /// An internal reqwest error
     JsonRpc(jsonrpc::Error),
 
@@ -328,7 +328,7 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-#[cfg(feature = "with-jsonrpc")]
+#[cfg(feature = "json-rpc")]
 impl From<jsonrpc::Error> for Error {
     fn from(value: jsonrpc::Error) -> Self {
         Error::JsonRpc(value)
@@ -338,7 +338,7 @@ impl From<jsonrpc::Error> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            #[cfg(feature = "with-jsonrpc")]
+            #[cfg(feature = "json-rpc")]
             Error::JsonRpc(e) => write!(f, "JsonRpc returned an error {e}"),
             Error::Api(e) => write!(f, "general jsonrpc error: {e}"),
             Error::Serde(e) => write!(f, "error while deserializing the response: {e}"),


### PR DESCRIPTION
### Description and Notes

Defining features related to the JSON-RPC server youll need to include "json-rpc" and "with-jsonrpc", since theyre related and across the project they enable code for the same feature/module, I changed "with-jsonrpc" to be "json-rpc" too.

This simplify packaging and may exponentially decrease the time that we run our `feature-matrix.sh`.

### How to verify the changes you have done?

1. we should not have any mention to "with-jsonrpc".
2. Other related features should be changed into having the same name.

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
