### PR TITLE
Automate Node Stop at End of Tests

### DIFF
--- a/tests/floresta-cli/addnode-v1.py
+++ b/tests/floresta-cli/addnode-v1.py
@@ -341,7 +341,6 @@ class AddnodeTestV1(FlorestaTestFramework):
         self.test_should_floresta_remove_bitcoind()
         self.test_should_bitcoind_not_see_floresta()
         self.test_should_floresta_onetry_connection_with_bitcoind()
-        self.stop()
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/addnode-v2.py
+++ b/tests/floresta-cli/addnode-v2.py
@@ -341,7 +341,6 @@ class AddnodeTestV2(FlorestaTestFramework):
         self.test_should_floresta_remove_bitcoind()
         self.test_should_bitcoind_not_see_floresta()
         self.test_should_floresta_onetry_connection_with_bitcoind()
-        self.stop()
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/getbestblockhash.py
+++ b/tests/floresta-cli/getbestblockhash.py
@@ -86,9 +86,6 @@ class GetBestblockhashTest(FlorestaTestFramework):
         self.assertEqual(floresta_best_block, floresta_chain["best_block"])
         self.assertEqual(floresta_best_block, utreexo_chain["bestblockhash"])
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetBestblockhashTest().main()

--- a/tests/floresta-cli/getblock.py
+++ b/tests/floresta-cli/getblock.py
@@ -75,9 +75,6 @@ class GetBlockTest(FlorestaTestFramework):
         self.assertEqual(response["versionHex"], GetBlockTest.version_hex)
         self.assertEqual(response["weight"], GetBlockTest.weight)
 
-        # Shutdown node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetBlockTest().main()

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -55,9 +55,6 @@ class GetBlockchaininfoTest(FlorestaTestFramework):
         self.assertEqual(response["root_hashes"], GetBlockchaininfoTest.root_hashes)
         self.assertEqual(response["validated"], GetBlockchaininfoTest.validated)
 
-        # Stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetBlockchaininfoTest().main()

--- a/tests/floresta-cli/getblockcount.py
+++ b/tests/floresta-cli/getblockcount.py
@@ -126,9 +126,6 @@ class GetBlockCountTest(FlorestaTestFramework):
         self.assertEqual(height_florestad, height_bitcoind)
         self.assertEqual(height_florestad, bitcoind_chain["blocks"])
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetBlockCountTest().main()

--- a/tests/floresta-cli/getblockhash.py
+++ b/tests/floresta-cli/getblockhash.py
@@ -98,9 +98,6 @@ class GetBlockhashTest(FlorestaTestFramework):
             for _hash in [hash_utreexod, hash_bitcoind]:
                 self.assertEqual(hash_floresta, _hash)
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetBlockhashTest().main()

--- a/tests/floresta-cli/getblockheader.py
+++ b/tests/floresta-cli/getblockheader.py
@@ -63,9 +63,6 @@ class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
         self.assertEqual(response["bits"], GetBlockheaderHeightZeroTest.bits)
         self.assertEqual(response["nonce"], GetBlockheaderHeightZeroTest.nonce)
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetBlockheaderHeightZeroTest().main()

--- a/tests/floresta-cli/getmemoryinfo.py
+++ b/tests/floresta-cli/getmemoryinfo.py
@@ -84,9 +84,6 @@ class GetMemoryInfoTest(FlorestaTestFramework):
         self.test_mode_stats_ibd(self.florestad)
         self.test_mode_mallocinfo_ibd(self.florestad)
 
-        # Stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetMemoryInfoTest().main()

--- a/tests/floresta-cli/getpeerinfo.py
+++ b/tests/floresta-cli/getpeerinfo.py
@@ -33,9 +33,6 @@ class GetPeerInfoTest(FlorestaTestFramework):
         self.assertIsSome(result)
         self.assertEqual(len(result), 0)
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetPeerInfoTest().main()

--- a/tests/floresta-cli/getroots.py
+++ b/tests/floresta-cli/getroots.py
@@ -30,9 +30,6 @@ class GetRootsIDBLenZeroTest(FlorestaTestFramework):
         vec_hashes = self.florestad.rpc.get_roots()
         self.assertTrue(len(vec_hashes) == 0)
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetRootsIDBLenZeroTest().main()

