### PR TITLE
feat(docker): add data persistence to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ utreexod/
 
 # Configuration files
 config.toml
+.pre-commit-config.yaml
+.env
 
 # direnv cache
 .direnv/

--- a/contrib/env.docker.sample
+++ b/contrib/env.docker.sample
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# This is a sample Docker environment file for Floresta.
+# You can customize it according to your needs.
+
+# uncomment to use a local data directory instead of docker volumes
+#FLORESTA_DATADIR=$HOME/.floresta
+
+# mainnet
+NETWORK=bitcoin
+RPC_PORT=8332
+ELECTRUM_PORT=50001
+
+# signet
+#NETWORK=signet
+#RPC_PORT=38332
+#ELECTRUM_PORT=60001
+
+# testnet
+#NETWORK=testnet
+#RPC_PORT=18332
+#ELECTRUM_PORT=30001
+
+# testnet4
+#NETWORK=testnet4
+#RPC_PORT=48332
+#ELECTRUM_PORT=40001
+
+# regtest
+#NETWORK=regtest
+#RPC_PORT=18442
+#ELECTRUM_PORT=20001

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -47,5 +47,44 @@ docker exec -it Floresta floresta-cli getblockchaininfo
 Floresta also (optionally) provides [Prometheus](https://prometheus.io/) metrics endpoint, which you can enable at compile time. If you want a quick setup with Grafana, we provide a [docker-compose.yml](../docker-compose.yml) for that as well. Just use:
 
 ```bash
-docker-compose -f docker-compose.yml up -d
+docker compose up -d
+```
+
+This will start Floresta on Bitcoin mainnet by default. All blockchain data, metrics, and Grafana configurations are persisted in Docker volumes.
+
+## Running on Different Networks
+
+The provided `docker-compose.yml` supports running Floresta on different Bitcoin networks. To make this easy and avoid port collisions, we provide a sample environment file.
+
+Copy the sample file from `contrib/env.docker.sample`:
+
+```bash
+cp contrib/env.docker.sample .env
+```
+
+Edit the `.env` file to uncomment the network you want to use (which sets the correct NETWORK, RPC_PORT, and ELECTRUM_PORT), and then run:
+
+```bash
+docker compose up -d
+```
+
+Alternatively, you can pass the variables directly inline:
+
+```bash
+NETWORK=signet RPC_PORT=38332 ELECTRUM_PORT=60001 docker compose up -d
+```
+
+## Using Local Floresta Data
+
+If you already have a florestad datadir on your machine (e.g., from a previous run), you can reuse that datadir instead of starting from scratch:
+
+```bash
+# Use your existing ~/.floresta directory
+FLORESTA_DATA=$HOME/.floresta docker compose up -d
+```
+
+You can also uncomment and set the FLORESTA_DATA variable directly inside your `.env` file:
+
+```yml
+FLORESTA_DATA=$HOME/.floresta
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 services:
   floresta:
     container_name: floresta
@@ -5,11 +7,19 @@ services:
       context: .
       args:
         BUILD_FEATURES: "metrics"
+    command: >-
+      florestad --data-dir /data/.floresta
+      -n ${NETWORK:-bitcoin}
+      --rpc-address 0.0.0.0:${RPC_PORT:-8332}
+      --electrum-address 0.0.0.0:${ELECTRUM_PORT:-50001}
     ports:
-      - 50001:50001
-      - 8332:8332
+      - ${RPC_PORT:-8332}:${RPC_PORT:-8332}
+      - ${ELECTRUM_PORT:-50001}:${ELECTRUM_PORT:-50001}
       - 3333:3333
+    tty: true
     restart: unless-stopped
+    volumes:
+      - ${FLORESTA_DATA:-floresta_data}:/data/.floresta
   prometheus:
     image: prom/prometheus
     container_name: prometheus
@@ -20,6 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./metrics/prometheus:/etc/prometheus
+      - prometheus_data:/prometheus
   grafana:
     image: grafana/grafana
     container_name: grafana
@@ -31,3 +42,12 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=grafana
     volumes:
       - ./metrics/grafana:/etc/grafana/provisioning/datasources
+      - grafana_data:/var/lib/grafana
+
+volumes:
+  floresta_data:
+    name: floresta_data
+  prometheus_data:
+    name: prometheus_data
+  grafana_data:
+    name: grafana_data


### PR DESCRIPTION
### Description and Notes

fixed https://github.com/getfloresta/Floresta/issues/795

this PR addresses the lack of data persistence and network flexibility in the current `docker-compose.yml` setup.

currently, users running `docker compose up` experience:
- **Data loss on container restart** — blockchain data, Prometheus metrics, and Grafana dashboards are lost every time containers are recreated
- **Mainnet-only** — no way to run on signet, testnet, or other networks without manually editing the compose file

### Changes

**Data Persistence:**
- Adds named Docker volumes for Floresta, Prometheus, and Grafana
- Supports `FLORESTA_DATA` environment variable to reuse existing local blockchain data (useful for sharing data between native and Docker installations)

**Network Configuration:**
- Adds `NETWORK` environment variable to easily switch between Bitcoin networks (`bitcoin`, `signet`, `testnet`, `testnet4`, `regtest`)
- Forces fixed internal ports (50001 for Electrum, 8332 for RPC) with `--rpc-address` and `--electrum-address` flags, avoiding port conflicts when changing networks

**Documentation:**
- Updates `doc/docker.md` with examples for running different networks and using local data directories

### How to verify the changes you have done?

Start the stack: `docker compose up -d` or `NETWORK=signet FLORESTA_DATA=$HOME/.floresta docker compose up`