### PR TITLE
add ci workflow for peripheral code linting

### DIFF
--- a/.github/workflows/peripheral-lint.yml
+++ b/.github/workflows/peripheral-lint.yml
@@ -1,0 +1,48 @@
+name: Peripheral Code Linting
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-peripheral:
+    runs-on: ubuntu-latest
+    name: Lint peripheral code (justfile, TOML, shell scripts)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Check and format justfile
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Check justfile formatting
+        run: just --fmt --check --unstable
+
+      # Check TOML files with taplo
+      - name: Install taplo
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+
+      - name: Check TOML formatting
+        run: |
+          taplo fmt --check Cargo.toml
+          taplo fmt --check pyproject.toml
+          taplo fmt --check .rustfmt.toml
+          taplo fmt --check typos.toml
+
+      # Check shell scripts with shellcheck
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Lint shell scripts
+        run: |
+          find contrib tests -name "*.sh" -type f | xargs shellcheck --severity=warning || true
+
+      # Check Dockerfile with hadolint
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,40 +1,40 @@
 [workspace]
 resolver = "2"
 members = [
-    # Libraries
-    "crates/floresta",
-    "crates/floresta-node",
-    "crates/floresta-chain",
-    "crates/floresta-rpc",
-    "crates/floresta-common",
-    "crates/floresta-compact-filters",
-    "crates/floresta-electrum",
-    "crates/floresta-watch-only",
-    "crates/floresta-wire",
-    "crates/floresta-mempool",
+  # Libraries
+  "crates/floresta",
+  "crates/floresta-node",
+  "crates/floresta-chain",
+  "crates/floresta-rpc",
+  "crates/floresta-common",
+  "crates/floresta-compact-filters",
+  "crates/floresta-electrum",
+  "crates/floresta-watch-only",
+  "crates/floresta-wire",
+  "crates/floresta-mempool",
 
-    # Binaries
-    "bin/florestad",
-    "bin/floresta-cli",
+  # Binaries
+  "bin/florestad",
+  "bin/floresta-cli",
 
-    # Tests and monitoring
-    "metrics",
-    "fuzz",
+  # Tests and monitoring
+  "metrics",
+  "fuzz",
 ]
 
 default-members = [
-    "crates/floresta",
-    "crates/floresta-node",
-    "crates/floresta-chain",
-    "crates/floresta-rpc",
-    "crates/floresta-common",
-    "crates/floresta-compact-filters",
-    "crates/floresta-electrum",
-    "crates/floresta-watch-only",
-    "crates/floresta-wire",
-    "crates/floresta-mempool",
-    "bin/florestad",
-    "bin/floresta-cli",
+  "crates/floresta",
+  "crates/floresta-node",
+  "crates/floresta-chain",
+  "crates/floresta-rpc",
+  "crates/floresta-common",
+  "crates/floresta-compact-filters",
+  "crates/floresta-electrum",
+  "crates/floresta-watch-only",
+  "crates/floresta-wire",
+  "crates/floresta-mempool",
+  "bin/florestad",
+  "bin/floresta-cli",
 ]
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:13.2-slim@sha256:18764e98673c3baf1a6f8d960b5b5a1ec69092049522abac4e2
 
 ARG BUILD_FEATURES=""
 
-RUN apt-get update && apt-get install -y \
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
     curl \
@@ -12,8 +13,10 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     pkg-config \
     libboost-all-dev \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup default 1.81.0

--- a/justfile
+++ b/justfile
@@ -1,12 +1,12 @@
 _default:
-  @just --list
+    @just --list
 
 # Checks whether a command is available.
 check-command cmd recipe="check-command" link_to_package="":
-    @if ! command -v "{{cmd}}" >/dev/null; then \
-        echo "Command '{{cmd}}' is not available, but 'just {{recipe}}' requires it." >&2; \
-        if [ -n "{{link_to_package}}" ]; then \
-            echo "This might help you: {{link_to_package}}" >&2; \
+    @if ! command -v "{{ cmd }}" >/dev/null; then \
+        echo "Command '{{ cmd }}' is not available, but 'just {{ recipe }}' requires it." >&2; \
+        if [ -n "{{ link_to_package }}" ]; then \
+            echo "This might help you: {{ link_to_package }}" >&2; \
         fi; \
         exit 1; \
     fi