--- a/tests/floresta-cli/getrpcinfo.py
+++ b/tests/floresta-cli/getrpcinfo.py
@@ -86,9 +86,6 @@ class GetRpcInfoTest(FlorestaTestFramework):
         self.test_floresta_getrpcinfo()
         self.test_bitcoind_getrpcinfo()
 
-        # stop node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetRpcInfoTest().main()

--- a/tests/floresta-cli/gettxout.py
+++ b/tests/floresta-cli/gettxout.py
@@ -130,9 +130,6 @@ class GetTxoutTest(FlorestaTestFramework):
                         txout_bitcoind["scriptPubKey"][key],
                     )
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     GetTxoutTest().main()

--- a/tests/floresta-cli/ping.py
+++ b/tests/floresta-cli/ping.py
@@ -41,8 +41,6 @@ class PingTest(FlorestaTestFramework):
         peer_info = self.bitcoind.rpc.get_peerinfo()
         self.assertTrue(peer_info[0]["bytesrecv_per_msg"]["ping"])
 
-        self.stop()
-
 
 if __name__ == "__main__":
     PingTest().main()

--- a/tests/floresta-cli/uptime.py
+++ b/tests/floresta-cli/uptime.py
@@ -63,7 +63,6 @@ class UptimeTest(FlorestaTestFramework):
         """
         self.test_node_uptime(node=self.florestad, test_time=15, margin=15)
         self.test_node_uptime(node=self.bitcoind, test_time=15, margin=15)
-        self.stop()
 
 
 if __name__ == "__main__":

--- a/tests/florestad/connect.py
+++ b/tests/florestad/connect.py
@@ -40,10 +40,6 @@ class CliConnectTest(FlorestaTestFramework):
         res = self.utreexod.rpc.get_peerinfo()
         self.assertEqual(len(res), 1)
 
-        # Stop the nodes
-        self.log("=== Stopping nodes")
-        self.stop()
-
 
 if __name__ == "__main__":
     CliConnectTest().main()

--- a/tests/florestad/reorg-chain.py
+++ b/tests/florestad/reorg-chain.py
@@ -86,8 +86,6 @@ class ChainReorgTest(FlorestaTestFramework):
         )
         self.assertEqual(floresta_roots, utreexo_roots["roots"])
 
-        self.stop()
-
 
 if __name__ == "__main__":
     ChainReorgTest().main()

--- a/tests/florestad/tls-fail.py
+++ b/tests/florestad/tls-fail.py
@@ -44,9 +44,6 @@ class TestSslFailInitialization(FlorestaTestFramework):
         self.assertIsSome(exc.exception)
         self.assertEqual(exc.exception.errno, errno.ECONNREFUSED)
 
-        # Stop `florestad`
-        self.stop()
-
 
 if __name__ == "__main__":
     TestSslFailInitialization().main()

--- a/tests/florestad/tls.py
+++ b/tests/florestad/tls.py
@@ -47,9 +47,6 @@ class TestSslInitialization(FlorestaTestFramework):
         self.assertEqual(id, 0)
         self.assertEqual(jsonrpc, "2.0")
 
-        # stop the node
-        self.stop()
-
 
 if __name__ == "__main__":
     TestSslInitialization().main()


### PR DESCRIPTION


### Description and Notes

Improves the test automation process by ensuring that all nodes are automatically stopped at the end of each test. Previously, it was necessary to explicitly call `stop()` in every test script. With these changes, this manual step is no longer required.

Additional improvements were made to the node stop logic to ensure that nodes are finalized correctly both when a test completes successfully and when a test fails. This guarantees a more precise and reliable shutdown of nodes after each test execution.

### How to verify the changes you have done?

- Run the test suite as usual.
- Observe that nodes are properly stopped at the end of each test, without needing explicit `stop()` calls in individual test scripts.
- Try forcing a test failure and confirm that nodes are still stopped as expected.
- You can inspect the test scripts: they should no longer include manual `stop()` calls at the end.