### PR TITLE
docs(cli): Add documentation for rpc calls

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -198,8 +198,13 @@ pub enum Methods {
     )]
     GetBlockCount,
 
-    /// Returns the proof that one or more transactions were included in a block
-    #[command(name = "gettxoutproof")]
+    #[doc = include_str!("../../../doc/rpc/gettxoutproof.md")]
+    #[command(
+        name = "gettxoutproof",
+        about = "Returns the Merkle proof that one or more transactions were included in a block.",
+        long_about = Some(include_str!("../../../doc/rpc/gettxoutproof.md")),
+        disable_help_subcommand = true
+    )]
     GetTxOutProof {
         /// The transaction IDs to prove
         #[arg(required = true, value_parser = crate::parsers::parse_json_array::<Txid>)]
@@ -210,8 +215,13 @@ pub enum Methods {
         blockhash: Option<BlockHash>,
     },
 
-    /// Returns the transaction, assuming it is cached by our watch only wallet
-    #[command(name = "gettransaction")]
+    #[doc = include_str!("../../../doc/rpc/gettransaction.md")]
+    #[command(
+        name = "gettransaction",
+        about = "Returns a transaction cached by the watch-only wallet.",
+        long_about = Some(include_str!("../../../doc/rpc/gettransaction.md")),
+        disable_help_subcommand = true
+    )]
     GetTransaction { txid: Txid, verbose: Option<bool> },
 
     #[doc = include_str!("../../../doc/rpc/rescanblockchain.md")]
@@ -253,8 +263,13 @@ pub enum Methods {
     #[command(name = "sendrawtransaction")]
     SendRawTransaction { tx: String },
 
-    /// Returns the block header for the given block hash
-    #[command(name = "getblockheader")]
+    #[doc = include_str!("../../../doc/rpc/getblockheader.md")]
+    #[command(
+        name = "getblockheader",
+        about = "Returns the block header for the given block hash.",
+        long_about = Some(include_str!("../../../doc/rpc/getblockheader.md")),
+        disable_help_subcommand = true
+    )]
     GetBlockHeader { hash: BlockHash },
 
     /// Loads a new descriptor to the watch only wallet

--- a/doc/rpc/getblockheader.md
+++ b/doc/rpc/getblockheader.md
@@ -1,0 +1,37 @@
+# `getblockheader`
+
+Returns the block header for the given block hash. A header contains the block's version, previous block hash, Merkle root, timestamp, difficulty target, and nonce.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getblockheader <hash>
+```
+
+### Examples
+
+```bash
+floresta-cli getblockheader 00000000000000000001a2f0b80b5eeb24fd80984e97869ad25b6abb4ff8a025
+```
+
+## Arguments
+
+`hash` - (string, required) The hash of the block to retrieve the header for, in hex format.
+
+## Returns
+
+### Ok Response
+
+- `version` - (numeric) The block version number.
+- `prev_blockhash` - (string) The hash of the previous block in the chain.
+- `merkle_root` - (string) The merkle root of all transactions in the block.
+- `time` - (numeric) The block timestamp as a UNIX epoch time.
+- `bits` - (numeric) The compressed difficulty target for the block.
+- `nonce` - (numeric) The nonce used to generate this block.
+
+### Error Response
+
+* `BlockNotFound` - The block hash provided does not match any known block.
+* `InvalidParameterType` - The hash parameter is not a valid block hash.

--- a/doc/rpc/gettransaction.md
+++ b/doc/rpc/gettransaction.md
@@ -1,0 +1,68 @@
+# `gettransaction`
+
+Returns a transaction cached by the watch-only wallet. Depending on the verbosity flag, the result is either a raw hex-encoded string or a detailed JSON object.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli gettransaction <txid> [<verbose>]
+```
+
+### Examples
+
+```bash
+floresta-cli gettransaction 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+
+# Returns a detailed JSON object.
+floresta-cli gettransaction 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b true
+```
+
+## Arguments
+
+`txid` - (string, required) The transaction ID to look up. The transaction must be cached by the watch-only wallet.
+
+`verbose` - (boolean, optional) Controls the response format. When `true`, the transaction is returned as a detailed JSON object. When `false` a 64-character hex-encoded string is returned.
+
+## Returns
+
+### Ok Response
+
+When `verbose` is `true`, returns a JSON object with the following fields:
+
+- `in_active_chain` - (boolean) Whether the transaction is in the active chain (i.e. has been confirmed).
+- `hex` - (string) The raw transaction as a hex-encoded string.
+- `txid` - (string) The transaction ID.
+- `hash` - (string) The witness transaction ID (wtxid).
+- `size` - (numeric) The serialized transaction size in bytes.
+- `vsize` - (numeric) The virtual transaction size in vbytes.
+- `weight` - (numeric) The transaction weight in weight units.
+- `version` - (numeric) The transaction version number.
+- `locktime` - (numeric) The transaction lock time.
+- `vin` - (array) An array of transaction inputs, each containing:
+  - `txid` - (string) The previous output transaction ID.
+  - `vout` - (numeric) The previous output index.
+  - `script_sig` - (object) The input script, with `asm` and `hex` fields.
+  - `sequence` - (numeric) The input sequence number.
+  - `witness` - (array) An array of hex-encoded witness data strings.
+- `vout` - (array) An array of transaction outputs, each containing:
+  - `value` - (numeric) The output value in satoshis.
+  - `n` - (numeric) The output index.
+  - `script_pub_key` - (object) The output script, with `asm`, `hex`, `req_sigs`, `type`, and `address` fields.
+- `blockhash` - (string) The hash of the block containing the transaction.
+- `confirmations` - (numeric) The number of confirmations (0 if unconfirmed).
+- `blocktime` - (numeric) The block timestamp as a UNIX epoch time.
+- `time` - (numeric) The transaction time as a UNIX epoch time (same as `blocktime`).
+
+When `verbose` is `false`, returns a 64-character hex-encoded string representing the raw transaction.
+
+
+### Error Enum `JsonRpcError`
+
+* `TxNotFound` - The transaction was not found in the watch-only wallet cache.
+
+## Notes
+
+- Only transactions cached by the watch-only wallet can be retrieved. You must first load descriptors with `loaddescriptor` so the wallet knows which addresses to track.
+- The CLI always requests verbose output regardless of the `verbose` argument passed.

