### PR TITLE
chore!: move `get_bip34_height` to consensus.rs

### DIFF
--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -404,7 +404,7 @@ mod tests {
         fn update_acc(
             &self,
             _: Stump,
-            _: Block,
+            _: &Block,
             _: u32,
             _: Proof,
             _: Vec<Sha256Hash>,

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -82,7 +82,7 @@ pub trait BlockchainInterface {
     fn update_acc(
         &self,
         acc: Stump,
-        block: Block,
+        block: &Block,
         height: u32,
         proof: Proof,
         del_hashes: Vec<sha256::Hash>,
@@ -313,7 +313,7 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
     fn update_acc(
         &self,
         acc: Stump,
-        block: Block,
+        block: &Block,
         height: u32,
         proof: Proof,
         del_hashes: Vec<sha256::Hash>,

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -426,7 +426,7 @@ impl BlockchainInterface for PartialChainState {
     fn update_acc(
         &self,
         _acc: Stump,
-        _block: Block,
+        _block: &Block,
         _height: u32,
         _proof: rustreexo::accumulator::proof::Proof,
         _del_hashes: Vec<bitcoin::hashes::sha256::Hash>,

--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -405,7 +405,7 @@ where
             .leaf_data
             .expect("Leaf data should be present");
 
-        let acc1 = self.update_acc(agreed, inflight_block.block, proof, &leaf_data, fork + 1)?;
+        let acc1 = self.update_acc(agreed, &inflight_block.block, proof, &leaf_data, fork + 1)?;
 
         let peer1_acc = Self::parse_acc(peer1_acc)?;
         let peer2_acc = Self::parse_acc(peer2_acc)?;
@@ -508,7 +508,7 @@ where
     fn update_acc(
         &self,
         acc: Stump,
-        block: Block,
+        block: &Block,
         proof: Proof,
         leaf_data: &[CompactLeafData],
         height: u32,


### PR DESCRIPTION
### Description and Notes

This function is independent of any `ChainBackend`, it just requires the block, so I'm making it a `Consensus` associate function.

I have also changed `BlockchainInterface::update_acc` to take a block reference, as ownership isn't needed (otherwise I would need to clone the block in a PR I'm working on).