### PR TITLE
chore(wire): use `SocketAddr` and `ServiceFlags` on `PeerInfo`

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1168,12 +1168,12 @@ where
     pub(crate) fn get_peer_info(&self, peer: &u32) -> Option<PeerInfo> {
         let peer = self.peers.get(peer)?;
         Some(PeerInfo {
-            kind: peer.kind,
-            state: peer.state,
-            address: format!("{}:{}", peer.address, peer.port),
-            services: peer.services.to_string(),
+            address: SocketAddr::new(peer.address, peer.port),
+            services: peer.services,
             user_agent: peer.user_agent.clone(),
             initial_height: peer.height,
+            state: peer.state,
+            kind: peer.kind,
             transport_protocol: peer.transport_protocol,
         })
     }

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -2,8 +2,10 @@
 //! that define the API to interact with the floresta node
 
 use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::time::Instant;
 
+use bitcoin::p2p::ServiceFlags;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
@@ -87,8 +89,9 @@ pub enum UserRequest {
 /// services it provides, the user agent it's using, the height of the blockchain it's currently
 /// at, its state and the kind of connection it has with the node.
 pub struct PeerInfo {
-    pub address: String,
-    pub services: String,
+    pub address: SocketAddr,
+    #[serde(serialize_with = "serialize_service_flags")]
+    pub services: ServiceFlags,
     pub user_agent: String,
     pub initial_height: u32,
     pub state: PeerStatus,
@@ -255,6 +258,13 @@ impl NodeInterface {
 
         extract_variant!(Ping, val)
     }
+}
+
+fn serialize_service_flags<S>(flags: &ServiceFlags, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&flags.to_string())
 }
 
 macro_rules! extract_variant {


### PR DESCRIPTION
This PR replaces the `String`s for `SocketAddr` and `ServiceFlags` on `PeerInfo`. Since `ServiceFlags` serializes to `u64`, I implemented a custom serializer to serialize it to the `Display` of `ServiceFlags` so our CLI doesn't break.