### PR TITLE
fix(deps): re-enable help for `florestad` and `floresta-cli`

### DIFF
--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 [dependencies]
 anyhow = "1.0"
 bitcoin = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["help"] }
 serde_json = { workspace = true }
 
 # Local dependencies

--- a/bin/florestad/Cargo.toml
+++ b/bin/florestad/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
 bitcoin = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["help"] }
 console-subscriber = { workspace = true, optional = true }
 dirs = { version = "4.0", default-features = false }
 tokio = { workspace = true }


### PR DESCRIPTION
### Description and Notes

This PR fixes a bug where the `--help` flag for both `florestad` and `floresta-cli` was not working and was instead returning an error. Issue #832 describes this unexpected behavior.

The problem was caused by the help feature being disabled in the `clap` dependency. This commit re-enables the help feature in `clap`, restoring the expected behavior and allowing users to properly access command-line help options.


### How to verify the changes you have done?

Run the following command:

```shell
cargo run --bin floresta-cli -- --help
```

or

```shell
cargo run --bin florestad -- --help
```

and verify that the help output is displayed correctly.