### PR TITLE
fix(test): clean big files on `clean` recipe

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -44,8 +44,7 @@ jobs:
           tests/prepare.sh --release
 
       - name: Run functional tests tasks
-        run: |
-          tests/run.sh
+        run: tests/run.sh --preserve-data-dir
 
       - name: Log tests on failure
         if: failure()

--- a/contrib/clean_data.sh
+++ b/contrib/clean_data.sh
@@ -1,27 +1,46 @@
 #!/bin/bash
 
-# Find all 'tmp-db' directories in subdirectories
-dirs=$(find . -type d -name 'tmp-db')
+# Threshold in bytes (21 MiB)
+TH=21
+THRESHOLD=$(($TH * 1024 * 1024))
+
+# Search paths for large directories
+set -- "/tmp/floresta-func-tests/data" "/tmp/floresta-func-tests/logs" $(find . -type d -name 'tmp-db')
+
+for search in "$@"; do
+    if [ -d "$search" ]; then
+        while IFS= read -r -d '' d; do
+            size=$(du -sb "$d" 2>/dev/null | cut -f1)
+            if [ -n "$size" ] && [ "$size" -gt "$THRESHOLD" ]; then
+                dirs+=("$d")
+            fi
+        done < <(find "$search" -mindepth 1 -maxdepth 1 -type d -print0)
+    fi
+done
+
+# Check if there is anything to delete
+if [ ${#dirs[@]} -eq 0 ]; then
+    echo "No directories larger than $TH MiB found."
+    exit 0
+fi
 
 # Display the directories that will be deleted
-echo "The following 'tmp-db' directories will be deleted:"
-echo "$dirs"
+echo "The following directories exceed $TH MiB and will be deleted:"
+for d in "${dirs[@]}"; do
+    size_human=$(du -sh "$d" 2>/dev/null | cut -f1)
+    echo "  $d ($size_human)"
+done
 
 # Prompt the user for confirmation
-read -r -p "Are you sure you want to delete './tmp' and all 'tmp-db' directories listed above? [y/N] " ans
+read -r -p "Are you sure you want to delete all those directories listed above? [y/N] " ans
 
 # Check the user's response
 if [[ "$ans" =~ ^[Yy]$ ]]; then
-    # User confirmed, proceed with deletion
-
-    # Delete 'tmp' in the current directory (if run via justfile this is the root)
-    rm -rf tmp
-
-    # Delete all 'tmp-db' directories found
-    find . -type d -name 'tmp-db' -exec rm -rf {} +
+    for d in "${dirs[@]}"; do
+        rm -rf "$d"
+    done
 
     echo "Directories deleted."
 else
-    # User did not confirm, cancel the operation
     echo "Deletion cancelled."
 fi

--- a/justfile
+++ b/justfile
@@ -1,3 +1,4 @@
+
 _default:
     @just --list
 
@@ -30,7 +31,8 @@ build-release:
 # Clean project build directory
 clean:
     cargo clean
-
+    sh contrib/clean_data.sh
+    
 # Execute all tests
 test crate="":
     @just test-doc {{ crate }}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -38,10 +38,11 @@ for arg in "$@"; do
     fi
 done
 
-# Clean up the logs dir if --preserve-data-dir was not passed
+# Clean up logsm data files and other stuffs
+# if --preserve-data-dir was not passed
 if [ "$PRESERVE_DATA" = false ]; then
     echo "Cleaning up test directories before running tests..."
-    rm -rf "$FLORESTA_TEMP_DIR/logs"
+    sh contrib/clean_data.sh
 fi
 
 # Run the tests


### PR DESCRIPTION
### Description and Notes

This commit add a bash command to `clean` recipe and try to improve the clean process through some big temporary files. In some local tests, those jumped from 0 to 51G in /tmp/folder

### How to verify the changes you have done?

See #848