### PR TITLE
fix(wire): Dont error when no conections while on regtest.

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1828,7 +1828,9 @@ where
         required_service: ServiceFlags,
     ) -> Result<(), WireError> {
         // If the user passes in a `--connect` cli argument, we only connect with
-        // that particular peer.
+        // that particular peer, but not having any peers means that we didnt tried to
+        // connect to it yet or the connection failed.
+
         if self.fixed_peer.is_some() && !self.peers.is_empty() {
             return Ok(());
         }
@@ -1851,8 +1853,8 @@ where
     }
 
     pub(crate) fn open_feeler_connection(&mut self) -> Result<(), WireError> {
-        // No feeler if `-connect` is set
-        if self.fixed_peer.is_some() {
+        // No feeler if `-connect` is set or when Regtest mode.
+        if self.fixed_peer.is_some() || self.network == Network::Regtest {
             return Ok(());
         }
         self.create_connection(ConnectionKind::Feeler)?;
@@ -1908,6 +1910,9 @@ where
             let net = self.network;
             self.address_man.add_fixed_addresses(net);
 
+            if self.network == Network::Regtest {
+                return Ok(());
+            }
             return Err(WireError::NoAddressesAvailable);
         };
 


### PR DESCRIPTION
### Description and Notes

Regtest doesnt allow do try out external conections but our `chain_selector` keeps trying to open connections and erroring because addrman doesnt have any dns seeds.

This PR fixes that, not having dns seeds and external peers is technically not a error in regtest

### How to verify the changes you have done?

run on regtest mode, be sure that you see that we dont fetch any dns seeds.
No errors because of that.

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
