### PR TITLE
feat(florestad): enable `assume-valid=0`

### DIFF
--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -82,9 +82,6 @@ pub enum FlorestadError {
     /// Setting up the watch-only wallet.
     CouldNotSetupWallet(String),
 
-    /// Invalid assumed valid value.
-    InvalidAssumeValid(bitcoin::hex::HexToArrayError),
-
     #[cfg(feature = "compact-filters")]
     /// Loading the compact filters store.
     CouldNotLoadCompactFiltersStore(IterableFilterStoreError),
@@ -182,9 +179,6 @@ impl std::fmt::Display for FlorestadError {
             }
             FlorestadError::CouldNotSetupWallet(err) => {
                 write!(f, "Could not setup wallet: {err}")
-            }
-            FlorestadError::InvalidAssumeValid(error) => {
-                write!(f, "Invalid assumed valid value: {error}")
             }
 
             #[cfg(feature = "compact-filters")]

--- a/crates/floresta-node/src/lib.rs
+++ b/crates/floresta-node/src/lib.rs
@@ -13,5 +13,6 @@ mod wallet_input;
 mod zmq;
 
 pub use florestad::AssumeUtreexoValue;
+pub use florestad::AssumeValidArg;
 pub use florestad::Config;
 pub use florestad::Florestad;


### PR DESCRIPTION
### Description and Notes

Previously our `--assume-valid` flag only took an option, and `None` was treated as the hardcoded assume-valid value.

I have instead made `florestad` parse an `AssumeValidArg` directly, so that users can specify `--assume-valid 0`.

Now you can also pass `--assume-valid hardcoded`, which is the default so not needed. You can still pass a custom hash as before, but it's validated in the command-line parser.

### How to verify the changes you have done?

Run `florestad` with `--assume-valid 0`, should be slower than usual.