@@ -33,17 +33,17 @@ clean:
 
 # Execute all tests
 test name="":
-    @just test-doc {{name}}
-    @just test-unit {{name}}
+    @just test-doc {{ name }}
+    @just test-unit {{ name }}
     @just test-wkspc
 
 # Execute doc tests
 test-doc name="":
-    cargo test {{name}} --doc
+    cargo test {{ name }} --doc
 
 # Execute unit tests
 test-unit name="":
-    cargo test --lib {{name}} -- --nocapture
+    cargo test --lib {{ name }} -- --nocapture
 
 # Execute workspace-related tests
 test-wkspc:
@@ -51,11 +51,11 @@ test-wkspc:
 
 # Execute tests/prepare.sh.
 test-functional-prepare arg="":
-    bash tests/prepare.sh {{arg}}
+    bash tests/prepare.sh {{ arg }}
 
 # Execute tests/run.sh
 test-functional-run arg="":
-    bash tests/run.sh {{arg}}
+    bash tests/run.sh {{ arg }}
 
 # Format and lint functional tests
 test-functional-uv-fmt:
@@ -112,7 +112,7 @@ format:
 # Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     @just check-command "cargo-hack" "test-features" "cargo install cargo-hack --locked --version 0.6.34"
-    ./contrib/feature_matrix.sh test {{arg}}
+    ./contrib/feature_matrix.sh test {{ arg }}
 
 # Format code and run clippy for all feature combinations in each crate (arg: optional, e.g., '-- -D warnings')
 lint-features arg="":
@@ -122,7 +122,7 @@ lint-features arg="":
     @just doc-check
     @just spell-check
 
-    ./contrib/feature_matrix.sh clippy '{{arg}}'
+    ./contrib/feature_matrix.sh clippy '{{ arg }}'
 
     @just test-functional-uv-fmt
 
@@ -140,10 +140,11 @@ pcc:
 
 # Must have pandoc installed
 # Needs sudo to overwrite existing man pages
+
 # Convert all markdown files on /doc/rpc/ to man pages on /doc/rpc_man/
 gen-manpages path="":
     @just check-command pandoc gen-manpages "https://pandoc.org/installing.html"
-    ./contrib/dist/gen_manpages.sh {{path}}
+    ./contrib/dist/gen_manpages.sh {{ path }}
 
 # Run typos
 spell-check:
@@ -155,16 +156,17 @@ spell-check:
 #   just install florestad         # installs only florestad
 #   just install floresta-cli      # installs only floresta-cli
 #
+
 # Floresta recipe to help installing the binaries without versioning problems.
 install bin="all":
-    if [ "{{bin}}" = "all" ]; then \
+    if [ "{{ bin }}" = "all" ]; then \
         cargo install --path bin/florestad --locked && \
         cargo install --path bin/floresta-cli --locked; \
-    elif [ "{{bin}}" = "florestad" ]; then \
+    elif [ "{{ bin }}" = "florestad" ]; then \
         cargo install --path bin/florestad --locked; \
-    elif [ "{{bin}}" = "floresta-cli" ]; then \
+    elif [ "{{ bin }}" = "floresta-cli" ]; then \
         cargo install --path bin/floresta-cli --locked; \
     else \
-        printf "Unknown binary: %s\n" "{{bin}}" >&2; \
+        printf "Unknown binary: %s\n" "{{ bin }}" >&2; \
         exit 1; \
     fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "black>=24.10.0",
   "pylint>=3.3.2",
   "cryptography>=44.0.2",
-  "pyOpenSSL>=25.0.0"
+  "pyOpenSSL>=25.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
adds github action to check formatting of justfile, toml files, shell scripts and dockerfile. runs on push and pull requests.

fixes #730

### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering, see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
