### PR TITLE
fix(wire): drain `node_rx` to keep main loop running

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node_context.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_context.rs
@@ -24,6 +24,8 @@
 //!    will handle new blocks (even if `SyncNode` haven't returned) and handle
 //!    requests by users.
 
+use std::time::Duration;
+
 use bitcoin::p2p::ServiceFlags;
 
 /// This trait mainly defines a bunch of constants that we need for the node, but we may tweak
@@ -80,9 +82,18 @@ pub trait NodeContext {
     /// How many concurrent GETDATA packages we can send at the same time
     const MAX_CONCURRENT_GETDATA: usize = 10;
 
+    /// How often we perform the main loop maintenance tasks (checking for timeouts, peers, etc.)
+    const MAINTENANCE_TICK: Duration = Duration::from_secs(1);
+
     fn get_required_services(&self) -> ServiceFlags {
         ServiceFlags::NETWORK
     }
 }
 
 pub(crate) type PeerId = u32;
+
+/// Simple return enum that tells the caller whether to continue looping or break out.
+pub(crate) enum LoopControl {
+    Continue,
+    Break,
+}


### PR DESCRIPTION
### Description and Notes

Closes #778

Currently the way we read messages makes us "get stuck" in the message-reading loop and we don't run the main loop, so we don't check for the kill signal to properly shutdown.

The reason is that `while let Ok(Some(msg)) = timeout(Duration::from_secs(1), self.node_rx.recv()).await` only exits if a message takes more than a second, and during IBD we are mostly receiving many messages per second.

In https://github.com/getfloresta/Floresta/pull/599 I tried to fix this for headers sync by adding the check inside the message loop. But the clean solution is to call `try_recv`, hence draining all messages and exiting (to keep the main loop running).

Also chain selector doesn't need to call `self.shutdown()`, that is called in running node after we return.

### How to verify the changes you have done?

Run the node and do a `CTRL+C` while in headers sync, IBD, and running node. In all three cases you should see the node doing a fast shutdown with the proper logs:

```
INFO florestad: Stopping Floresta
INFO floresta_node::florestad: Stopping node...
INFO floresta_wire::p2p_wire::node: Shutting down node...
INFO floresta_wire::p2p_wire::node: Saving utreexo peers to disk...
```

The main loop was running and could check the kill signal, and so we properly save the progress. No data corruption message when you re-start.