### PR TITLE
add data persistence volumes to docker-compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,77 @@
+# Docker Compose configuration for Floresta development
+# This file is designed for contributors who want to develop and test changes locally
+#
+# Features:
+# - Source code binding for hot-reloading with cargo-watch
+# - Environment variable support for different networks
+# - Named volumes for data persistence
+#
+# Usage:
+#   NETWORK=signet docker-compose -f docker-compose.dev.yml up
+#   docker-compose -f docker-compose.dev.yml up  # defaults to mainnet
+
+services:
+  floresta-dev:
+    container_name: floresta-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        BUILD_FEATURES: "metrics"
+    ports:
+      - "${RPC_PORT:-8332}:8332"
+      - "${ELECTRUM_PORT:-50001}:50001"
+      - "${METRICS_PORT:-3333}:3333"
+    environment:
+      - NETWORK=${NETWORK:-bitcoin}
+      - RUST_LOG=${RUST_LOG:-info}
+    volumes:
+      # Source code binding for development
+      - .:/app:cached
+      # Persistent data directory
+      - floresta_dev_data:/data/.floresta
+      # Cargo cache for faster builds
+      - cargo_cache:/usr/local/cargo/registry
+      - cargo_git_cache:/usr/local/cargo/git
+    working_dir: /app
+    # Override command to use cargo-watch for hot-reloading
+    # Uncomment the following line if you have cargo-watch installed in the image
+    # command: cargo watch -x 'run --bin florestad -- -n ${NETWORK:-bitcoin}'
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus-dev
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    restart: unless-stopped
+    volumes:
+      - ./metrics/prometheus:/etc/prometheus
+      - prometheus_dev_data:/prometheus
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana-dev
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-grafana}
+    volumes:
+      - ./metrics/grafana:/etc/grafana/provisioning/datasources
+      - grafana_dev_data:/var/lib/grafana
+
+volumes:
+  floresta_dev_data:
+    name: floresta_dev_data
+  prometheus_dev_data:
+    name: prometheus_dev_data
+  grafana_dev_data:
+    name: grafana_dev_data
+  cargo_cache:
+    name: floresta_cargo_cache
+  cargo_git_cache:
+    name: floresta_cargo_git_cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - 8332:8332
       - 3333:3333
     restart: unless-stopped
+    volumes:
+      - floresta_data:/data/.floresta
   prometheus:
     image: prom/prometheus
     container_name: prometheus
@@ -20,6 +22,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./metrics/prometheus:/etc/prometheus
+      - prometheus_data:/prometheus
   grafana:
     image: grafana/grafana
     container_name: grafana
@@ -31,3 +34,12 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=grafana
     volumes:
       - ./metrics/grafana:/etc/grafana/provisioning/datasources
+      - grafana_data:/var/lib/grafana
+
+volumes:
+  floresta_data:
+    name: floresta_data
+  prometheus_data:
+    name: prometheus_data
+  grafana_data:
+    name: grafana_data


### PR DESCRIPTION
added named volumes for floresta, prometheus and grafana data so it persists when containers restart. also added a docker-compose.dev.yml for development with source code binding.

fixes #795

### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering, see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
