### PR TITLE
feat(wire): introduce RequestSelection

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -38,6 +38,7 @@ use super::node::NodeRequest;
 use super::transport::TransportError;
 use super::transport::TransportProtocol;
 use super::transport::WriteTransport;
+use crate::block_proof::UtreexoProofMask;
 use crate::node::ConnectionKind;
 use crate::p2p_wire::block_proof::GetUtreexoProof;
 use crate::p2p_wire::block_proof::UtreexoProof;
@@ -389,7 +390,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             NodeRequest::GetBlockProof((block_hash, proof_hashes_bitmap, leaf_index_bitmap)) => {
                 let get_block_proof = GetUtreexoProof {
                     block_hash,
-                    include_leaves: true,
+                    request_bitmap: UtreexoProofMask::request_all(),
                     proof_hashes_bitmap,
                     leaf_index_bitmap,
                 };


### PR DESCRIPTION
### Description and Notes

A UtreexoProof struct contains three main items: a Merkle Proof, the position targets and the preimage for each UTXO being spent. RequestSelection allows you to choose which one of the structs do you want independently.

This is serialized as a Bitmap, but the api uses a builder pattern where you can use a setter to tell which ones do you want.

There's also the `request_all` helper that just sets all Bits, and is useful to avoid having to call all three setters.

### How to verify the changes you have done?

Run the latest `utreexod` `main` on `signet` and connect floresta with and without this change. On `master` it should error out with a tx validation error for missing txout.