### PR TITLE
chore(wire): re-export `TransportProtocol`

### DIFF
--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -36,7 +36,9 @@ pub use p2p_wire::node_interface;
 pub use p2p_wire::running_node;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::sync_node;
+pub use p2p_wire::transport::TransportProtocol;
 pub use p2p_wire::UtreexoNodeConfig;
+
 /// NodeHooks is a trait that defines the hooks that a node can use to interact with the network
 /// and the blockchain. Every time an event happens, the node will call the corresponding hook.
 pub trait NodeHooks {


### PR DESCRIPTION
This PR simply re-exports the `TransportProtocol` enum.