### PR TITLE
chore(license): bump copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 The Floresta Project Developers
+Copyright (c) 2022-2026 The Floresta Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Description and Notes

After two years, finally update the copyright header for the present year. I'm also using the `start-present` version, rather than just present.

### How to verify the changes you have done?

Idk, find a calendar?