### PR TITLE
refactor(wire): create `handle_peer_msg_common`

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -657,6 +657,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         let _ = self.node_tx.send(message);
     }
 }
+
 pub(super) mod peer_utils {
     use std::net::IpAddr;
     use std::net::Ipv4Addr;
@@ -717,6 +718,7 @@ pub(super) mod peer_utils {
         })
     }
 }
+
 #[derive(Debug)]
 pub struct Version {
     pub user_agent: String,
@@ -728,6 +730,7 @@ pub struct Version {
     pub kind: ConnectionKind,
     pub transport_protocol: TransportProtocol,
 }
+
 /// Messages passed from different modules to the main node to process. They should minimal
 /// and only if it requires global states, everything else should be handled by the module
 /// itself.


### PR DESCRIPTION
### Description and Notes

Our three node contexts are handling the following `PeerMessages` in the same way (the only difference was for running node, which was using `unwrap`):

- `Addr`
- `NotFound`
- `Transaction`
- `UtreexoState`

So the new method handles them and returns `None`, or gives back the message so that we handle it specifically for each context. This simplifies our context implementations.