### PR TITLE
fix: cleanup test directories before running tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,9 +26,7 @@ if [[ -z "$FLORESTA_TEMP_DIR" ]]; then
 
 fi
 
-# Clean existing data/logs directories before running the tests
 rm -rf "$FLORESTA_TEMP_DIR/data"
-
 # Detect if --preserve-data-dir is among args
 # and forward args to uv
 PRESERVE_DATA=false
@@ -42,12 +40,11 @@ for arg in "$@"; do
     fi
 done
 
+# Clean existing logs directories BEFORE running tests (unless preserving)
+if [ "$PRESERVE_DATA" = false ]; then
+    echo "Cleaning up test directories before running tests..."
+    rm -rf "$FLORESTA_TEMP_DIR/logs"
+fi
+
 # Run the re-freshed tests
 uv run ./tests/test_runner.py "${UV_ARGS[@]}"
-
-# Clean up the data dir if we succeeded and --preserve-data-dir was not passed
-if [ $? -eq 0 ] && [ "$PRESERVE_DATA" = false ];
-then
-    echo "Tests passed, cleaning up the data dir at $FLORESTA_TEMP_DIR"
-    rm -rf $FLORESTA_TEMP_DIR/data $FLORESTA_TEMP_DIR/logs
-fi


### PR DESCRIPTION
Related to #760 (mitigation)

- Keep unconditional /data cleanup at start
- Make /logs cleanup conditional on --preserve-data-dir flag
- Prevents reusing old log state between test runs

### Description and Notes

Currently, the cleanup of `/logs` directory happens at the END of test execution and only if tests pass. This causes:
- Failed tests leave corrupted log state for next run
- Tests may fail when run multiple times without manual cleanup

This PR provides a **temporary mitigation** by making `/logs` cleanup conditional on the `--preserve-data-dir` flag, while keeping `/data` unconditionally cleaned at start.

**Note:** This is a partial fix. Complete resolution will come in a follow-up PR after #742 is merged, where cleanup logic will be migrated to the Python runner for better control over test data management.

### How to verify the changes you have done?
```bash
# Test 1: Run tests multiple times
./tests/prepare.sh
./tests/run.sh
./tests/run.sh  # Should work without manual cleanup

# Test 2: Preserve logs for debugging
./tests/run.sh --preserve-data-dir
ls -la $FLORESTA_TEMP_DIR/logs  # Logs preserved
```

### Next Steps

After #742 is merged, I plan to submit a follow-up PR to:
- Migrate cleanup logic to the Python test runner
- Provide more granular control over test data management
- Fully resolve #760

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - [ ] Ran `just pcc` (skipped - changes are bash-only, validated manually)
  - [ ] Ran `just lint-features '-- -D warnings' && cargo test --release` (not applicable)
  - [ ] Confirmed CI passed on my fork (will run after PR creation)
- [x] I've linked any related issue(s) in the sections above

**Manual validation performed:**
- ✅ Bash syntax check (`bash -n`)
- ✅ Logic tested with simulations
- ✅ `--preserve-data-dir` flag tested
- ✅ Consecutive test runs verified