### PR TITLE
feat(consensus): use rust-bitcoinkernel v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoinkernel"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dac21e1d2e51f1e1fb2bc50d04748b6152812f22138a7708277d166cabfd8f"
+checksum = "1d9c800b68ef4ad5c3bf1d668375433934b97faaa487758b7b8aadff42764c2d"
 dependencies = [
  "libbitcoinkernel-sys",
 ]
@@ -1670,9 +1670,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libbitcoinkernel-sys"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431abda412df5863cccaae257644ee9929b7156b22f5e2205671e1f369bd74c4"
+checksum = "35576852961d85614bb5dd3f8a3283b2c4b4310d9dc306f07b4b0b6a6b039eeb"
 dependencies = [
  "bindgen",
  "cc",

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bitcoin = { workspace = true }
-bitcoinkernel = { version = "0.1", optional = true }
+bitcoinkernel = { version = "0.2", optional = true }
 lru = { version = "0.16", optional = true }
 memmap2 = { version = "0.9", optional = true }
 rustreexo = { workspace = true }


### PR DESCRIPTION
### Description and Notes

- Bumps `rust-bitcoinkernel` to the latest version (v0.2)
- Script verification now reuses `PrecomputedTransactionData`, which eliminates quadratic hashing in transactions with multiple inputs

I'd also add that the kernel now supports header verification, though it may be overkill to build the kernel just for that purpose.