### PR TITLE
Allow any content type on JSON-RPC requests

### DIFF
--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -4,8 +4,12 @@ use std::slice;
 use std::sync::Arc;
 use std::time::Instant;
 
+use axum::body::Body;
+use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::Method;
+use axum::http::Response;
+use axum::http::StatusCode;
 use axum::routing::post;
 use axum::Json;
 use axum::Router;
@@ -515,8 +519,28 @@ fn get_json_rpc_error_code(err: &JsonRpcError) -> i32 {
 
 async fn json_rpc_request(
     State(state): State<Arc<RpcImpl<impl RpcChain>>>,
-    Json(req): Json<RpcRequest>,
-) -> axum::http::Response<axum::body::Body> {
+    body: Bytes,
+) -> Response<Body> {
+    let req: RpcRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(e) => {
+            let error = RpcError {
+                code: -32700,
+                message: format!("Parse error: {e}"),
+                data: None,
+            };
+            let body = json!({
+                "error": error,
+                "id": Value::Null,
+            });
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap();
+        }
+    };
+
     debug!("Received JSON-RPC request: {req:?}");
 
     let id = req.id.clone();


### PR DESCRIPTION
Closes #656.

Axum's `Json` extractor would only allow `application/json` as the content type. To match Bitcoin Core's behavior, we now parse the request's body using `serde_json::from_slice` to allow any (including none) content type.

```console
% curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getbestblockhash", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:38332/
{"id":"curltest","result":"00000009d936f60d83297e3e5105fbe0be64439bc2b059723d214690f4226382"}%
 
% curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getbestblockhash", "params": []}' -H 'content-type: application/json-rpc;' http://127.0.0.1:38332/
{"id":"curltest","result":"0000000c1538aadbaab58c07105f67478ecf17b4d85f63e3d494211c8baa82db"}%

% curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getbestblockhash", "params": []}' http://127.0.0.1:38332/
{"id":"curltest","result":"0000000c1538aadbaab58c07105f67478ecf17b4d85f63e3d494211c8baa82db"}%
```



