### PR TITLE
docs: add documentation for RPC endpoints

### DIFF
--- a/doc/rpc/findtxout.md
+++ b/doc/rpc/findtxout.md
@@ -1,0 +1,48 @@
+# `findtxout`
+
+Searches for a specific UTXO in the blockchain using compact block filters.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli findtxout <txid> <vout> <script> [height_hint]
+```
+
+### Examples
+
+```bash
+floresta-cli findtxout "abc123..." 0 "76a914..."
+floresta-cli findtxout "abc123..." 1 "76a914..." 700000
+```
+
+## Arguments
+
+- `txid` - (string, required) The transaction ID containing the output.
+- `vout` - (numeric, required) The output index (0-based).
+- `script` - (string, required) The scriptPubKey of the output as a hex-encoded string.
+- `height_hint` - (numeric, optional, default=0) A block height hint to start searching from. Providing an accurate hint speeds up the search significantly.
+
+## Returns
+
+### Ok Response
+
+A JSON object containing:
+
+- `value` - (numeric) The value of the UTXO in satoshis.
+- `scriptPubKey` - (object) Information about the output script.
+
+Returns an empty object if the UTXO doesn't exist or has been spent.
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- This method requires compact block filters to be enabled (`blockfilters=1`).
+- Unlike `gettxout`, this searches the entire blockchain, not just cached outputs.
+- The `height_hint` greatly improves performance by limiting the search range.
+- Useful for finding arbitrary UTXOs without having them pre-cached.
+- The search can be slow without a height hint, especially for old transactions.

--- a/doc/rpc/getblockheader.md
+++ b/doc/rpc/getblockheader.md
@@ -1,0 +1,45 @@
+# `getblockheader`
+
+Returns the block header for a given block hash.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getblockheader <hash>
+```
+
+### Examples
+
+```bash
+floresta-cli getblockheader "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+```
+
+## Arguments
+
+- `hash` - (string, required) The block hash (64-character hex string) of the block whose header you want to retrieve.
+
+## Returns
+
+### Ok Response
+
+A JSON object containing the block header fields:
+
+- `version` - (numeric) The block version.
+- `prev_blockhash` - (string) The hash of the previous block.
+- `merkle_root` - (string) The Merkle root of all transactions in the block.
+- `time` - (numeric) The block timestamp (Unix epoch time).
+- `bits` - (string) The difficulty target in compact format.
+- `nonce` - (numeric) The nonce used for proof-of-work.
+
+### Error Enum `CommandError`
+
+Returns an error if the block hash is not found.
+
+## Notes
+
+- Block headers are 80 bytes and contain essential metadata about the block.
+- The header does not include transaction data, only the Merkle root.
+- This is useful for light clients that need to verify the chain without downloading full blocks.
+- The `prev_blockhash` field links blocks together to form the blockchain.

