### PR TITLE
fix(electrum): fix a bug with broadcast

### DIFF
--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -499,7 +499,6 @@ impl Florestad {
             cfilters,
             chain_provider.get_handle(),
         )
-        .await
         .map_err(FlorestadError::CouldNotCreateElectrumServer)?;
 
         // Default Electrum Server port.
@@ -526,7 +525,7 @@ impl Florestad {
 
         task::spawn(client_accept_loop(
             non_tls_listener,
-            electrum_server.message_transmitter.clone(),
+            electrum_server.get_notifier(),
             None,
         ));
         info!("Electrum Server is running at {electrum_addr}");
@@ -591,7 +590,7 @@ impl Florestad {
             let tls_acceptor: TlsAcceptor = TlsAcceptor::from(tls_config);
             task::spawn(client_accept_loop(
                 tls_listener,
-                electrum_server.message_transmitter.clone(),
+                electrum_server.get_notifier(),
                 Some(tls_acceptor),
             ));
             info!("Electrum TLS Server is running at {electrum_addr_tls}");


### PR DESCRIPTION
### Description and Notes

In #698 small bug where our node would stop responding during start-up, on very specific conditions was introduced.

If we broadcast a transaction and shutdown floresta before it gets confirmed, then try to start floresta again, we would get stuck. This happens because electrum would try to use the node handle to broadcast a transaction, but since `FlorestaNode` wouldn't be running, the electrum server would never get an answer, blocking forever.

This commit fixes this by moving the re-broadcast to then main loop. Now the re-broadcast code will try to broadcast again every 24 hours, until the tx gets confirmed. This makes sure our transaction won't fall off the mempool. It also only broadcasts after the node left IBD, to avoid having a transaction that gets stuck inside our mempool due to it already being confirmed.

I've also made all ElectrumServer's field private, there's no reason for them to be public.

### How to verify the changes you have done?

To reproduce the bug: broadcast a transaction that spends from/to a cached address, then before it confirms, shut `florestad` down gracefully. When you restart it, it won't go past a log message about the RPC being up. On this branch it should start as expected.