### PR TITLE
Wallet: move database to sqlite, remove kv and memmory db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "libsqlite3-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,10 +1216,9 @@ dependencies = [
  "bitcoin",
  "floresta-chain",
  "floresta-common",
- "kv",
  "rand",
+ "rusqlite",
  "serde",
- "serde_json",
  "tracing",
 ]
 
@@ -1274,16 +1285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,15 +1327,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1716,15 +1708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,19 +1765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620727085ac39ee9650b373fe6d8073a0aee6f99e52a9c72b25f7671078039ab"
-dependencies = [
- "pin-project-lite",
- "serde",
- "sled",
- "thiserror 1.0.69",
- "toml 0.5.11",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1813,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2074,37 +2056,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2115,7 +2072,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2263,7 +2220,7 @@ checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.5",
+ "parking_lot",
  "prometheus-client-derive-encode",
 ]
 
@@ -2391,15 +2348,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -2459,6 +2407,30 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -2714,22 +2686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,6 +2717,19 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "bindgen",
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -3008,15 +2977,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3348,6 +3308,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ corepc-types = "0.11"
 console-subscriber = { version = "0.5", default-features = false }
 dns-lookup = "2.1"
 hex = "0.4"
-kv = "0.24"
 miniscript = { version = "12.3", default-features = false }
 rand = "0.8"
 rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs", "pem"] }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -21,7 +21,7 @@ use floresta_common::get_spk_hash;
 use floresta_common::spsc::Channel;
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
 use floresta_compact_filters::network_filters::NetworkFilters;
-use floresta_watch_only::kv_database::KvDatabase;
+use floresta_watch_only::sqlite_database::SqliteDatabase;
 use floresta_watch_only::AddressCache;
 use floresta_watch_only::CachedTransaction;
 use floresta_wire::node_interface::NodeInterface;
