### PR TITLE
fix just pcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!WARNING]
+> \[!WARNING\]
 > We are currently migrating from the old Utreexo P2P protocol to the new version described in [BIP-0183](https://github.com/bitcoin/bips/pull/1923).
 > Since there are no bridge nodes running the new protocol on mainnet yet, Floresta can currently sync only on 
 > signet. Mainnet support will return once the new protocol design and its implementation in both Floresta and

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -533,7 +533,7 @@ mod tests {
 
         let expected_hex_string =
             "00000000000000000000000000000000000000000000000000000bb80bb80bb8";
-        let expected_work = Work::from_hex(&format!("0x{}", expected_hex_string)).unwrap();
+        let expected_work = Work::from_hex(&format!("0x{expected_hex_string}")).unwrap();
 
         assert_eq!(work.to_string_hex(), expected_hex_string);
         assert_eq!(work, expected_work);


### PR DESCRIPTION
This PR fix `just pcc`.

1. Escape the WARNING marker in the README so it renders correctly.
2. Also inline format string interpolation.
