### PR TITLE
chore(wire): increase DNS_SEED_REQUEST_INTERVAL

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -47,8 +47,8 @@ use crate::TransportProtocol;
 /// such as hard-coded peers
 const HARDCODED_ADDRESSES_GRACE_PERIOD: Duration = Duration::from_secs(60);
 
-/// The minimum amount of time between address fetching requests from DNS seeds (2 minutes).
-const DNS_SEED_REQUEST_INTERVAL: Duration = Duration::from_secs(2 * 60);
+/// The minimum amount of time between address fetching requests from DNS seeds (one hour).
+const DNS_SEED_REQUEST_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 impl<T, Chain> UtreexoNode<Chain, T>
 where
@@ -464,15 +464,13 @@ where
         });
 
         tokio::task::spawn_blocking(move || {
-            let dns_seeds = floresta_chain::get_chain_dns_seeds(network);
-            let mut addresses = Vec::new();
-
             let default_port = Self::get_port(network);
-            for seed in dns_seeds {
-                let _addresses = AddressMan::get_seeds_from_dns(&seed, default_port, proxy_addr);
+            let dns_seeds = floresta_chain::get_chain_dns_seeds(network);
 
-                if let Ok(_addresses) = _addresses {
-                    addresses.extend(_addresses);
+            let mut addresses = Vec::new();
+            for seed in &dns_seeds {
+                if let Ok(got) = AddressMan::get_seeds_from_dns(seed, default_port, proxy_addr) {
+                    addresses.extend(got);
                 }
             }
 
@@ -480,6 +478,7 @@ where
                 "Fetched {} peer addresses from all DNS seeds",
                 addresses.len()
             );
+
             node_sender
                 .send(NodeNotification::DnsSeedAddresses(addresses))
                 .unwrap();


### PR DESCRIPTION
### Description and Notes

In https://github.com/getfloresta/Floresta/pull/793 we reduced the `DNS_SEED_REQUEST_INTERVAL` to two minutes.
This tells how long do we wait before re-doing a request do the DNS
seeds. The goal was to make sure we had enough peers to keep going.

However, it doesn't seem like it worked as intended since DNS servers
are currently bad at giving utreexo peers (and on signet they are also
bad at giving CBS peers). This forces our node to retry DNS requests
every two minutes. But since most users don't have their own recursive
resolver (I don't), the previous result is almost always cached, so you
get basically the same answer several times.

This pollutes stdout for no good reason. Since https://github.com/getfloresta/Floresta/pull/781 we now are super
aggressive about asking for addresses and checking whether they are
alive and learning about their capabilities and https://github.com/getfloresta/Floresta/pull/865 will make it
even better, since we can try several feeler connections at the same
time. So I think DNS seeds should be only used to get us some starting
peers, and then we build our local network view from the P2P net
ourselves.