@@ -176,7 +176,7 @@ pub struct ElectrumServer<Blockchain: BlockchainInterface> {
 
     /// The address cache is used to store addresses and transactions, like a
     /// watch-only wallet, but it is adapted to the electrum protocol.
-    address_cache: Arc<AddressCache<KvDatabase>>,
+    address_cache: Arc<AddressCache<SqliteDatabase>>,
 
     /// The clients are the clients connected to our server, we keep track of them
     /// using a unique id.
@@ -218,7 +218,7 @@ pub struct ElectrumServer<Blockchain: BlockchainInterface> {
 
 impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     pub fn new(
-        address_cache: Arc<AddressCache<KvDatabase>>,
+        address_cache: Arc<AddressCache<SqliteDatabase>>,
         chain: Arc<Blockchain>,
         block_filters: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         node_interface: NodeInterface,
@@ -956,8 +956,8 @@ mod test {
     use floresta_common::assert_ok;
     use floresta_common::get_spk_hash;
     use floresta_mempool::Mempool;
-    use floresta_watch_only::kv_database::KvDatabase;
     use floresta_watch_only::merkle::MerkleProof;
+    use floresta_watch_only::sqlite_database::SqliteDatabase;
     use floresta_watch_only::AddressCache;
     use floresta_wire::address_man::AddressMan;
     use floresta_wire::address_man::ReachableNetworks;
@@ -1019,10 +1019,9 @@ mod test {
         headers
     }
 
-    fn get_test_cache() -> Arc<AddressCache<KvDatabase>> {
-        let test_id: u32 = rand::random();
-        let cache = KvDatabase::new(format!("./tmp-db/{test_id}.floresta")).unwrap();
-        let cache = AddressCache::new(cache);
+    fn get_test_cache() -> Arc<AddressCache<SqliteDatabase>> {
+        let db = SqliteDatabase::new_ephemeral().unwrap();
+        let cache = AddressCache::new(db);
 
         // Inserting test transactions in the wallet
         let (transaction, proof) = get_test_transaction();

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -383,7 +383,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let hash = get_spk_hash(&script);
 
                 if !self.address_cache.is_address_cached(&hash) {
-                    self.address_cache.cache_address(script.clone());
+                    self.address_cache.cache_address(script.clone())?;
                     self.addresses_to_scan.push(script);
                     let res = json!({
                         "confirmed": 0,
@@ -404,7 +404,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let hash = get_spk_hash(&script);
 
                 if !self.address_cache.is_address_cached(&hash) {
-                    self.address_cache.cache_address(script.clone());
+                    self.address_cache.cache_address(script.clone())?;
                     self.addresses_to_scan.push(script);
                     return json_rpc_res!(request, null);
                 }
@@ -470,7 +470,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
 
                 let updated = self
                     .address_cache
-                    .cache_mempool_transaction(&tx)
+                    .cache_mempool_transaction(&tx)?
                     .into_iter()
                     .map(|spend| (tx.clone(), spend))
                     .collect::<Vec<_>>();
@@ -540,7 +540,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     }
 
     pub async fn rebroadcast_mempool_transactions(&self) {
-        let unconfirmed = self.address_cache.find_unconfirmed().unwrap();
+        let unconfirmed = match self.address_cache.find_unconfirmed() {
+            Ok(txs) => txs,
+            Err(e) => {
+                error!("Error fetching unconfirmed transactions: {e}");
+                return;
+            }
+        };
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -594,9 +600,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     continue;
                 }
 
-                self.addresses_to_scan.iter().for_each(|address| {
-                    self.address_cache.cache_address(address.clone());
-                });
+                for address in self.addresses_to_scan.iter() {
+                    if let Err(e) = self.address_cache.cache_address(address.clone()) {
+                        error!("Error caching address: {e}");
+                    }
+                }
 
                 info!("Catching up with addresses {:?}", self.addresses_to_scan);
                 let addresses: Vec<_> = self.addresses_to_scan.drain(..).collect();
@@ -702,10 +710,12 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }]
         });
 
-        let current_height = self.address_cache.get_cache_height();
+        let current_height = self.address_cache.get_cache_height().unwrap_or(0);
 
         if (!self.chain.is_in_ibd() || height % 1000 == 0) && (height > current_height) {
-            self.address_cache.bump_height(height);
+            if let Err(e) = self.address_cache.bump_height(height) {
+                error!("Error bumping cache height: {e}");
+            }
         }
 
         if self.chain.get_height().unwrap() == height {
@@ -717,9 +727,10 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }
         }
 
-        let transactions = self.address_cache.block_process(&block, height);
-
-        self.wallet_notify(&transactions);
+        match self.address_cache.block_process(&block, height) {
+            Ok(transactions) => self.wallet_notify(&transactions),
+            Err(e) => error!("Error processing block at height {height}: {e}"),
+        }
     }
 
     /// Handles each kind of Message
@@ -1021,11 +1032,11 @@ mod test {
 
     fn get_test_cache() -> Arc<AddressCache<SqliteDatabase>> {
         let db = SqliteDatabase::new_ephemeral().unwrap();
-        let cache = AddressCache::new(db);
+        let cache = AddressCache::new(db).unwrap();
 
         // Inserting test transactions in the wallet
         let (transaction, proof) = get_test_transaction();
-        cache.cache_transaction(
+        let _ = cache.cache_transaction(
             &transaction,
             118511,
             transaction.output[0].value.to_sat(),

--- a/crates/floresta-electrum/src/error.rs
+++ b/crates/floresta-electrum/src/error.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use floresta_common::impl_error_from;
+use floresta_watch_only::sqlite_database::SqliteDatabaseError;
+use floresta_watch_only::WatchOnlyError;
 use thiserror::Error;
 use tokio::sync::oneshot;
 
@@ -22,4 +25,9 @@ pub enum Error {
 
     #[error("Node isn't working")]
     NodeInterface(#[from] oneshot::error::RecvError),
+
+    #[error("Wallet error: {0}")]
+    Wallet(WatchOnlyError<SqliteDatabaseError>),
 }
+
+impl_error_from!(Error, WatchOnlyError<SqliteDatabaseError>, Wallet);

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -264,4 +264,4 @@ impl_from_error!(
     WatchOnlyError<SqliteDatabaseError>
 );
 
-impl std::error::Error for FlorestadError {}
+impl error::Error for FlorestadError {}

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -80,7 +80,7 @@ pub enum FlorestadError {
     InvalidDataDir(String),
 
     /// Obtaining a lock on the data directory.
-    CouldNotOpenSqLiteDatabase(SqliteDatabaseError),
+    CouldNotOpenSqliteDatabase(SqliteDatabaseError),
 
     /// Initializing the watch-only wallet.
     CouldNotInitializeWallet(WatchOnlyError<SqliteDatabaseError>),
@@ -177,7 +177,7 @@ impl Display for FlorestadError {
             FlorestadError::InvalidDataDir(path) => {
                 write!(f, "Data directory doesn't exist or is not writable: {path}")
             }
-            FlorestadError::CouldNotOpenSqLiteDatabase(err) => {
+            FlorestadError::CouldNotOpenSqliteDatabase(err) => {
                 write!(f, "Could not open the sqlite database: {err}")
             }
             FlorestadError::CouldNotInitializeWallet(err) => {

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -12,7 +12,7 @@ use floresta_chain::BlockchainError;
 use floresta_chain::FlatChainstoreError;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::IterableFilterStoreError;
-use floresta_watch_only::kv_database::KvDatabaseError;
+use floresta_watch_only::sqlite_database::SqliteDatabaseError;
 use floresta_watch_only::WatchOnlyError;
 use tokio_rustls::rustls::pki_types;
 
@@ -80,10 +80,10 @@ pub enum FlorestadError {
     InvalidDataDir(String),
 
     /// Obtaining a lock on the data directory.
-    CouldNotOpenKvDatabase(KvDatabaseError),
+    CouldNotOpenSqLiteDatabase(SqliteDatabaseError),
 
     /// Initializing the watch-only wallet.
-    CouldNotInitializeWallet(WatchOnlyError<KvDatabaseError>),
+    CouldNotInitializeWallet(WatchOnlyError<SqliteDatabaseError>),
 
     /// Setting up the watch-only wallet.
     CouldNotSetupWallet(String),
@@ -108,7 +108,7 @@ pub enum FlorestadError {
     InvalidProvidedXpub(String, slip132::Error),
 
     /// Failed to obtain the wallet cache.
-    CouldNotObtainWalletCache(WatchOnlyError<KvDatabaseError>),
+    CouldNotObtainWalletCache(WatchOnlyError<SqliteDatabaseError>),
 
     /// Failed to push a descriptor to the wallet.
     CouldNotPushDescriptor(String),
@@ -177,8 +177,8 @@ impl Display for FlorestadError {
             FlorestadError::InvalidDataDir(path) => {
                 write!(f, "Data directory doesn't exist or is not writable: {path}")
             }
-            FlorestadError::CouldNotOpenKvDatabase(err) => {
-                write!(f, "Cannot open a key-value database: {err}")
+            FlorestadError::CouldNotOpenSqLiteDatabase(err) => {
+                write!(f, "Could not open the sqlite database: {err}")
             }
             FlorestadError::CouldNotInitializeWallet(err) => {
                 write!(f, "Could not initialize wallet: {err}")
@@ -259,6 +259,9 @@ impl_from_error!(TomlParsing, toml::de::Error);
 impl_from_error!(BlockValidation, BlockValidationErrors);
 impl_from_error!(AddressParsing, bitcoin::address::ParseError);
 impl_from_error!(Miniscript, miniscript::Error);
-impl_from_error!(CouldNotObtainWalletCache, WatchOnlyError<KvDatabaseError>);
+impl_from_error!(
+    CouldNotObtainWalletCache,
+    WatchOnlyError<SqliteDatabaseError>
+);
 
-impl error::Error for FlorestadError {}
+impl std::error::Error for FlorestadError {}

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -726,9 +726,9 @@ impl Florestad {
         })
     }
 
-    fn load_wallet(data_dir: &String) -> Result<AddressCache<KvDatabase>, FlorestadError> {
+    fn load_wallet(data_dir: &str) -> Result<AddressCache<SqliteDatabase>, FlorestadError> {
         let database =
-            SqliteDatabase::new(data_dir).map_err(FlorestadError::CouldNotOpenSqLiteDatabase)?;
+            SqliteDatabase::new(data_dir).map_err(FlorestadError::CouldNotOpenSqliteDatabase)?;
         Ok(AddressCache::new(database))
     }
 

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -29,7 +29,7 @@ use floresta_compact_filters::network_filters::NetworkFilters;
 use floresta_electrum::electrum_protocol::client_accept_loop;
 use floresta_electrum::electrum_protocol::ElectrumServer;
 use floresta_mempool::Mempool;
-use floresta_watch_only::kv_database::KvDatabase;
+use floresta_watch_only::sqlite_database::SqliteDatabase;
 use floresta_watch_only::AddressCache;
 use floresta_wire::address_man::AddressMan;
 use floresta_wire::address_man::ReachableNetworks;
@@ -728,14 +728,14 @@ impl Florestad {
 
     fn load_wallet(data_dir: &String) -> Result<AddressCache<KvDatabase>, FlorestadError> {
         let database =
-            KvDatabase::new(data_dir.to_owned()).map_err(FlorestadError::CouldNotOpenKvDatabase)?;
+            SqliteDatabase::new(data_dir).map_err(FlorestadError::CouldNotOpenSqLiteDatabase)?;
         Ok(AddressCache::new(database))
     }
 
     fn setup_wallet(
         &self,
         data_dir: &str,
-        wallet: &mut AddressCache<KvDatabase>,
+        wallet: &mut AddressCache<SqliteDatabase>,
     ) -> Result<(), FlorestadError> {
         // The config file inside our data directory or inside the specified directory
         let config_file = match self.config.config_file {

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -729,7 +729,7 @@ impl Florestad {
     fn load_wallet(data_dir: &str) -> Result<AddressCache<SqliteDatabase>, FlorestadError> {
         let database =
             SqliteDatabase::new(data_dir).map_err(FlorestadError::CouldNotOpenSqliteDatabase)?;
-        Ok(AddressCache::new(database))
+        Ok(AddressCache::new(database)?)
     }
 
     fn setup_wallet(
@@ -757,7 +757,7 @@ impl Florestad {
             }
         }
         for addresses in setup.addresses {
-            wallet.cache_address(addresses.script_pubkey());
+            wallet.cache_address(addresses.script_pubkey())?;
         }
 
         info!("Wallet setup completed!");

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -613,7 +613,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             return Err(JsonRpcError::NoBlockFilters);
         };
 
-        self.wallet.cache_address(script.clone());
+        self.wallet.cache_address(script.clone())?;
         let filter_key = script.to_bytes();
         let candidates = cfilters
             .match_any(
@@ -642,7 +642,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 return Err(JsonRpcError::BlockNotFound);
             };
 
-            self.wallet.block_process(&candidate, height);
+            self.wallet.block_process(&candidate, height)?;
         }
 
         let val = match self.get_tx_out(txid, vout, false)? {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -109,18 +109,18 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
         // It's ok to unwrap because we know there is at least one element in the vector
         let addresses = parsed.pop().unwrap();
-        let addresses = (0..100)
+        let derived_addresses = (0..100)
             .map(|index| {
                 let address = addresses
                     .at_derivation_index(index)
                     .unwrap()
                     .script_pubkey();
-                self.wallet.cache_address(address.clone());
-                address
+                self.wallet.cache_address(address.clone())?;
+                Ok(address)
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
 
-        debug!("Rescanning with block filters for addresses: {addresses:?}");
+        debug!("Rescanning with block filters for addresses: {derived_addresses:?}");
 
         let addresses = self.wallet.get_cached_addresses();
         let wallet = self.wallet.clone();
@@ -608,7 +608,9 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                     .unwrap()
                     .unwrap();
 
-                wallet.block_process(&block, height);
+                if let Err(e) = wallet.block_process(&block, height) {
+                    error!("Error processing block at height {height}: {e}");
+                }
             }
         }
 

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -32,7 +32,7 @@ use floresta_chain::ThreadSafeChain;
 use floresta_common::parse_descriptors;
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
 use floresta_compact_filters::network_filters::NetworkFilters;
-use floresta_watch_only::kv_database::KvDatabase;
+use floresta_watch_only::sqlite_database::SqliteDatabase;
 use floresta_watch_only::AddressCache;
 use floresta_watch_only::CachedTransaction;
 use floresta_wire::node_interface::NodeInterface;
@@ -77,7 +77,7 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
     pub(super) network: Network,
     pub(super) chain: Blockchain,
-    pub(super) wallet: Arc<AddressCache<KvDatabase>>,
+    pub(super) wallet: Arc<AddressCache<SqliteDatabase>>,
     pub(super) node: NodeInterface,
     pub(super) kill_signal: Arc<RwLock<bool>>,
     pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
@@ -584,7 +584,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     async fn rescan_with_block_filters(
         addresses: Vec<ScriptBuf>,
         chain: Blockchain,
-        wallet: Arc<AddressCache<KvDatabase>>,
+        wallet: Arc<AddressCache<SqliteDatabase>>,
         cfilters: Arc<NetworkFilters<FlatFiltersStore>>,
         node: NodeInterface,
         start_height: Option<u32>,
@@ -737,7 +737,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         chain: Blockchain,
-        wallet: Arc<AddressCache<KvDatabase>>,
+        wallet: Arc<AddressCache<SqliteDatabase>>,
         node: NodeInterface,
         kill_signal: Arc<RwLock<bool>>,
         network: Network,

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -12,9 +12,8 @@ readme.workspace = true # Floresta/README.md
 
 [dependencies]
 bitcoin = { workspace = true, features = ["serde"] }
-kv = { workspace = true }
+rusqlite = { version = "0.38", optional = true, features = [ "bundled", "buildtime_bindgen" ], default-features = false  }
 serde = { workspace = true }
-serde_json = { workspace = true, features = ["alloc"] }
 tracing = { workspace = true }
 
 # Local dependencies
@@ -23,10 +22,11 @@ floresta-common = { workspace = true, features = ["descriptors-no-std"] }
 
 [dev-dependencies]
 rand = { workspace = true }
+rusqlite = { version = "0.38", features = [ "bundled", "buildtime_bindgen" ], default-features = false }
 
 [features]
-default = ["std"]
-memory-database = []
+default = ["std", "sqlite"]
+sqlite = ["dep:rusqlite"]
 # The default features in common are `std` and `descriptors-std` (which is a superset of `descriptors-no-std`)
 std = ["floresta-common/default", "serde/std"]
 

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -22,7 +22,6 @@ use floresta_chain::UtxoData;
 use floresta_common::get_spk_hash;
 use floresta_common::parse_descriptors;
 
-pub mod kv_database;
 #[cfg(any(test, feature = "memory-database"))]
 pub mod memory_database;
 pub mod merkle;

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -24,6 +24,9 @@ use floresta_common::parse_descriptors;
 
 pub mod merkle;
 
+#[cfg(any(test, feature = "sqlite"))]
+pub mod sqlite_database;
+
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::hash_types::Txid;
@@ -116,7 +119,7 @@ impl Default for CachedTransaction {
 }
 
 /// An address inside our cache, contains all information we need to satisfy electrum's requests
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedAddress {
     script_hash: Hash,
     balance: u64,
@@ -127,7 +130,7 @@ pub struct CachedAddress {
 
 /// Holds some useful data about our wallet, like how many addresses we have, how many
 /// transactions we have, etc.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Stats {
     pub address_count: usize,
     pub transaction_count: usize,
@@ -143,7 +146,7 @@ pub trait AddressCacheDatabase {
     type Error: Debug + Send + Sync + 'static;
     /// Saves a new address to the database. If the address already exists, `update` should
     /// be used instead
-    fn save(&self, address: &CachedAddress);
+    fn save(&self, address: &CachedAddress) -> Result<(), Self::Error>;
     /// Loads all addresses we have cached so far
     fn load(&self) -> Result<Vec<CachedAddress>, Self::Error>;
     /// Loads the data associated with our watch-only wallet.
@@ -151,7 +154,7 @@ pub trait AddressCacheDatabase {
     /// Saves the data associated with our watch-only wallet.
     fn save_stats(&self, stats: &Stats) -> Result<(), Self::Error>;
     /// Updates an address, probably because a new transaction arrived
-    fn update(&self, address: &CachedAddress);
+    fn update(&self, address: &CachedAddress) -> Result<(), Self::Error>;
     /// TODO: Maybe turn this into another db
     /// Returns the height of the last block we filtered
     fn get_cache_height(&self) -> Result<u32, Self::Error>;
@@ -329,7 +332,9 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
             transactions: Vec::new(),
             utxos: Vec::new(),
         };
-        self.database.save(&new_address);
+        self.database
+            .save(&new_address)
+            .expect("Database not working");
 
         self.address_map.insert(hash, new_address);
         self.script_set.insert(hash);
@@ -446,7 +451,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
         if let Some(address) = self.address_map.get_mut(&hash) {
             if !address.transactions.contains(&transaction_to_cache.hash) {
                 address.transactions.push(transaction_to_cache.hash);
-                self.database.update(address);
+                self.database.update(address).expect("Database not working");
             }
         }
     }
@@ -490,7 +495,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
 
             if !address.transactions.contains(&transaction_to_cache.hash) {
                 address.transactions.push(transaction_to_cache.hash);
-                self.database.update(address);
+                self.database.update(address).expect("Database not working");
             }
         }
     }
@@ -533,7 +538,9 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                 transactions: Vec::new(),
                 utxos: Vec::new(),
             };
-            self.database.save(&new_address);
+            self.database
+                .save(&new_address)
+                .expect("Database not working");
 
             e.insert(new_address);
             self.script_set.insert(hash);
@@ -801,7 +808,7 @@ mod test {
     use floresta_common::get_spk_hash;
     use floresta_common::prelude::*;
 
-    use super::memory_database::MemoryDatabase;
+    use super::sqlite_database::SqliteDatabase;
     use super::AddressCache;
     use crate::merkle::MerkleProof;
 
@@ -813,8 +820,9 @@ mod test {
         deserialize(&hex).unwrap()
     }
 
-    fn get_test_cache() -> AddressCache<MemoryDatabase> {
-        let database = MemoryDatabase::new();
+    fn get_test_cache() -> AddressCache<SqliteDatabase> {
+        let database = SqliteDatabase::new_ephemeral().unwrap();
+
         AddressCache::new(database)
     }
 

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -22,8 +22,6 @@ use floresta_chain::UtxoData;
 use floresta_common::get_spk_hash;
 use floresta_common::parse_descriptors;
 
-#[cfg(any(test, feature = "memory-database"))]
-pub mod memory_database;
 pub mod merkle;
 
 use bitcoin::consensus::deserialize;

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -44,10 +44,21 @@ use serde::Serialize;
 use sync::RwLock;
 use tracing::error;
 
+/// Errors that can occur when interacting with the watch-only wallet.
 #[derive(Debug)]
 pub enum WatchOnlyError<DatabaseError: Debug> {
     WalletNotInitialized,
+
+    /// A referenced transaction was not found in the cache.
     TransactionNotFound,
+
+    /// A script hash referenced by a UTXO or transaction is not present in the address map.
+    CachedAddressNotFound,
+
+    /// A transaction input or output index is out of bounds.
+    IndexOutOfBounds,
+
+    /// An error originating from the underlying database implementation.
     DatabaseError(DatabaseError),
 }
 
@@ -59,6 +70,12 @@ impl<DatabaseError: Debug> Display for WatchOnlyError<DatabaseError> {
             }
             WatchOnlyError::TransactionNotFound => {
                 write!(f, "Transaction not found")
+            }
+            WatchOnlyError::CachedAddressNotFound => {
+                write!(f, "Cached address not found in address map, the wallet may be in a corrupted state")
+            }
+            WatchOnlyError::IndexOutOfBounds => {
+                write!(f, "Index out of bounds")
             }
             WatchOnlyError::DatabaseError(e) => {
                 write!(f, "Database error: {e:?}")
@@ -188,7 +205,11 @@ struct AddressCacheInner<D: AddressCacheDatabase> {
 impl<D: AddressCacheDatabase> AddressCacheInner<D> {
     /// Iterates through a block, finds transactions destined to ourselves.
     /// Returns all transactions we found.
-    fn block_process(&mut self, block: &Block, height: u32) -> Vec<(Transaction, TxOut)> {
+    fn block_process(
+        &mut self,
+        block: &Block,
+        height: u32,
+    ) -> Result<Vec<(Transaction, TxOut)>, WatchOnlyError<D::Error>> {
         let mut my_transactions = Vec::new();
         // Check if this transaction spends from one of our utxos
         for (position, transaction) in block.txdata.iter().enumerate() {
@@ -197,17 +218,17 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                     let script = self
                         .address_map
                         .get(script)
-                        .expect("Can't cache a utxo for a address we don't have")
+                        .ok_or(WatchOnlyError::CachedAddressNotFound)?
                         .to_owned();
                     let tx = self
                         .get_transaction(&txin.previous_output.txid)
-                        .expect("We cached a utxo for a transaction we don't have");
+                        .ok_or(WatchOnlyError::TransactionNotFound)?;
 
                     let utxo = tx
                         .tx
                         .output
                         .get(txin.previous_output.vout as usize)
-                        .expect("Did we cache an invalid utxo?");
+                        .ok_or(WatchOnlyError::IndexOutOfBounds)?;
 
                     let merkle_block = MerkleProof::from_block(block, position as u64);
 
@@ -220,7 +241,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                         vin,
                         true,
                         script.script_hash,
-                    )
+                    )?;
                 }
             }
             // Checks if one of our addresses is the recipient of this transaction
@@ -240,19 +261,17 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                         vout,
                         false,
                         hash,
-                    );
+                    )?;
                 }
             }
         }
-        my_transactions
+        Ok(my_transactions)
     }
 
-    fn new(database: D) -> AddressCacheInner<D> {
-        let scripts = database.load().expect("Could not load database");
+    fn new(database: D) -> Result<AddressCacheInner<D>, WatchOnlyError<D::Error>> {
+        let scripts = database.load()?;
         if database.get_stats().is_err() {
-            database
-                .save_stats(&Stats::default())
-                .expect("Could not save stats");
+            database.save_stats(&Stats::default())?;
         }
         let mut address_map = HashMap::new();
         let mut script_set = HashSet::new();
@@ -265,12 +284,12 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
             address_map.insert(address.script_hash, address);
         }
 
-        AddressCacheInner {
+        Ok(AddressCacheInner {
             database,
             address_map,
             script_set,
             utxo_index,
-        }
+        })
     }
 
     fn get_address_utxos(&self, script_hash: &Hash) -> Option<Vec<(TxOut, OutPoint)>> {
@@ -320,10 +339,10 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
 
     /// Adds a new address to track, should be called at wallet setup and every once in a while
     /// to cache new addresses, as we use the first ones. Only requires a script to cache.
-    fn cache_address(&mut self, script_pk: ScriptBuf) {
+    fn cache_address(&mut self, script_pk: ScriptBuf) -> Result<(), WatchOnlyError<D::Error>> {
         let hash = get_spk_hash(&script_pk);
         if self.address_map.contains_key(&hash) {
-            return;
+            return Ok(());
         }
         let new_address = CachedAddress {
             balance: 0,
@@ -332,12 +351,11 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
             transactions: Vec::new(),
             utxos: Vec::new(),
         };
-        self.database
-            .save(&new_address)
-            .expect("Database not working");
+        self.database.save(&new_address)?;
 
         self.address_map.insert(hash, new_address);
         self.script_set.insert(hash);
+        Ok(())
     }
 
     /// Setup is the first command that should be executed. In a new cache. It sets our wallet's
@@ -360,21 +378,19 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                     .at_derivation_index(idx)
                     .expect("We validate those descriptors before saving")
                     .script_pubkey();
-                self.cache_address(script);
+                self.cache_address(script)?;
             }
         }
         stats.derivation_index += 100;
         Ok(self.database.save_stats(&stats)?)
     }
 
-    fn maybe_derive_addresses(&mut self) {
-        let stats = self.database.get_stats().unwrap();
+    fn maybe_derive_addresses(&mut self) -> Result<(), WatchOnlyError<D::Error>> {
+        let stats = self.database.get_stats()?;
         if stats.transaction_count > (stats.derivation_index as usize * 100) {
-            let res = self.derive_addresses();
-            if res.is_err() {
-                error!("Error deriving addresses: {res:?}");
-            }
+            self.derive_addresses()?;
         }
+        Ok(())
     }
 
     fn find_unconfirmed(&self) -> Result<Vec<Transaction>, WatchOnlyError<D::Error>> {
@@ -390,27 +406,35 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
         Ok(unconfirmed)
     }
 
-    fn find_spend(&self, transaction: &Transaction) -> Vec<(usize, TxOut)> {
+    fn find_spend(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<Vec<(usize, TxOut)>, WatchOnlyError<D::Error>> {
         let mut spends = Vec::new();
         for (idx, input) in transaction.input.iter().enumerate() {
             if self.utxo_index.contains_key(&input.previous_output) {
-                let prev_tx = self.get_transaction(&input.previous_output.txid).unwrap();
+                let prev_tx = self
+                    .get_transaction(&input.previous_output.txid)
+                    .ok_or(WatchOnlyError::TransactionNotFound)?;
                 spends.push((
                     idx,
                     prev_tx.tx.output[input.previous_output.vout as usize].clone(),
                 ));
             }
         }
-        spends
+        Ok(spends)
     }
 
-    fn cache_mempool_transaction(&mut self, transaction: &Transaction) -> Vec<TxOut> {
-        let mut coins = self.find_spend(transaction);
+    fn cache_mempool_transaction(
+        &mut self,
+        transaction: &Transaction,
+    ) -> Result<Vec<TxOut>, WatchOnlyError<D::Error>> {
+        let mut coins = self.find_spend(transaction)?;
         for (idx, spend) in coins.iter() {
             let script = self
                 .address_map
                 .get(&get_spk_hash(&spend.script_pubkey))
-                .unwrap()
+                .ok_or(WatchOnlyError::CachedAddressNotFound)?
                 .to_owned();
             self.cache_transaction(
                 transaction,
@@ -421,12 +445,17 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                 *idx,
                 true,
                 script.script_hash,
-            )
+            )?;
         }
         for (idx, out) in transaction.output.iter().enumerate() {
             let spk_hash = get_spk_hash(&out.script_pubkey);
             if self.script_set.contains(&spk_hash) {
-                let script = self.address_map.get(&spk_hash).unwrap().to_owned();
+                let script = self
+                    .address_map
+                    .get(&spk_hash)
+                    .ok_or(WatchOnlyError::CachedAddressNotFound)?
+                    .to_owned();
+
                 coins.push((idx, out.clone()));
                 self.cache_transaction(
                     transaction,
@@ -437,23 +466,28 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                     idx,
                     true,
                     script.script_hash,
-                )
+                )?;
             }
         }
-        coins
+        Ok(coins
             .iter()
             .cloned()
             .unzip::<usize, TxOut, Vec<usize>, Vec<TxOut>>()
-            .1
+            .1)
     }
 
-    fn save_mempool_tx(&mut self, hash: Hash, transaction_to_cache: CachedTransaction) {
+    fn save_mempool_tx(
+        &mut self,
+        hash: Hash,
+        transaction_to_cache: CachedTransaction,
+    ) -> Result<(), WatchOnlyError<D::Error>> {
         if let Some(address) = self.address_map.get_mut(&hash) {
             if !address.transactions.contains(&transaction_to_cache.hash) {
                 address.transactions.push(transaction_to_cache.hash);
-                self.database.update(address).expect("Database not working");
+                self.database.update(address)?;
             }
         }
+        Ok(())
     }
 
     fn save_non_mempool_tx(
@@ -464,7 +498,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
         index: usize,
         hash: Hash,
         transaction_to_cache: CachedTransaction,
-    ) {
+    ) -> Result<(), WatchOnlyError<D::Error>> {
         if let Some(address) = self.address_map.get_mut(&hash) {
             // This transaction is spending from this address, so we should remove the UTXO
             if is_spend {
@@ -473,7 +507,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                 let input = transaction
                     .input
                     .get(index)
-                    .expect("Malformed call, index is bigger than the output vector");
+                    .ok_or(WatchOnlyError::IndexOutOfBounds)?;
                 let idx = address
                     .utxos
                     .iter()
@@ -495,9 +529,10 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
 
             if !address.transactions.contains(&transaction_to_cache.hash) {
                 address.transactions.push(transaction_to_cache.hash);
-                self.database.update(address).expect("Database not working");
+                self.database.update(address)?;
             }
         }
+        Ok(())
     }
 
     /// Caches a new transaction. This method may be called for addresses we don't follow yet,
@@ -513,7 +548,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
         index: usize,
         is_spend: bool,
         hash: sha256::Hash,
-    ) {
+    ) -> Result<(), WatchOnlyError<D::Error>> {
         let transaction_to_cache = CachedTransaction {
             height,
             merkle_block: Some(merkle_block),
@@ -521,9 +556,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
             hash: transaction.compute_txid(),
             position,
         };
-        self.database
-            .save_transaction(&transaction_to_cache)
-            .expect("Database not working");
+        self.database.save_transaction(&transaction_to_cache)?;
 
         if let Entry::Vacant(e) = self.address_map.entry(hash) {
             let script = transaction.output[index].script_pubkey.clone();
@@ -538,14 +571,12 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                 transactions: Vec::new(),
                 utxos: Vec::new(),
             };
-            self.database
-                .save(&new_address)
-                .expect("Database not working");
+            self.database.save(&new_address)?;
 
             e.insert(new_address);
             self.script_set.insert(hash);
         }
-        self.maybe_derive_addresses();
+        self.maybe_derive_addresses()?;
         // Confirmed transaction
         if height > 0 {
             return self.save_non_mempool_tx(
@@ -558,7 +589,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
             );
         }
         // Unconfirmed transaction
-        self.save_mempool_tx(hash, transaction_to_cache);
+        self.save_mempool_tx(hash, transaction_to_cache)
     }
 }
 
@@ -579,15 +610,17 @@ impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressC
         height: u32,
         _spent_utxos: Option<&HashMap<OutPoint, UtxoData>>,
     ) {
-        self.block_process(block, height);
+        if let Err(e) = self.block_process(block, height) {
+            error!("Error processing block at height {height}: {e}");
+        }
     }
 }
 
 impl<D: AddressCacheDatabase> AddressCache<D> {
-    pub fn new(database: D) -> AddressCache<D> {
-        AddressCache {
-            inner: RwLock::new(AddressCacheInner::new(database)),
-        }
+    pub fn new(database: D) -> Result<AddressCache<D>, WatchOnlyError<D::Error>> {
+        Ok(AddressCache {
+            inner: RwLock::new(AddressCacheInner::new(database)?),
+        })
     }
 
     pub fn get_utxo(&self, outpoint: &OutPoint) -> Option<TxOut> {
@@ -620,17 +653,14 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
             .collect()
     }
 
-    pub fn bump_height(&self, height: u32) {
+    pub fn bump_height(&self, height: u32) -> Result<(), WatchOnlyError<D::Error>> {
         let inner = self.inner.read().expect("poisoned lock");
-        inner
-            .database
-            .set_cache_height(height)
-            .expect("Database is not working");
+        Ok(inner.database.set_cache_height(height)?)
     }
 
-    pub fn get_cache_height(&self) -> u32 {
+    pub fn get_cache_height(&self) -> Result<u32, WatchOnlyError<D::Error>> {
         let inner = self.inner.read().expect("poisoned lock");
-        inner.database.get_cache_height().unwrap_or(0)
+        Ok(inner.database.get_cache_height()?)
     }
 
     /// Tells whether or not a descriptor is already cached
@@ -672,7 +702,11 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         inner.setup()
     }
 
-    pub fn block_process(&self, block: &Block, height: u32) -> Vec<(Transaction, TxOut)> {
+    pub fn block_process(
+        &self,
+        block: &Block,
+        height: u32,
+    ) -> Result<Vec<(Transaction, TxOut)>, WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.block_process(block, height)
     }
@@ -713,7 +747,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
             .map_err(WatchOnlyError::DatabaseError)
     }
 
-    pub fn maybe_derive_addresses(&self) {
+    pub fn maybe_derive_addresses(&self) -> Result<(), WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.maybe_derive_addresses()
     }
@@ -723,17 +757,24 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         inner.find_unconfirmed()
     }
 
-    pub fn cache_address(&self, script_pk: ScriptBuf) {
+    pub fn cache_address(&self, script_pk: ScriptBuf) -> Result<(), WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.cache_address(script_pk)
     }
 
-    pub fn cache_mempool_transaction(&self, transaction: &Transaction) -> Vec<TxOut> {
+    pub fn cache_mempool_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<Vec<TxOut>, WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.cache_mempool_transaction(transaction)
     }
 
-    pub fn save_mempool_tx(&self, hash: Hash, transaction_to_cache: CachedTransaction) {
+    pub fn save_mempool_tx(
+        &self,
+        hash: Hash,
+        transaction_to_cache: CachedTransaction,
+    ) -> Result<(), WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.save_mempool_tx(hash, transaction_to_cache)
     }
@@ -746,7 +787,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         index: usize,
         hash: Hash,
         transaction_to_cache: CachedTransaction,
-    ) {
+    ) -> Result<(), WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.save_non_mempool_tx(
             transaction,
@@ -777,7 +818,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         index: usize,
         is_spend: bool,
         hash: sha256::Hash,
-    ) {
+    ) -> Result<(), WatchOnlyError<D::Error>> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.cache_transaction(
             transaction,
@@ -823,7 +864,7 @@ mod test {
     fn get_test_cache() -> AddressCache<SqliteDatabase> {
         let database = SqliteDatabase::new_ephemeral().unwrap();
 
-        AddressCache::new(database)
+        AddressCache::new(database).unwrap()
     }
 
     fn get_test_address() -> (Address<NetworkChecked>, sha256::Hash) {
@@ -846,7 +887,7 @@ mod test {
         // Should have no address before caching
         assert_eq!(cache.n_cached_addresses(), 0);
 
-        cache.cache_address(address.script_pubkey());
+        cache.cache_address(address.script_pubkey()).unwrap();
         // Assert we indeed have one cached address
         assert_eq!(cache.n_cached_addresses(), 1);
         assert_eq!(cache.get_address_balance(&script_hash), Some(0));
@@ -868,16 +909,18 @@ mod test {
         let (_, script_hash) = get_test_address();
         let cache = get_test_cache();
 
-        cache.cache_transaction(
-            &transaction,
-            118511,
-            transaction.output[0].value.to_sat(),
-            merkle_block,
-            1,
-            0,
-            false,
-            get_spk_hash(&transaction.output[0].script_pubkey),
-        );
+        cache
+            .cache_transaction(
+                &transaction,
+                118511,
+                transaction.output[0].value.to_sat(),
+                merkle_block,
+                1,
+                0,
+                false,
+                get_spk_hash(&transaction.output[0].script_pubkey),
+            )
+            .unwrap();
 
         assert_eq!(
             script_hash,
@@ -931,16 +974,18 @@ mod test {
         let transaction = Vec::from_hex(transaction).unwrap();
         let transaction = deserialize(&transaction).unwrap();
 
-        cache.cache_transaction(
-            &transaction,
-            0,
-            transaction.output[1].value.to_sat(),
-            MerkleProof::default(),
-            2,
-            1,
-            false,
-            get_spk_hash(&transaction.output[1].script_pubkey),
-        );
+        cache
+            .cache_transaction(
+                &transaction,
+                0,
+                transaction.output[1].value.to_sat(),
+                MerkleProof::default(),
+                2,
+                1,
+                false,
+                get_spk_hash(&transaction.output[1].script_pubkey),
+            )
+            .unwrap();
 
         assert_eq!(
             cache.find_unconfirmed().unwrap()[0].compute_txid(),
@@ -952,11 +997,11 @@ mod test {
     fn test_process_block() {
         let (address, script_hash) = get_test_address();
         let cache = get_test_cache();
-        cache.cache_address(address.script_pubkey());
+        cache.cache_address(address.script_pubkey()).unwrap();
 
         let block = "000000203ea734fa2c8dee7d3194878c9eaf6e83a629f79b3076ec857793995e01010000eb99c679c0305a1ac0f5eb2a07a9f080616105e605b92b8c06129a2451899225ab5481633c4b011e0b26720102020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0403efce01feffffff026ef2052a01000000225120a1a1b1376d5165617a50a6d2f59abc984ead8a92df2b25f94b53dbc2151824730000000000000000776a24aa21a9ed1b4c48a7220572ff3ab3d2d1c9231854cb62542fbb1e0a4b21ebbbcde8d652bc4c4fecc7daa2490047304402204b37c41fce11918df010cea4151737868111575df07f7f2945d372e32a6d11dd02201658873a8228d7982df6bdbfff5d0cad1d6f07ee400e2179e8eaad8d115b7ed001000120000000000000000000000000000000000000000000000000000000000000000000000000020000000001017ca523c5e6df0c014e837279ab49be1676a9fe7571c3989aeba1e5d534f4054a0000000000fdffffff01d2410f00000000001600142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a02473044022071b8583ba1f10531b68cb5bd269fb0e75714c20c5a8bce49d8a2307d27a082df022069a978dac00dd9d5761aa48c7acc881617fa4d2573476b11685596b17d437595012103b193d06bd0533d053f959b50e3132861527e5a7a49ad59c5e80a265ff6a77605eece0100";
         let block = deserialize(&Vec::from_hex(block).unwrap()).unwrap();
-        cache.block_process(&block, 118511);
+        cache.block_process(&block, 118511).unwrap();
 
         let balance = cache.get_address_balance(&script_hash);
         let history = cache.get_address_history(&script_hash).unwrap();
@@ -980,8 +1025,8 @@ mod test {
         // TESTS FOR SMALL HELPER FUNCTIONS
 
         // [bump_height], [get_cache_height], [set_cache_height]
-        cache.bump_height(118511);
-        assert_eq!(cache.get_cache_height(), 118511);
+        cache.bump_height(118511).unwrap();
+        assert_eq!(cache.get_cache_height().unwrap(), 118511);
 
         // [is_cached], [push_descriptor]
         let desc = "wsh(sortedmulti(1,[54ff5a12/48h/1h/0h/2h]tpubDDw6pwZA3hYxcSN32q7a5ynsKmWr4BbkBNHydHPKkM4BZwUfiK7tQ26h7USm8kA1E2FvCy7f7Er7QXKF8RNptATywydARtzgrxuPDwyYv4x/<0;1>/*,[bcf969c0/48h/1h/0h/2h]tpubDEFdgZdCPgQBTNtGj4h6AehK79Jm4LH54JrYBJjAtHMLEAth7LuY87awx9ZMiCURFzFWhxToRJK6xp39aqeJWrG5nuW3eBnXeMJcvDeDxfp/<0;1>/*))#fuw35j0q";
@@ -1003,10 +1048,10 @@ mod test {
         let script_hash = get_spk_hash(&spk);
         let cache = get_test_cache();
 
-        cache.cache_address(spk);
+        cache.cache_address(spk).unwrap();
 
-        cache.block_process(&block1, 118511);
-        cache.block_process(&block2, 118509);
+        cache.block_process(&block1, 118511).unwrap();
+        cache.block_process(&block2, 118509).unwrap();
 
         let address = cache.inner.read().unwrap();
         let address = address.address_map.get(&script_hash).unwrap();

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -4,7 +4,7 @@
 //! volatile, and all data is lost after the database is dropped or the process is terminated.
 //! It's not meant to use in production, but for the integrated testing framework
 //!
-//! For actual databases that can be used for production code, see [KvDatabase](crate::kv_database::KvDatabase).
+//! For actual databases that can be used for production code, see [SqliteDatabase](crate::sqlite_database::SqliteDatabase).
 use bitcoin::hashes::sha256;
 use bitcoin::Txid;
 use floresta_common::prelude::sync::RwLock;

--- a/crates/floresta-watch-only/src/sqlite_database.rs
+++ b/crates/floresta-watch-only/src/sqlite_database.rs
@@ -1,0 +1,631 @@
+//! A SQLite-based database for the watch-only wallet.
+//!
+//! This module provides both a persistent and a ephemeral storage implementation using SQLite via rusqlite.
+//!
+//! It implements the [`AddressCacheDatabase`] trait to store addresses, transactions,
+//! descriptors, and wallet statistics.
+
+use std::error::Error;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::sync::Mutex;
+use std::sync::PoisonError;
+
+use bitcoin::consensus;
+use bitcoin::consensus::deserialize;
+use bitcoin::consensus::encode;
+use bitcoin::hashes::Hash as HashTrait;
+use bitcoin::OutPoint;
+use bitcoin::ScriptBuf;
+use bitcoin::Txid;
+use floresta_common::impl_error_from;
+use floresta_common::prelude;
+use floresta_common::prelude::*;
+use rusqlite::params;
+use rusqlite::types::Type;
+use rusqlite::Connection;
+use rusqlite::Error as SqliteError;
+
+use super::merkle::MerkleProof;
+use super::AddressCacheDatabase;
+use super::CachedAddress;
+use super::CachedTransaction;
+use super::Stats;
+
+/// Addresses table keyed by script hash, storing balance, script, associated transactions and UTXOs.
+const CREATE_ADDRESSES: &str = "
+    CREATE TABLE IF NOT EXISTS addresses (
+        script_hash BLOB PRIMARY KEY,
+        balance INTEGER NOT NULL,
+        script BLOB NOT NULL,
+        transactions BLOB NOT NULL,
+        utxos BLOB NOT NULL
+    );";
+
+/// Transactions table keyed by txid, storing the raw transaction, block height, merkle proof and position.
+const CREATE_TRANSACTIONS: &str = "
+    CREATE TABLE IF NOT EXISTS transactions (
+        txid BLOB PRIMARY KEY,
+        tx BLOB NOT NULL,
+        height INTEGER NOT NULL,
+        merkle_block BLOB,
+        position INTEGER NOT NULL
+    );";
+
+/// Descriptors table storing unique output descriptor strings.
+const CREATE_DESCRIPTORS: &str = "
+    CREATE TABLE IF NOT EXISTS descriptors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        descriptor TEXT NOT NULL UNIQUE
+    );";
+
+/// Singleton stats table (enforced by `CHECK (id = 0)`) holding aggregate wallet statistics.
+const CREATE_STATS: &str = "
+    CREATE TABLE IF NOT EXISTS stats (
+        id INTEGER PRIMARY KEY CHECK (id = 0),
+        address_count INTEGER NOT NULL,
+        transaction_count INTEGER NOT NULL,
+        utxo_count INTEGER NOT NULL,
+        cache_height INTEGER NOT NULL,
+        txo_count INTEGER NOT NULL,
+        balance INTEGER NOT NULL,
+        derivation_index INTEGER NOT NULL
+    );";
+
+/// Metadata sql table that holds some wallet extra info.
+const CREATE_METADATA: &str = "
+    CREATE TABLE IF NOT EXISTS metadata (
+        key TEXT PRIMARY KEY,
+        value BLOB NOT NULL
+    );";
+
+/// Holds all table definitions inside an array.
+const SQL_TABLES: &[&str] = &[
+    CREATE_ADDRESSES,
+    CREATE_TRANSACTIONS,
+    CREATE_DESCRIPTORS,
+    CREATE_STATS,
+    CREATE_METADATA,
+];
+
+/// A SQLite-backed database for the watch-only wallet.
+pub struct SqliteDatabase {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteDatabase {
+    /// Creates a new SQLite database at the given path.
+    ///
+    /// This will create the database file if it doesn't exist and initialize
+    /// all required tables.
+    pub fn new(path: &str) -> Result<Self> {
+        let conn = Connection::open(format!("{path}/wallet.sqlite3"))?;
+        let conn = Mutex::new(conn);
+        let db = SqliteDatabase { conn };
+        db.init_tables()?;
+        Ok(db)
+    }
+
+    /// Creates a new in-memory SQLite database.
+    ///
+    /// Useful for testing purposes since all data is kept in memory and
+    /// lost after dropping the instance.
+    pub fn new_ephemeral() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let conn = Mutex::new(conn);
+        let db = SqliteDatabase { conn };
+        db.init_tables()?;
+        Ok(db)
+    }
+
+    /// Initialize all required tables.
+    fn init_tables(&self) -> Result<()> {
+        let conn = self.conn.lock()?;
+        for table in SQL_TABLES {
+            conn.execute_batch(table)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn to_conv_error(index: usize) -> SqliteError {
+        SqliteError::FromSqlConversionFailure(
+            index,
+            Type::Blob,
+            Box::new(SqliteDatabaseError::CorruptedData),
+        )
+    }
+
+    pub(super) fn hash_from_slice<T: HashTrait>(bytes: &[u8], index: usize) -> rusqlite::Result<T> {
+        T::from_slice(bytes).map_err(|_| Self::to_conv_error(index))
+    }
+
+    fn decode_txids_blob(bytes: &[u8], col: usize) -> rusqlite::Result<Vec<Txid>> {
+        if bytes.len() % 32 != 0 {
+            return Err(SqliteDatabase::to_conv_error(col));
+        }
+
+        let decode_txid = |chunk| SqliteDatabase::hash_from_slice(chunk, col);
+
+        bytes.chunks_exact(32).map(decode_txid).collect()
+    }
+
+    fn decode_outpoints_blob(bytes: &[u8], col: usize) -> rusqlite::Result<Vec<OutPoint>> {
+        if bytes.len() % 36 != 0 {
+            return Err(SqliteDatabase::to_conv_error(col));
+        }
+
+        let decode_outpoint = |chunk: &[u8]| {
+            let txid: Txid = SqliteDatabase::hash_from_slice(&chunk[..32], col)?;
+            let vout = u32::from_le_bytes(chunk[32..36].try_into().expect("4 bytes"));
+            Ok(OutPoint { txid, vout })
+        };
+
+        bytes.chunks_exact(36).map(decode_outpoint).collect()
+    }
+}
+
+#[derive(Debug)]
+pub enum SqliteDatabaseError {
+    /// Error from rusqlite
+    Sqlite(rusqlite::Error),
+
+    /// Error deserializing Bitcoin consensus data
+    ConsensusEncoding(encode::Error),
+
+    /// Wallet has not been initialized
+    WalletNotInitialized,
+
+    /// Transaction was not found in the database
+    TransactionNotFound,
+
+    /// Mutex was poisoned (a thread panicked while holding the lock)
+    MutexPoisoned,
+
+    /// We tried to parse a `Vec<u8>` into a type and it failed.
+    CorruptedData,
+}
+
+impl_error_from!(SqliteDatabaseError, rusqlite::Error, Sqlite);
+impl_error_from!(SqliteDatabaseError, encode::Error, ConsensusEncoding);
+
+impl Display for SqliteDatabaseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SqliteDatabaseError::Sqlite(e) => write!(f, "SQLite error: {e}"),
+            SqliteDatabaseError::ConsensusEncoding(e) => {
+                write!(f, "Consensus deserialization error: {e}")
+            }
+            SqliteDatabaseError::WalletNotInitialized => write!(f, "Wallet not initialized"),
+            SqliteDatabaseError::TransactionNotFound => write!(f, "Transaction not found"),
+            SqliteDatabaseError::MutexPoisoned => write!(f, "Mutex poisoned"),
+            SqliteDatabaseError::CorruptedData => write!(f, "Corrupted Data"),
+        }
+    }
+}
+
+impl<T> From<PoisonError<T>> for SqliteDatabaseError {
+    fn from(_: PoisonError<T>) -> Self {
+        SqliteDatabaseError::MutexPoisoned
+    }
+}
+
+impl Error for SqliteDatabaseError {}
+
+type Result<T> = prelude::Result<T, SqliteDatabaseError>;
+
+impl AddressCacheDatabase for SqliteDatabase {
+    type Error = SqliteDatabaseError;
+
+    fn load(&self) -> Result<Vec<CachedAddress>> {
+        let conn = self.conn.lock()?;
+        let mut stmt = conn
+            .prepare("SELECT script_hash, balance, script, transactions, utxos FROM addresses")?;
+
+        let rows = stmt.query_map([], |row| {
+            let script_hash: Vec<u8> = row.get(0)?;
+            let script_hash = Self::hash_from_slice(&script_hash, 0)?;
+
+            let balance: i64 = row.get(1)?;
+            let script: Vec<u8> = row.get(2)?;
+
+            let txids_blob: Vec<u8> = row.get(3)?;
+            let transactions = Self::decode_txids_blob(&txids_blob, 3)?;
+
+            let utxos_blob: Vec<u8> = row.get(4)?;
+            let utxos = Self::decode_outpoints_blob(&utxos_blob, 4)?;
+
+            let script = deserialize(&script).map_err(|e| -> SqliteError {
+                SqliteError::FromSqlConversionFailure(2, Type::Blob, Box::new(e))
+            })?;
+
+            Ok(CachedAddress {
+                script_hash,
+                balance: balance as u64,
+                script,
+                transactions,
+                utxos,
+            })
+        })?;
+
+        Ok(rows.collect::<rusqlite::Result<_>>()?)
+    }
+
+    fn save(&self, address: &CachedAddress) -> Result<()> {
+        let script_hash = address.script_hash.as_byte_array().to_vec();
+        let balance = address.balance as i64;
+        let script = consensus::serialize(&address.script);
+        let mut tx_buf = Vec::with_capacity(address.transactions.len() * 32);
+
+        for txid in &address.transactions {
+            tx_buf.extend_from_slice(txid.as_byte_array());
+        }
+
+        let transactions = tx_buf;
+
+        let mut utxo_buf = Vec::with_capacity(address.utxos.len() * 36);
+        for op in &address.utxos {
+            utxo_buf.extend_from_slice(op.txid.as_byte_array());
+
+            utxo_buf.extend_from_slice(&op.vout.to_le_bytes());
+        }
+
+        let utxos = utxo_buf;
+
+        self.conn.lock()?.execute(
+            "INSERT OR REPLACE INTO addresses (script_hash, balance, script, transactions, utxos)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![script_hash, balance, script, transactions, utxos],
+        )?;
+
+        Ok(())
+    }
+
+    fn update(&self, address: &CachedAddress) -> Result<()> {
+        self.save(address)
+    }
+
+    fn get_cache_height(&self) -> Result<u32> {
+        let conn = self.conn.lock()?;
+        let result: std::result::Result<i64, _> = conn.query_row(
+            "SELECT value FROM metadata WHERE key = 'height'",
+            [],
+            |row| row.get(0),
+        );
+
+        match result {
+            Ok(height) => Ok(height as u32),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                Err(SqliteDatabaseError::WalletNotInitialized)
+            }
+            Err(e) => Err(SqliteDatabaseError::Sqlite(e)),
+        }
+    }
+
+    fn set_cache_height(&self, height: u32) -> Result<()> {
+        self.conn.lock()?.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('height', ?1)",
+            params![height as i64],
+        )?;
+        Ok(())
+    }
+
+    fn desc_save(&self, descriptor: &str) -> Result<()> {
+        self.conn.lock()?.execute(
+            "INSERT OR IGNORE INTO descriptors (descriptor) VALUES (?1)",
+            params![descriptor],
+        )?;
+        Ok(())
+    }
+
+    fn descs_get(&self) -> Result<Vec<String>> {
+        let conn = self.conn.lock()?;
+
+        let mut stmt = conn.prepare("SELECT descriptor FROM descriptors")?;
+
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    fn get_transaction(&self, txid: &Txid) -> Result<CachedTransaction> {
+        let txid_bytes = txid.as_byte_array().to_vec();
+
+        let conn = self.conn.lock()?;
+
+        let result = conn.query_row(
+            "SELECT txid, tx, height, merkle_block, position FROM transactions WHERE txid = ?1",
+            params![txid_bytes],
+            |row| {
+                let hash: Vec<u8> = row.get(0)?;
+                let tx: Vec<u8> = row.get(1)?;
+                let height: i64 = row.get(2)?;
+                let merkle_block: Option<Vec<u8>> = row.get(3)?;
+                let position: i64 = row.get(4)?;
+                Ok((hash, tx, height, merkle_block, position))
+            },
+        );
+
+        match result {
+            Ok((hash, tx, height, merkle_block, position)) => Ok(CachedTransaction {
+                hash: Txid::from_byte_array(
+                    hash.try_into()
+                        .map_err(|_| SqliteDatabaseError::CorruptedData)?,
+                ),
+                tx: consensus::deserialize(&tx)?,
+                height: height as u32,
+                merkle_block: merkle_block
+                    .map(|mb| consensus::deserialize::<MerkleProof>(&mb))
+                    .transpose()?,
+                position: position as u32,
+            }),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                Err(SqliteDatabaseError::TransactionNotFound)
+            }
+            Err(e) => Err(SqliteDatabaseError::Sqlite(e)),
+        }
+    }
+
+    fn save_transaction(&self, tx: &CachedTransaction) -> Result<()> {
+        let txid_bytes = tx.hash.as_byte_array().to_vec();
+
+        let tx_bytes = consensus::serialize(&tx.tx);
+
+        let height = tx.height as i64;
+
+        let merkle_block = tx.merkle_block.as_ref().map(consensus::serialize);
+
+        let position = tx.position as i64;
+
+        self.conn.lock()?.execute(
+            "INSERT OR REPLACE INTO transactions (txid, tx, height, merkle_block, position)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![txid_bytes, tx_bytes, height, merkle_block, position],
+        )?;
+        Ok(())
+    }
+
+    fn get_stats(&self) -> Result<Stats> {
+        let conn = self.conn.lock()?;
+        let result = conn.query_row(
+            "SELECT address_count, transaction_count, utxo_count, cache_height,
+                    txo_count, balance, derivation_index
+             FROM stats WHERE id = 0",
+            [],
+            |row| {
+                Ok(Stats {
+                    address_count: row.get::<_, i64>(0)? as usize,
+                    transaction_count: row.get::<_, i64>(1)? as usize,
+                    utxo_count: row.get::<_, i64>(2)? as usize,
+                    cache_height: row.get::<_, i64>(3)? as u32,
+                    txo_count: row.get::<_, i64>(4)? as usize,
+                    balance: row.get::<_, i64>(5)? as u64,
+                    derivation_index: row.get::<_, i64>(6)? as u32,
+                })
+            },
+        );
+
+        match result {
+            Ok(stats) => Ok(stats),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                Err(SqliteDatabaseError::WalletNotInitialized)
+            }
+            Err(e) => Err(SqliteDatabaseError::Sqlite(e)),
+        }
+    }
+
+    fn save_stats(&self, stats: &Stats) -> Result<()> {
+        self.conn.lock()?.execute(
+            "INSERT OR REPLACE INTO stats
+             (id, address_count, transaction_count, utxo_count, cache_height,
+              txo_count, balance, derivation_index)
+             VALUES (0, ?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                stats.address_count as i64,
+                stats.transaction_count as i64,
+                stats.utxo_count as i64,
+                stats.cache_height as i64,
+                stats.txo_count as i64,
+                stats.balance as i64,
+                stats.derivation_index as i64,
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn list_transactions(&self) -> Result<Vec<Txid>> {
+        let conn = self.conn.lock()?;
+        let mut stmt = conn.prepare("SELECT txid FROM transactions")?;
+
+        let rows = stmt.query_map([], |row| {
+            let bytes: Vec<u8> = row.get(0)?;
+            Self::hash_from_slice(&bytes, 0)
+        })?;
+
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::str::FromStr;
+    use std::fs::create_dir;
+    use std::path::PathBuf;
+
+    use bitcoin::address::NetworkChecked;
+    use bitcoin::consensus::deserialize;
+    use bitcoin::consensus::Decodable;
+    use bitcoin::hashes::hex::FromHex;
+    use bitcoin::hashes::sha256;
+    use bitcoin::hashes::Hash;
+    use bitcoin::Address;
+    use bitcoin::OutPoint;
+    use bitcoin::Transaction;
+    use bitcoin::Txid;
+    use floresta_common::get_spk_hash;
+
+    use super::SqliteDatabase;
+    use crate::merkle::MerkleProof;
+    use crate::AddressCacheDatabase;
+    use crate::CachedAddress;
+    use crate::CachedTransaction;
+    use crate::Stats;
+
+    fn deserialize_from_str<T: Decodable>(thing: &str) -> T {
+        let hex = Vec::from_hex(thing).unwrap();
+        deserialize(&hex).unwrap()
+    }
+
+    fn get_test_db() -> SqliteDatabase {
+        SqliteDatabase::new_ephemeral().unwrap()
+    }
+
+    fn get_test_address() -> (Address<NetworkChecked>, sha256::Hash) {
+        let address = Address::from_str("tb1q9d4zjf92nvd3zhg6cvyckzaqumk4zre26x02q9")
+            .unwrap()
+            .assume_checked();
+        let script_hash = get_spk_hash(&address.script_pubkey());
+        (address, script_hash)
+    }
+
+    #[test]
+    fn test_meta_getset() {
+        let db = get_test_db();
+
+        // Test stats
+        let stats = Stats {
+            address_count: 12,
+            transaction_count: 21,
+            utxo_count: 12,
+            cache_height: 21,
+            txo_count: 12,
+            balance: 21,
+            derivation_index: 12,
+        };
+
+        db.save_stats(&stats).unwrap();
+        assert_eq!(db.get_stats().unwrap(), stats);
+
+        // Test cache height
+        let test_height: u32 = rand::random();
+
+        db.set_cache_height(test_height).unwrap();
+        assert_eq!(db.get_cache_height().unwrap(), test_height);
+    }
+
+    #[test]
+    fn test_persistence() {
+        let path = env!("CARGO_MANIFEST_DIR").to_owned() + "/tmp-db";
+        if !PathBuf::from(&path).exists() {
+            create_dir(&path).unwrap()
+        };
+
+        let db = SqliteDatabase::new(&path).unwrap();
+        let descriptor_string = "wsh(sortedmulti(1,[54ff5a12/48h/1h/0h/2h]tpubDDw6pwZA3hYxcSN32q7a5ynsKmWr4BbkBNHydHPKkM4BZwUfiK7tQ26h7USm8kA1E2FvCy7f7Er7QXKF8RNptATywydARtzgrxuPDwyYv4x/<0;1>/*,[bcf969c0/48h/1h/0h/2h]tpubDEFdgZdCPgQBTNtGj4h6AehK79Jm4LH54JrYBJjAtHMLEAth7LuY87awx9ZMiCURFzFWhxToRJK6xp39aqeJWrG5nuW3eBnXeMJcvDeDxfp/<0;1>/*))#fuw35j0q".to_owned();
+
+        db.desc_save(&descriptor_string).unwrap();
+        // Kill db
+        drop(db);
+
+        let db_new = SqliteDatabase::new(&path).unwrap();
+
+        assert_eq!(db_new.descs_get().unwrap(), vec![descriptor_string]);
+
+        drop(db_new);
+        std::fs::remove_dir_all(&path).unwrap();
+    }
+
+    #[test]
+    fn test_desc_getsetlist() {
+        let db = get_test_db();
+
+        // Test descriptors
+        let desc = "wsh(sortedmulti(1,[54ff5a12/48h/1h/0h/2h]tpubDDw6pwZA3hYxcSN32q7a5ynsKmWr4BbkBNHydHPKkM4BZwUfiK7tQ26h7USm8kA1E2FvCy7f7Er7QXKF8RNptATywydARtzgrxuPDwyYv4x/<0;1>/*,[bcf969c0/48h/1h/0h/2h]tpubDEFdgZdCPgQBTNtGj4h6AehK79Jm4LH54JrYBJjAtHMLEAth7LuY87awx9ZMiCURFzFWhxToRJK6xp39aqeJWrG5nuW3eBnXeMJcvDeDxfp/<0;1>/*))#fuw35j0q";
+
+        db.desc_save(desc).unwrap();
+        assert_eq!(db.descs_get().unwrap(), vec![desc]);
+
+        // Should ignore desc, we should already have it.
+        db.desc_save(desc).unwrap();
+        assert_eq!(db.descs_get().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_addr_getset() {
+        let db = get_test_db();
+
+        // Test addresses
+        let (address, script_hash) = get_test_address();
+
+        let cache_address = CachedAddress {
+            script_hash,
+            balance: 21,
+            script: address.script_pubkey(),
+            transactions: vec![Txid::all_zeros()],
+            utxos: vec![OutPoint::new(Txid::all_zeros(), 42)],
+        };
+
+        db.save(&cache_address).unwrap();
+
+        let load = db.load().unwrap();
+        assert_eq!(load[0], cache_address);
+
+        let mut updated_address = cache_address.clone();
+        updated_address.balance = 1000;
+
+        db.update(&updated_address).unwrap();
+
+        let new_load = db.load().unwrap();
+
+        assert_eq!(new_load[0], updated_address);
+    }
+
+    #[test]
+    /// Test asserting transactiong get, set
+    fn test_transaction_getsetlist() {
+        let db = get_test_db();
+
+        // Test transactions
+        let transaction = "020000000001017ca523c5e6df0c014e837279ab49be1676a9fe7571c3989aeba1e5d534f4054a0000000000fdffffff01d2410f00000000001600142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a02473044022071b8583ba1f10531b68cb5bd269fb0e75714c20c5a8bce49d8a2307d27a082df022069a978dac00dd9d5761aa48c7acc881617fa4d2573476b11685596b17d437595012103b193d06bd0533d053f959b50e3132861527e5a7a49ad59c5e80a265ff6a77605eece0100";
+        let transaction: Transaction = deserialize_from_str(transaction);
+
+        let merkle_block = "0100000000000000ea530307089e3e6f6e8997a0ae48e1dc2bee84635bc4e6c6ecdcc7225166b06b010000000000000034086ef398efcdec47b37241221c8f4613e02bc31026cc74d07ddb3092e6d6e7";
+        let merkle_block: MerkleProof = deserialize_from_str(merkle_block);
+
+        let cache_tx = CachedTransaction {
+            tx: transaction.clone(),
+            height: 118511,
+            merkle_block: Some(merkle_block),
+            hash: transaction.compute_txid(),
+            position: 1,
+        };
+
+        db.save_transaction(&cache_tx).unwrap();
+
+        let wrong_txid = bitcoin::Txid::all_zeros();
+        assert!(db.get_transaction(&wrong_txid).is_err());
+
+        let correct_txid = cache_tx.tx.compute_txid();
+        assert_eq!(db.get_transaction(&correct_txid).unwrap(), cache_tx);
+
+        assert_eq!(db.list_transactions().unwrap(), vec![correct_txid]);
+    }
+
+    #[test]
+    /// Test call behavior when called on a freshly created wallet
+    fn test_wallet_not_initialized() {
+        let db = get_test_db();
+        let expected_err = "Wallet not initialized";
+
+        assert_eq!(
+            db.get_cache_height().err().unwrap().to_string(),
+            expected_err
+        );
+
+        assert_eq!(db.get_stats().err().unwrap().to_string(), expected_err);
+
+        assert_eq!(db.descs_get().unwrap(), Vec::<String>::new());
+
+        assert_eq!(db.list_transactions().unwrap(), Vec::<Txid>::new());
+    }
+}

--- a/crates/floresta-watch-only/src/sqlite_database.rs
+++ b/crates/floresta-watch-only/src/sqlite_database.rs
@@ -17,7 +17,6 @@ use bitcoin::consensus::deserialize;
 use bitcoin::consensus::encode;
 use bitcoin::hashes::Hash as HashTrait;
 use bitcoin::OutPoint;
-use bitcoin::ScriptBuf;
 use bitcoin::Txid;
 use floresta_common::impl_error_from;
 use floresta_common::prelude;

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { workspace = true }
 # Local dependencies
 floresta = { path = "../floresta", features = [
     "bitcoinkernel",
-    "memory-database",
+    "sqlite",
     "electrum-server",
     "watch-only-wallet",
 ] }
@@ -51,7 +51,7 @@ electrum-server = ["dep:floresta-electrum"]
 bitcoinkernel = ["floresta-chain/bitcoinkernel"]
 watch-only-wallet = ["dep:floresta-watch-only"]
 # Works only if `watch-only-wallet` is set
-memory-database = ["floresta-watch-only?/memory-database"]
+sqlite = ["floresta-watch-only?/sqlite"]
 flat-chainstore = ["floresta-chain/flat-chainstore"]
 
 [lib]

--- a/crates/floresta/examples/watch-only.rs
+++ b/crates/floresta/examples/watch-only.rs
@@ -6,7 +6,7 @@ use bitcoin::consensus::deserialize;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::ScriptBuf;
 use floresta_common::get_spk_hash;
-use floresta_watch_only::memory_database::MemoryDatabase;
+use floresta_watch_only::sqlite_database::SqliteDatabase;
 use floresta_watch_only::AddressCache;
 use miniscript::bitcoin::secp256k1::Secp256k1;
 use miniscript::Descriptor;

--- a/crates/floresta/examples/watch-only.rs
+++ b/crates/floresta/examples/watch-only.rs
@@ -12,10 +12,11 @@ use miniscript::bitcoin::secp256k1::Secp256k1;
 use miniscript::Descriptor;
 
 fn main() {
-    // First, we need some place to store the wallet data. Here, we use an in-memory database,
-    // that will be destroyed when the program exits. You can use any database that implements
-    // the `AddressCacheDatabase` trait.
-    let wallet_data = MemoryDatabase::new();
+    // First, we need some place to store the wallet data. Here, we use a local path for simplicity,
+    // but in production the wallet db should be placed inside the node's datadir. You can use any
+    // database that implements the `AddressCacheDatabase` trait.
+    let wallet_data = SqliteDatabase::new("./wallet_db").unwrap();
+
     // Then, we create the wallet itself.
     let wallet = AddressCache::new(wallet_data);
     // Now, we need to add the addresses we want to watch. We can add them one by one, or
@@ -36,15 +37,17 @@ fn main() {
     // We can now add the descriptor to the wallet. This will generate the first 100 addresses
     // for us, and add them to the wallet.
     for i in 0..100 {
-        wallet.cache_address(bitcoin::ScriptBuf::from(
-            descriptor
-                .at_derivation_index(i)
-                .unwrap()
-                .explicit_script()
-                .unwrap()
-                .as_bytes()
-                .to_vec(),
-        ));
+        wallet
+            .cache_address(ScriptBuf::from(
+                descriptor
+                    .at_derivation_index(i)
+                    .unwrap()
+                    .explicit_script()
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            ))
+            .unwrap();
     }
     // We can now process some blocks. Here, we process the first 11 blocks of a custom
     // regtest network. Each coinbase some of the addresses derived above.

--- a/crates/floresta/examples/watch-only.rs
+++ b/crates/floresta/examples/watch-only.rs
@@ -18,7 +18,7 @@ fn main() {
     let wallet_data = SqliteDatabase::new("./wallet_db").unwrap();
 
     // Then, we create the wallet itself.
-    let wallet = AddressCache::new(wallet_data);
+    let wallet = AddressCache::new(wallet_data).unwrap();
     // Now, we need to add the addresses we want to watch. We can add them one by one, or
     // we can add a descriptor that will generate the addresses for us. Here, we use a
     // descriptor that generates P2WPKH addresses. The descriptor is parsed using the
@@ -53,7 +53,9 @@ fn main() {
     // regtest network. Each coinbase some of the addresses derived above.
     for block in BLOCKS.iter() {
         let block = Vec::from_hex(block).unwrap();
-        let _ = wallet.block_process(&deserialize(&block).unwrap(), 1);
+        wallet
+            .block_process(&deserialize(&block).unwrap(), 1)
+            .unwrap();
     }
     // We can now query the wallet for information about the addresses we added. For example,
     // we can get the history of the second address, the balance, and the UTXOs. To fetch the


### PR DESCRIPTION
### Description and Notes

Addressing https://github.com/getfloresta/Floresta/issues/665, I implemented the existing `AddressCacheDatabase` trait on top of [`rusqlite`](https://crates.io/crates/rusqlite), the only feature that the changes present is "bundled" which they declared to be better when regarding windows support.

Regarding the implementation, it is pretty straightforward, I had the other two databases, `memmory_database.rs` and `kv_database.rs` to be inspired. I think the tests are extensive and ensure the implementation runs fine, for every commit I made sure for `just lint-features` and `just test-feature` to also run fine.

### How to verify the changes you have done?

Review tests under `sqlite_database.rs` and run them.

Since this present a lot of features changes, running `just lint-features` and `just test-feature` is good.

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
