### PR TITLE
feat(wire): allow NodeInterface to request peer banning

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -593,6 +593,17 @@ where
         }
     }
 
+    /// Bans a peer by address, disconnecting it immediately.
+    pub fn handle_ban_peer(&mut self, addr: BitcoinSocketAddr) -> Result<(), WireError> {
+        let peer_id = self
+            .peers
+            .iter()
+            .find_map(|(&id, peer)| (*peer.address.as_bitcoin_socket_addr() == addr).then_some(id))
+            .ok_or(WireError::PeerNotFoundAtAddress(addr))?;
+
+        self.disconnect_and_ban(peer_id)
+    }
+
     /// Checks whether some of our inflight requests have timed out.
     ///
     /// This function will check if any of our inflight requests have timed out, and if so,

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -202,6 +202,22 @@ where
 
                 return;
             }
+
+            UserRequest::BanPeer(addr) => {
+                let node_response = match self.handle_ban_peer(addr.clone()) {
+                    Ok(()) => {
+                        info!("Banned peer {addr}");
+                        NodeResponse::BanPeer(true)
+                    }
+                    Err(err) => {
+                        warn!("Failed to ban peer {addr}: {err:?}");
+                        NodeResponse::BanPeer(false)
+                    }
+                };
+
+                let _ = responder.send(node_response);
+                return;
+            }
         };
 
         let peer = self.send_to_fast_peer(req, ServiceFlags::NONE);

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -106,6 +106,9 @@ pub enum UserRequest {
         /// The remote node will send min(height(stop_hash), 2_000) headers on each request.
         stop_hash: BlockHash,
     },
+
+    /// Ban a peer by its address, disconnecting it immediately.
+    BanPeer(BitcoinSocketAddr),
 }
 
 #[derive(Debug)]
@@ -155,6 +158,9 @@ pub enum NodeResponse {
 
     /// Received compact block filter headers.
     CFilterHeaders(CFHeaders),
+
+    /// A response indicating whether a peer was successfully banned.
+    BanPeer(bool),
 }
 
 #[derive(Debug)]
@@ -307,6 +313,12 @@ impl NetworkMethods for NodeHandle {
         let val = self.send_request(UserRequest::GetAddrManInfo).await?;
 
         extract_variant!(GetAddrManInfo, val)
+    }
+
+    async fn ban_peer(&self, addr: BitcoinSocketAddr) -> Result<bool, Self::Error> {
+        let val = self.send_request(UserRequest::BanPeer(addr)).await?;
+
+        extract_variant!(BanPeer, val)
     }
 }
 

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -151,6 +151,11 @@ pub trait NetworkMethods {
 
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> impl Future<Output = Result<ConnectionStats, Self::Error>>;
+
+    /// Bans a peer by its address, disconnecting it immediately.
+    ///
+    /// Returns a bool indicating whether the ban was successful.
+    fn ban_peer(&self, addr: BitcoinSocketAddr) -> impl Future<Output = Result<bool, Self::Error>>;
 }
 
 /// Methods used to interact with the node's configuration.


### PR DESCRIPTION
### Description

Closes #809.

Adds [ban_peer()](cci:1://file:///home/stonepillar/Documents/Workspace/foss/oss/Floresta/crates/floresta-wire/src/p2p_wire/node_interface.rs:258:4-272:5) to [NodeInterface](cci:2://file:///home/stonepillar/Documents/Workspace/foss/oss/Floresta/crates/floresta-wire/src/p2p_wire/node_interface.rs:164:0-166:1), allowing external consumers to ban a peer by address and port. Follows the same pattern as the existing [disconnect_peer()](cci:1://file:///home/stonepillar/Documents/Workspace/foss/oss/Floresta/crates/floresta-wire/src/p2p_wire/node_interface.rs:243:4-256:5) flow. Internally calls the existing [disconnect_and_ban()](cci:1://file:///home/stonepillar/Documents/Workspace/foss/oss/Floresta/crates/floresta-wire/src/p2p_wire/node/peer_man.rs:495:4-506:5) method.