--- a/doc/rpc/getmemoryinfo.md
+++ b/doc/rpc/getmemoryinfo.md
@@ -1,0 +1,46 @@
+# `getmemoryinfo`
+
+Returns statistics about Floresta's memory usage.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getmemoryinfo [mode]
+```
+
+### Examples
+
+```bash
+floresta-cli getmemoryinfo
+floresta-cli getmemoryinfo "stats"
+```
+
+## Arguments
+
+- `mode` - (string, optional, default="stats") The type of memory information to return. Currently only "stats" is supported.
+
+## Returns
+
+### Ok Response
+
+A JSON object containing memory statistics:
+
+- `used` - (numeric) Currently used memory in bytes.
+- `free` - (numeric) Available free memory in bytes.
+- `total` - (numeric) Total memory allocated to the process in bytes.
+- `locked` - (numeric) Amount of locked (non-swappable) memory in bytes.
+- `chunks_used` - (numeric) Number of memory chunks in use.
+- `chunks_free` - (numeric) Number of free memory chunks.
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Returns zeroed values for all runtimes that are not `*-gnu` (glibc) or macOS.
+- This is useful for monitoring node resource usage.
+- Memory statistics come from the system's memory allocator.
+- The `locked` field shows memory protected from swapping (for security-sensitive data).

--- a/doc/rpc/getpeerinfo.md
+++ b/doc/rpc/getpeerinfo.md
@@ -1,0 +1,50 @@
+# `getpeerinfo`
+
+Returns information about the connected peers.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getpeerinfo
+```
+
+### Examples
+
+```bash
+floresta-cli getpeerinfo
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+An array of JSON objects, one for each connected peer:
+
+- `addr` - (string) The IP address and port of the peer.
+- `services` - (string) The services offered by the peer.
+- `version` - (numeric) The peer's protocol version.
+- `subver` - (string) The peer's user agent string.
+- `inbound` - (boolean) Whether the connection is inbound.
+- `startingheight` - (numeric) The peer's block height when we connected.
+- `banscore` - (numeric) The peer's ban score.
+- `synced_headers` - (numeric) The last header we have in common with this peer.
+- `synced_blocks` - (numeric) The last block we have in common with this peer.
+- `connection_type` - (string) Type of connection (e.g., "outbound-full-relay").
+- `transport_protocol_type` - (string) The P2P transport protocol (v1 or v2).
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Use this to monitor your node's network connectivity.
+- A healthy node should have multiple peers.
+- The `banscore` increases when peers send invalid data.
+- v2 transport provides encrypted P2P communication (BIP324).

--- a/doc/rpc/getroots.md
+++ b/doc/rpc/getroots.md
@@ -1,0 +1,46 @@
+# `getroots`
+
+Returns the current Utreexo accumulator roots for the UTXO set.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getroots
+```
+
+### Examples
+
+```bash
+floresta-cli getroots
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+- (json array of strings) An array of hex-encoded Utreexo root hashes.
+
+```json
+[
+  "abc123def456...",
+  "789ghi012jkl..."
+]
+```
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Utreexo is a hash-based dynamic accumulator for the Bitcoin UTXO set.
+- The roots allow proving that a UTXO exists without storing the entire UTXO set.
+- The number of roots is logarithmic in the number of UTXOs.
+- These roots are essential for Utreexo proof verification.
+- This is what makes Floresta a lightweight node - it stores only these roots instead of the full UTXO set.

--- a/doc/rpc/getrpcinfo.md
+++ b/doc/rpc/getrpcinfo.md
@@ -1,0 +1,43 @@
+# `getrpcinfo`
+
+Returns information about the RPC server.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getrpcinfo
+```
+
+### Examples
+
+```bash
+floresta-cli getrpcinfo
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+A JSON object containing:
+
+- `active_commands` - (json array) List of currently executing RPC commands.
+  - `method` - (string) The name of the RPC command.
+  - `duration` - (numeric) Running time in microseconds.
+- `logpath` - (string) The complete file path to the debug log.
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Useful for debugging and monitoring RPC server performance.
+- The `active_commands` array shows commands currently being processed.
+- Long-running commands may indicate performance issues.
+- The `logpath` helps locate debug information for troubleshooting.

--- a/doc/rpc/gettransaction.md
+++ b/doc/rpc/gettransaction.md
@@ -1,0 +1,50 @@
+# `gettransaction`
+
+Returns a transaction from the watch-only wallet cache.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli gettransaction <txid> [verbose]
+```
+
+### Examples
+
+```bash
+floresta-cli gettransaction "abc123def456..."
+floresta-cli gettransaction "abc123def456..." true
+```
+
+## Arguments
+
+- `txid` - (string, required) The transaction ID (txid) of the transaction to retrieve.
+- `verbose` - (boolean, optional, default=false) If true, returns a JSON object with detailed transaction information. If false, returns the raw transaction hex.
+
+## Returns
+
+### Ok Response (verbose=false)
+
+- (string) The raw transaction as a hex-encoded string.
+
+### Ok Response (verbose=true)
+
+- `txid` - (string) The transaction ID.
+- `hash` - (string) The transaction hash.
+- `size` - (numeric) The transaction size in bytes.
+- `vsize` - (numeric) The virtual transaction size.
+- `version` - (numeric) The transaction version.
+- `locktime` - (numeric) The transaction locktime.
+- `vin` - (json array) Array of input objects.
+- `vout` - (json array) Array of output objects.
+
+### Error Enum `CommandError`
+
+Returns an error if the transaction is not found in the wallet cache.
+
+## Notes
+
+- This method only returns transactions that are cached by the watch-only wallet.
+- To have transactions cached, you must first load descriptors using `loaddescriptor`.
+- For transactions not in the cache, you may need to rescan the blockchain.

--- a/doc/rpc/gettxoutproof.md
+++ b/doc/rpc/gettxoutproof.md
@@ -1,0 +1,39 @@
+# `gettxoutproof`
+
+Returns the Merkle proof that one or more transactions were included in a block.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli gettxoutproof <txids> [blockhash]
+```
+
+### Examples
+
+```bash
+floresta-cli gettxoutproof '["txid1", "txid2"]'
+floresta-cli gettxoutproof '["abc123..."]' "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+```
+
+## Arguments
+
+- `txids` - (json array, required) A JSON array of transaction IDs to prove. Each element should be a valid transaction ID (64-character hex string).
+- `blockhash` - (string, optional) The block hash to look for the transactions in. If not specified, Floresta will search in the most recent blocks.
+
+## Returns
+
+### Ok Response
+
+- `proof` - (string) A hex-encoded Merkle proof string that proves the transactions were included in the specified block.
+
+### Error Enum `CommandError`
+
+Returns `null` if the proof cannot be generated (e.g., transaction not found).
+
+## Notes
+
+- The proof can be verified using `verifytxoutproof` on Bitcoin Core or compatible implementations.
+- All transactions must be in the same block.
+- This is useful for SPV (Simplified Payment Verification) proofs.

