### PR TITLE
fix(running_ctx): call `ask_missed_proofs` inside a tick loop

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -445,16 +445,15 @@ where
 
         // tries to download filters from the network
         try_and_log!(self.download_filters());
+        try_and_log!(self.ask_missed_block());
 
         // requests that need a utreexo peer
         if !self.has_utreexo_peers() {
             return LoopControl::Continue;
         }
 
-        // Check if we haven't missed any block
-        if self.inflight.len() < RunningNode::MAX_INFLIGHT_REQUESTS {
-            try_and_log!(self.ask_missed_block());
-        }
+        try_and_log!(self.ask_for_missed_proofs());
+
         LoopControl::Continue
     }
 


### PR DESCRIPTION
### Description and Notes

Due to not calling `ask_for_missed_proof` inside the `running_ctx`, there's an edge case where we could get stuck. This PR addresses it.

This bug seems very prone to happen when Tor is being used, since it tends to be way more volatile.