### PR TITLE
ci: add `no-std` job to check `floresta-common`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,6 +132,39 @@ jobs:
             target/release/
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
+  no-std:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - crate: floresta-common
+            feature_args: ""
+          - crate: floresta-common
+            feature_args: "--features descriptors-no-std"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.81.0
+        with:
+          # Common bare-metal Cortex-M target (no_std: `core` + `alloc`).
+          targets: thumbv7em-none-eabi
+
+      - name: Install ARM GCC (for secp256k1-sys)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi
+
+      - name: Build ${{ matrix.crate }} for no_std target
+        shell: bash
+        run: |
+          cargo build -p "${{ matrix.crate }}" \
+            --target thumbv7em-none-eabi \
+            --no-default-features \
+            ${{ matrix.feature_args }} \
+            --locked
+
   build-docker:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description and Notes

This ensures we don't link `std` by mistake, as our no-default-feature `floresta-common` wouldn't be able to compile for a `no_std` target.

If we ever link the `std` lib, we will get this error:

```bash
error[E0463]: can't find crate for `std`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crypto-common-0.1.7/src/lib.rs:13:1
   |
13 | extern crate std;
   | ^^^^^^^^^^^^^^^^^ can't find crate
   |
   = note: the `thumbv7em-none-eabihf` target may not support the standard library

For more information about this error, try `rustc --explain E0463`.
error: could not compile `crypto-common` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```
