### PR TITLE
chore(doc): fixup and update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+> We are currently migrating from the old Utreexo P2P protocol to the new version described in [BIP-0183](https://github.com/bitcoin/bips/pull/1923).
+> Since there are no bridge nodes running the new protocol on mainnet yet, Floresta can currently sync only on 
+> signet. Mainnet support will return once the new protocol design and its implementation in both Floresta and
+> [utreexod](https://github.com/utreexo/utreexod) are complete.
+
 <div align="center">
   <h1>Floresta</h1>
 
@@ -33,51 +39,75 @@
   </p>
 
   <h4>
-    <a href="https://getfloresta.org">Project Homepage</a>
+    <a href="https://getfloresta.org">Homepage</a>
     <span> | </span>
     <a href="https://docs.getfloresta.sh">Documentation</a>
   </h4>
 </div>
 
-Floresta is a lightweight and embeddable Bitcoin client designed for users and applications that want strong validation guarantees without the operational overhead of traditional full nodes.
+Floresta is a lightweight and embeddable Bitcoin client designed for users and applications that
+want strong validation guarantees without the operational overhead of traditional full nodes.
 
-It can be run as a standalone fully validating node or embedded as a library, allowing developers to reuse the same client components across different applications and deployments.
+It can be run as a standalone fully validating node or embedded as a library, allowing developers
+to reuse the same client components across different applications and deployments.
 
 ## Name
 
-Floresta is the Portuguese word for forest. It is a reference to the Utreexo accumulator, which is a forest of Merkle trees. It's pronounced /floˈɾɛstɐ/.
+Floresta is the Portuguese word for forest. It is a reference to the Utreexo accumulator,
+which is a forest of Merkle trees. It's pronounced _/floˈɾɛstɐ/_.
 
 ## Architecture
 
-Floresta is composed of two main parts: `libfloresta` and `florestad`.
+Floresta is written in Rust and implements modern Bitcoin validation techniques such as
+[Utreexo](https://eprint.iacr.org/2019/611),
+[PoW Fraud Proofs](https://blog.dlsouza.lol/2023/09/28/pow-fraud-proof.html), and pruning,
+to significantly reduce resource requirements while preserving trust and security.
 
-`libfloresta` is a collection of reusable components that can be integrated into Bitcoin applications. `florestad` builds on top of `libfloresta` to provide a full node daemon, including a watch-only wallet and an Electrum server.
+Floresta is composed of two main components: `libfloresta` and `florestad`.
 
-If you only want to run a node, you can use `florestad` directly, either by building it from source using the instructions in the [documentation](/doc/README.md) or by downloading a pre-built binary from the [latest release](https://github.com/getfloresta/Floresta/releases/latest) page.
+[`libfloresta`](https://github.com/getfloresta/Floresta/tree/master/crates) is a collection of
+reusable components that can be integrated into Bitcoin applications.
+[`florestad`](https://github.com/getfloresta/Floresta/tree/master/bin/florestad) builds on top of
+[`libfloresta`](https://github.com/getfloresta/Floresta/tree/master/crates) to provide a full node
+daemon, including a watch-only wallet and an Electrum server.
 
-## Design
+If you only want to run a node, you can use
+[`florestad`](https://github.com/getfloresta/Floresta/tree/master/bin/florestad) by building it from
+source, following the instructions for [Unix](doc/build-unix.md) or [MacOS](doc/build-macos.md).
 
-Floresta is written in Rust and implements modern Bitcoin validation techniques such as [Utreexo](https://eprint.iacr.org/2019/611), [PoW Fraud Proofs](https://blog.dlsouza.lol/2023/09/28/pow-fraud-proof.html), and pruning to significantly reduce resource requirements while preserving trust and security.
+## Consensus Implementation
 
-## For developers
+One of the most challenging parts of working with Bitcoin is keeping up with the consensus rules.
+Given its nature as a consensus protocol, it's very important to make sure that the implementation
+is correct and on par with Bitcoin Core. Instead of reimplementing a Bitcoin Script interpreter,
+we use [`rust-bitcoinkernel`](https://github.com/TheCharlatan/rust-bitcoinkernel/), which is a
+wrapper around [`libbitcoinkernel`](https://github.com/bitcoin/bitcoin/issues/24303),
+a C++ library that exposes Bitcoin Core's validation engine. It allows validating blocks,
+transaction outputs and reading block data with the same API as Bitcoin Core.
 
-Detailed documentation for `libfloresta` is available [here](https://docs.getfloresta.sh/floresta/). Additionally, the [floresta-docs](https://josesk999.github.io/floresta-docs/) mdBook provides an in-depth look at the libraries' architecture and internals.
+## Developing
 
-Further information can be found in the [doc folder](/doc).
+Detailed documentation for [`libfloresta`](https://github.com/getfloresta/Floresta/tree/master/crates)
+is available [here](https://docs.getfloresta.sh/floresta/). Additionally, the
+[floresta-docs](https://getfloresta.github.io/floresta-docs/) `mdBook` provides an
+in-depth look at the libraries' architecture and internals.
+
+Further information can be found in the [documentation folder](/doc).
+
+Contributions are welcome. Feel free to open an issue or a pull request. Check out our
+[Contribution Guidelines](CONTRIBUTING.md) for more information on best practices.
+
+If you want to contribute but don't know where to start, take a look at the
+[Good First Issues](https://github.com/getfloresta/Floresta/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 
 ## Community
 
-If you want to discuss this project, you can join our Discord server [here](https://discord.gg/5Wj8fjjS93). To report security vulnerabilities, please see our [Security Policy](SECURITY.md).
-
-## Contributing
-
-Contributions are welcome, feel free to open an issue or a pull request. Check out our [CONTRIBUTING.md](CONTRIBUTING.md) for more information on best practices and guidelines.
-
-If you want to contribute but don't know where to start, take a look at the issues, there's a few of them marked as `good first issue`.
+If you want to discuss this project, you can join the [Discord Server](https://discord.gg/5Wj8fjjS93).
+To report security vulnerabilities, please see the [Security Policy](SECURITY.md).
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/getfloresta/Floresta/blob/master/LICENSE) file for details.
+This project is licensed under the [MIT License](https://github.com/getfloresta/Floresta/blob/master/LICENSE).
 
 ## Acknowledgments
 
@@ -85,9 +115,4 @@ This project is licensed under the MIT License - see the [LICENSE](https://githu
 * [Bitcoin Core](https://github.com/bitcoin/bitcoin)
 * [Rust Bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 * [Rust Miniscript](https://github.com/rust-bitcoin/rust-miniscript)
-
-## Consensus Implementation
-
-One of the most challenging parts of working with Bitcoin is keeping up with the consensus rules. Given its nature as a consensus protocol, it's very important to make sure that the implementation is correct. Instead of reimplementing a Script interpreter, we use [`rust-bitcoinconsensus`](https://github.com/rust-bitcoin/rust-bitcoinconsensus/) to verify transactions. This is a bind around a shared library that is part of Bitcoin Core. This way, we can be sure that the consensus rules are the same as Bitcoin Core, at least for scripts.
-
-Although tx validation is arguably the hardest part in this process. This integration can be further improved by using `libbitcoinkernel`, that will increase the scope of `libbitcoinconsensus` to outside scripts, but this is still a work in progress.
+* [Rust Bitcoin Kernel](https://github.com/TheCharlatan/rust-bitcoinkernel)


### PR DESCRIPTION
Replaces #773.

This PR makes some fixups to `README.md`, including: 
- Break long lines
- Replace `rust-bitcoinconsensus` for `rust-bitcoinkernel`
- Consolidate and reorder sections
- Add a warning that synching on mainnet is not possible yet
- Update links to point to the new organization

