### PR TITLE
fix(chain_selector): fix a bug where we can sometimes get stuck and don't download any extra header

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -97,6 +97,19 @@ where
         Some((id, peer))
     }
 
+    /// Returns how many connected peers we have.
+    ///
+    /// This function will only count peers that completed handshake and are ready
+    /// to be used.
+    pub(crate) fn connected_peers(&self) -> usize {
+        self.peers
+            .values()
+            .filter(|p| {
+                p.state == PeerStatus::Ready && matches!(p.kind, ConnectionKind::Regular(_))
+            })
+            .count()
+    }
+
     /// Sends a request to an initialized peer that supports `required_service`, chosen via a
     /// latency-weighted distribution (lower latency => more likely).
     ///


### PR DESCRIPTION
### Description and Notes

`ChainSelector` currently have a bug where, in very rare cases, it might get stuck due to a peer timing out or disconnecting while having an inflight request. The actual bug is fixed in the second commit, but I've also added a logic that prevents us from getting stuck at. I've also added a requirement that chain selection can only happen if we have at least `MAX_OUTGOING_PEERS`, since this helps protecting us against eclipse attacks during this very important phase.