--- a/doc/rpc/gettxoutproof.md
+++ b/doc/rpc/gettxoutproof.md
@@ -1,0 +1,43 @@
+# `gettxoutproof`
+
+Returns the Merkle proof that one or more transactions were included in a block. The proof is returned as a hex-encoded serialized `MerkleBlock`.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli gettxoutproof <txids> [<blockhash>]
+```
+
+### Examples
+
+```bash
+# Get proof for a single transaction (block is looked up via the watch-only wallet)
+floresta-cli gettxoutproof '["4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"]'
+
+# Get proof for multiple transactions in the same block
+floresta-cli gettxoutproof '["txid1", "txid2"]' 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+```
+
+## Arguments
+
+`txids` - (JSON array of strings, required) A JSON array of transaction IDs to prove. All transactions must exist in the same block. The value must be a valid JSON array of 64-character hexadecimal transaction hashes.
+
+`blockhash` - (string, optional) The hash of the block to search for the transactions. If omitted, the node uses the first transaction ID to look up the block via the watch-only wallet cache.
+
+## Returns
+
+### Ok Response
+
+- (string) A hex-encoded serialized `MerkleBlock` containing the Merkle proof that the specified transactions were included in the block.
+
+### Error Enum `JsonRpcError`
+
+* `TxNotFound` - One or more of the specified transactions were not found in the block. This also occurs when `blockhash` is omitted and the first transaction is not cached in the watch-only wallet.
+* `BlockNotFound` - The specified block hash does not match any known block, or the block containing the transaction could not be retrieved.
+
+## Notes
+
+- All specified transactions must exist in the same block; there is no way to build a common Merkle proof across multiple blocks.
+- When `blockhash` is omitted, the node uses the first txid to find the block through the watch-only wallet. This requires the transaction to have been previously cached (e.g. via `loaddescriptor`).


### PR DESCRIPTION
### Description and Notes

Continuing the effort to close issue #799  , this PR adds documentation for three additional RPC commands in the Floresta CLI:
- `getblockheader` : Returns the block header (version, prev_blockhash, merkle_root, time, bits, nonce) for a given block hash.
- `gettxoutproof` : Returns a hex-encoded Merkle proof that one or more transactions were included in a block. Supports an optional `blockhash`  parameter; when omitted, the block is resolved via the watch-only wallet.
- `gettransaction` : Returns a transaction cached by the watch-only wallet, either as a verbose JSON object or a hex-encoded string depending on the verbose flag.

### How to verify the changes you have done?

1. Review the new documentation files in the doc/rpc directory:
- getblockheader.md
- gettxoutproof.md
- gettransaction.md

2. Verify the CLI help output includes the new documentation:
```
floresta-cli getblockheader --help
floresta-cli gettxoutproof --help
floresta-cli gettransaction --help
```