--- a/doc/rpc/listdescriptors.md
+++ b/doc/rpc/listdescriptors.md
@@ -1,0 +1,49 @@
+# `listdescriptors`
+
+Returns a list of all descriptors currently loaded in the watch-only wallet.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli listdescriptors
+```
+
+### Examples
+
+```bash
+floresta-cli listdescriptors
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+- (json array of strings) An array of descriptor strings loaded in the wallet.
+
+```json
+[
+  "wpkh([fingerprint/84'/0'/0']xpub.../0/*)#checksum",
+  "wpkh([fingerprint/84'/0'/0']xpub.../1/*)#checksum"
+]
+```
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Descriptors define which addresses the wallet watches.
+- Use `loaddescriptor` to add new descriptors to the wallet.
+- Common descriptor types include:
+  - `wpkh` - Native SegWit (P2WPKH)
+  - `pkh` - Legacy (P2PKH)
+  - `sh(wpkh())` - Wrapped SegWit (P2SH-P2WPKH)
+- The checksum (after `#`) ensures descriptor integrity.
+- Descriptors persist across node restarts.

--- a/doc/rpc/ping.md
+++ b/doc/rpc/ping.md
@@ -1,0 +1,39 @@
+# `ping`
+
+Sends a ping message to all connected peers to check if they are still alive.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli ping
+```
+
+### Examples
+
+```bash
+floresta-cli ping
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+- json null
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Requests that each peer sends a `pong` response.
+- Useful for testing connectivity with peers.
+- Does not return the ping times; it only initiates the ping.
+- Peers that don't respond may be disconnected.
+- Use `getpeerinfo` to see detailed peer connection status.

--- a/doc/rpc/sendrawtransaction.md
+++ b/doc/rpc/sendrawtransaction.md
@@ -1,0 +1,42 @@
+# `sendrawtransaction`
+
+Submits a raw transaction to the Bitcoin network.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli sendrawtransaction <tx>
+```
+
+### Examples
+
+```bash
+floresta-cli sendrawtransaction "0100000001..."
+```
+
+## Arguments
+
+- `tx` - (string, required) The raw transaction as a hex-encoded string. Must be a valid, fully signed Bitcoin transaction.
+
+## Returns
+
+### Ok Response
+
+- `txid` - (string) The transaction ID (txid) of the submitted transaction, as a hex-encoded string.
+
+### Error Enum `CommandError`
+
+Returns an error if:
+- The transaction is malformed or invalid.
+- The transaction fails consensus rules.
+- The transaction double-spends an existing transaction.
+- The transaction's inputs are already spent.
+
+## Notes
+
+- The transaction must be fully signed before submission.
+- You can create raw transactions using Bitcoin libraries or other wallet software.
+- Once broadcast, the transaction cannot be easily reversed.
+- The transaction will be relayed to connected peers for inclusion in a block.

--- a/doc/rpc/stop.md
+++ b/doc/rpc/stop.md
@@ -1,0 +1,38 @@
+# `stop`
+
+Requests a graceful shutdown of the Floresta node.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli stop
+```
+
+### Examples
+
+```bash
+floresta-cli stop
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+- (string) Returns the message "Floresta stopping".
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- This initiates a graceful shutdown of the florestad process.
+- The node will finish current operations before stopping.
+- All data is safely persisted before shutdown.
+- Use this instead of forcefully killing the process to avoid data corruption.

--- a/doc/rpc/uptime.md
+++ b/doc/rpc/uptime.md
@@ -1,0 +1,38 @@
+# `uptime`
+
+Returns the number of seconds that the Floresta node has been running.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli uptime
+```
+
+### Examples
+
+```bash
+floresta-cli uptime
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+- (numeric) The number of seconds since the node was started.
+
+### Error Enum `CommandError`
+
+Any of the error types on `rpc_types::Error`.
+
+## Notes
+
+- Useful for monitoring node stability and uptime.
+- The counter starts when florestad is launched.
+- Can be used in scripts to detect recent restarts.
+- Does not persist across restarts.


### PR DESCRIPTION
Add comprehensive documentation for the following RPC endpoints:
- findtxout
- getblockheader
- getmemoryinfo
- getpeerinfo
- getroots
- getrpcinfo
- gettransaction
- gettxoutproof
- listdescriptors
- ping
- sendrawtransaction
- stop
- uptime

All documentation follows the established template format.

Closes #799

### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering, see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
