### PR TITLE
Use `core::error::Error` instead of `std::error::Error`

### DIFF
--- a/bin/floresta-cli/src/parsers.rs
+++ b/bin/floresta-cli/src/parsers.rs
@@ -1,5 +1,5 @@
+use core::error::Error;
 use std::any::type_name;
-use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
 

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -300,7 +300,7 @@ mod tests {
         }
     }
 
-    impl std::error::Error for MockBlockchainError {}
+    impl core::error::Error for MockBlockchainError {}
 
     pub struct MockBlockchainInterface {
         pub headers: HashMap<BlockHash, Header>,

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -21,7 +21,7 @@ use crate::DatabaseError;
 /// likely on disk.
 ///
 /// This trait requires an associated error type that implements [DatabaseError]; a marker trait
-/// satisfied by any `T: std::error::Error + std::fmt::Display`. This is useful to abstract the
+/// satisfied by any `T: core::error::Error + std::fmt::Display`. This is useful to abstract the
 /// database implementation from the blockchain.
 pub trait ChainStore {
     type Error: DatabaseError;

--- a/crates/floresta-common/src/error.rs
+++ b/crates/floresta-common/src/error.rs
@@ -1,9 +1,0 @@
-/// A no-std implementation of the `Error` trait for floresta
-use crate::prelude::fmt::Debug;
-use crate::prelude::Display;
-
-/// `Error` is a trait representing the basic expectations for error values,
-/// i.e., values of type `E` in [`Result<T, E>`]. Errors must describe
-/// themselves through the [`Display`] and [`Debug`] traits. This is a simplified implementation of
-/// the trait, used inside floresta, in case of a no-std environment.
-pub trait Error: Debug + Display {}

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -26,8 +26,6 @@ use sha2::Digest;
 
 #[cfg(feature = "std")]
 mod ema;
-#[cfg(not(feature = "std"))]
-mod error;
 pub mod macros;
 pub mod spsc;
 
@@ -118,6 +116,7 @@ pub mod prelude {
     pub use alloc::vec::Vec;
     pub use core::cmp;
     pub use core::convert;
+    pub use core::error::Error;
     pub use core::fmt;
     pub use core::fmt::Display;
     pub use core::iter;
@@ -136,8 +135,6 @@ pub mod prelude {
     pub use bitcoin::io::Write;
     pub use hashbrown::HashMap;
     pub use hashbrown::HashSet;
-
-    pub use crate::error::Error;
 }
 
 #[cfg(feature = "std")]
@@ -152,12 +149,12 @@ pub mod prelude {
     extern crate std;
     pub use alloc::format;
     pub use alloc::string::ToString;
+    pub use core::error::Error;
     pub use std::borrow::ToOwned;
     pub use std::boxed::Box;
     pub use std::collections::hash_map::Entry;
     pub use std::collections::HashMap;
     pub use std::collections::HashSet;
-    pub use std::error::Error;
     pub use std::fmt::Display;
     pub use std::fmt::Formatter;
     pub use std::fmt::{self};

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1,3 +1,4 @@
+use core::error;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -219,7 +220,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         chain: Arc<Blockchain>,
         block_filters: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         node_interface: NodeInterface,
-    ) -> Result<ElectrumServer<Blockchain>, Box<dyn std::error::Error>> {
+    ) -> Result<ElectrumServer<Blockchain>, Box<dyn error::Error>> {
         let (tx, rx) = unbounded_channel();
 
         Ok(ElectrumServer {

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -2,9 +2,9 @@
 //! our transactions every 1 hour.
 //! Once our transaction is included in a block, we remove it from the mempool.
 
+use core::error::Error;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::error::Error;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::time::Duration;

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -1,3 +1,4 @@
+use core::error;
 use std::net::AddrParseError;
 
 use bitcoin::consensus::encode;
@@ -90,7 +91,7 @@ pub enum FlorestadError {
     CouldNotCreateChainProvider(String),
 
     /// Failed to create an Electrum server.
-    CouldNotCreateElectrumServer(Box<dyn std::error::Error>),
+    CouldNotCreateElectrumServer(Box<dyn error::Error>),
 
     /// Failed to bind the Electrum server to a socket.
     FailedToBindElectrumServer(std::io::Error),
@@ -254,4 +255,5 @@ impl_from_error!(BlockValidation, BlockValidationErrors);
 impl_from_error!(AddressParsing, bitcoin::address::ParseError);
 impl_from_error!(Miniscript, miniscript::Error);
 impl_from_error!(CouldNotObtainWalletCache, WatchOnlyError<KvDatabaseError>);
-impl std::error::Error for FlorestadError {}
+
+impl error::Error for FlorestadError {}

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -1,3 +1,4 @@
+use core::error;
 use std::fmt::Display;
 
 use corepc_types::v30::GetBlockVerboseOne;
@@ -342,4 +343,4 @@ impl Display for AddNodeCommand {
     }
 }
 
-impl std::error::Error for Error {}
+impl error::Error for Error {}

--- a/crates/floresta-wire/src/p2p_wire/socks.rs
+++ b/crates/floresta-wire/src/p2p_wire/socks.rs
@@ -6,6 +6,7 @@
 //! async runtime. This allows the caller to use this module with any async runtime
 //! they want.
 
+use core::error;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
@@ -144,4 +145,4 @@ impl std::fmt::Display for Socks5Error {
     }
 }
 
-impl std::error::Error for Socks5Error {}
+impl error::Error for Socks5Error {}


### PR DESCRIPTION
Closes #868 

Replace `std::error::Error` with `core::error::Error` across the codebase, as it was [made stable on 1.81.0](https://doc.rust-lang.org/core/error/trait.Error.html)