### PR TITLE
chore(rpcserver): Match signature of getblock to its rpc

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -10,7 +10,6 @@ use clap::Subcommand;
 use floresta_rpc::jsonrpc_client::Client;
 use floresta_rpc::rpc::FlorestaRPC;
 use floresta_rpc::rpc_types::AddNodeCommand;
-use floresta_rpc::rpc_types::GetBlockRes;
 use floresta_rpc::rpc_types::RescanConfidence;
 
 // Main function that runs the CLI application
@@ -92,12 +91,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         }
         Methods::GetRoots => serde_json::to_string_pretty(&client.get_roots()?)?,
         Methods::GetBlock { hash, verbosity } => {
-            let block = client.get_block(hash, verbosity)?;
-
-            match block {
-                GetBlockRes::One(block) => serde_json::to_string_pretty(&block)?,
-                GetBlockRes::Zero(block) => serde_json::to_string_pretty(&block)?,
-            }
+            serde_json::to_string_pretty(&client.get_block(hash, verbosity)?)?
         }
         Methods::GetPeerInfo => serde_json::to_string_pretty(&client.get_peer_info()?)?,
         Methods::Stop => serde_json::to_string_pretty(&client.stop()?)?,

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -38,7 +38,6 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
-use super::res::GetBlockRes;
 use super::res::JsonRpcError;
 use super::res::RawTxJson;
 use super::res::RpcError;
@@ -269,25 +268,13 @@ async fn handle_json_rpc_request(
         "getblock" => {
             let hash = get_hash(&params, 0, "block_hash")?;
             // Default value in case of missing parameter is 1
-            let verbosity = get_optional_field(&params, 1, "verbosity", get_numeric)?.unwrap_or(1);
+            let verbosity: u8 =
+                get_optional_field(&params, 1, "verbosity", get_numeric)?.unwrap_or(1);
 
-            match verbosity {
-                0 => {
-                    let block = state.get_block_serialized(hash).await?;
-
-                    let block = GetBlockRes::Zero(block);
-                    Ok(serde_json::to_value(block).unwrap())
-                }
-
-                1 => {
-                    let block = state.get_block(hash).await?;
-
-                    let block = GetBlockRes::One(block.into());
-                    Ok(serde_json::to_value(block).unwrap())
-                }
-
-                _ => Err(JsonRpcError::InvalidVerbosityLevel),
-            }
+            state
+                .get_block(hash, verbosity)
+                .await
+                .map(|v| serde_json::to_value(v).expect("GetBlockRes implements serde"))
         }
 
         "getblockchaininfo" => state
@@ -300,10 +287,10 @@ async fn handle_json_rpc_request(
 
         "getblockfrompeer" => {
             let hash = get_hash(&params, 0, "block_hash")?;
-            state
-                .get_block(hash)
-                .await
-                .map(|v| serde_json::to_value(v).unwrap())
+
+            state.get_block(hash, 0).await?;
+
+            Ok(Value::Null)
         }
 
         "getblockhash" => {

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -226,31 +226,13 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes> {
         let verbosity = verbosity.unwrap_or(1);
 
-        match verbosity {
-            0 => {
-                let block = self.call(
-                    "getblock",
-                    &[
-                        Value::String(hash.to_string()),
-                        Value::Number(Number::from(verbosity)),
-                    ],
-                )?;
-                Ok(GetBlockRes::Zero(block))
-            }
-
-            1 => {
-                let block = self.call(
-                    "getblock",
-                    &[
-                        Value::String(hash.to_string()),
-                        Value::Number(Number::from(verbosity)),
-                    ],
-                )?;
-                Ok(GetBlockRes::One(block))
-            }
-
-            _ => Err(rpc_types::Error::InvalidVerbosity),
-        }
+        self.call(
+            "getblock",
+            &[
+                Value::String(hash.to_string()),
+                Value::Number(Number::from(verbosity)),
+            ],
+        )
     }
 
     fn get_block_count(&self) -> Result<u32> {

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -182,8 +182,10 @@ pub struct PeerInfo {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum GetBlockRes {
     Zero(String),
+
     One(Box<GetBlockVerboseOne>),
 }
 


### PR DESCRIPTION
### Description and Notes

 #682 introduced changes that brought getblock rpc method closer to bitcoin core behavior. The changes presented here make the internal method signature to match the specification.
