### PR TITLE
Use `core::str` and `core::fmt` instead of `std::*`

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 mod parsers;
 
 use anyhow::Ok;

--- a/bin/floresta-cli/src/parsers.rs
+++ b/bin/floresta-cli/src/parsers.rs
@@ -1,7 +1,9 @@
 use core::error::Error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
+use core::str::FromStr;
 use std::any::type_name;
-use std::fmt::Display;
-use std::str::FromStr;
 
 #[derive(Debug)]
 /// Collection of errors to deal with parsing.
@@ -15,7 +17,7 @@ pub enum ParseError {
 }
 
 impl Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ParseError::InvalidArray => write!(
                 f,

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -1,4 +1,5 @@
 use core::cmp::min;
+use core::error::Error;
 use core::ops::Add;
 
 use bitcoin::block::Header;
@@ -6,7 +7,6 @@ use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::BlockHash;
 use bitcoin::Work;
 use floresta_common::prelude::Box;
-use floresta_common::prelude::Error;
 use floresta_common::prelude::String;
 use floresta_common::prelude::Vec;
 
@@ -269,6 +269,9 @@ impl WorkExt for Work {
 
 #[cfg(test)]
 mod tests {
+    use core::fmt;
+    use core::fmt::Display;
+    use core::fmt::Formatter;
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -294,8 +297,8 @@ mod tests {
         NotFound,
     }
 
-    impl std::fmt::Display for MockBlockchainError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl Display for MockBlockchainError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
             write!(f, "MockBlockchainError")
         }
     }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1435,7 +1435,6 @@ macro_rules! write_lock {
 
 #[cfg(all(test, feature = "flat-chainstore"))]
 mod test {
-    use core::str::FromStr;
     use std::format;
     use std::fs::File;
     use std::io::Cursor;

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -21,8 +21,8 @@ use crate::DatabaseError;
 /// likely on disk.
 ///
 /// This trait requires an associated error type that implements [DatabaseError]; a marker trait
-/// satisfied by any `T: core::error::Error + std::fmt::Display`. This is useful to abstract the
-/// database implementation from the blockchain.
+/// satisfied by any `T: Display + Error`. This is useful to abstract the database implementation
+/// from the blockchain.
 pub trait ChainStore {
     type Error: DatabaseError;
 

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -7,8 +7,13 @@
 //!
 //! Each error type implements `Display` and `Debug` for error reporting.
 
-use core::fmt::Debug;
 extern crate alloc;
+
+use core::error::Error;
+use core::fmt;
+use core::fmt::Debug;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use bitcoin::Network;
 use bitcoin::OutPoint;
@@ -96,13 +101,13 @@ macro_rules! tx_err {
 }
 
 impl Display for TransactionError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Transaction {} is invalid: {}", self.txid, self.error)
     }
 }
 
 impl Display for BlockValidationErrors {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             BlockValidationErrors::BlockDoesntExtendTip => {
                 write!(f, "This block doesn't build directly on the tip")

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1324,7 +1324,6 @@ pub mod migrate_v0_to_v1 {
 mod tests {
     use core::mem::size_of;
     use std::fs;
-    use std::str::FromStr;
 
     use bitcoin::block::Header;
     use bitcoin::consensus::deserialize;

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! - [BlockchainInterface]: The main interface for interacting with the backend
 //! - [UpdatableChainstate]: Trait defining methods for updating the chain state
+
 extern crate alloc;
 
 pub mod chain_state;
@@ -20,6 +21,7 @@ pub mod partial_chain;
 pub mod udata;
 
 use alloc::sync::Arc;
+use core::error::Error;
 
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::hashes::sha256;

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -20,6 +20,7 @@
 //!     leak through the API, as we are not enforcing lifetime or borrowing rules at compile time.
 //!   - Sending is fine: There's nothing in this module that makes it not sendable to between
 //!     threads, as long as the origin thread gives away the ownership.
+
 use core::cell::UnsafeCell;
 
 use bitcoin::block::Header as BlockHeader;
@@ -459,7 +460,6 @@ impl From<PartialChainStateInner> for PartialChainState {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
     use std::collections::HashMap;
 
     use bitcoin::block::Header;

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -179,6 +179,10 @@ impl Encodable for ScriptPubKeyKind {
 /// to consume a block (delete transactions included in it from the mempool);
 /// or to validate a block.
 pub mod proof_util {
+    use core::fmt;
+    use core::fmt::Display;
+    use core::fmt::Formatter;
+
     use bitcoin::blockdata::script;
     use bitcoin::blockdata::script::Instruction;
     use bitcoin::consensus::Encodable;
@@ -552,10 +556,6 @@ pub mod proof_util {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
-
-    use std::str::FromStr;
-
     use bitcoin::blockdata::script;
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::opcodes::all::OP_NOP;

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -90,6 +90,8 @@ pub mod service_flags {
 pub fn parse_descriptors(
     descriptors: &[String],
 ) -> Result<Vec<Descriptor<DescriptorPublicKey>>, miniscript::Error> {
+    use core::str::FromStr;
+
     let descriptors = descriptors
         .iter()
         .map(|descriptor| {
@@ -116,9 +118,6 @@ pub mod prelude {
     pub use alloc::vec::Vec;
     pub use core::cmp;
     pub use core::convert;
-    pub use core::error::Error;
-    pub use core::fmt;
-    pub use core::fmt::Display;
     pub use core::iter;
     pub use core::mem;
     pub use core::ops;
@@ -127,8 +126,6 @@ pub mod prelude {
     pub use core::option;
     pub use core::result;
     pub use core::slice;
-    pub use core::str;
-    pub use core::str::FromStr;
 
     pub use bitcoin::io::Error as ioError;
     pub use bitcoin::io::Read;
@@ -149,22 +146,17 @@ pub mod prelude {
     extern crate std;
     pub use alloc::format;
     pub use alloc::string::ToString;
-    pub use core::error::Error;
     pub use std::borrow::ToOwned;
     pub use std::boxed::Box;
     pub use std::collections::hash_map::Entry;
     pub use std::collections::HashMap;
     pub use std::collections::HashSet;
-    pub use std::fmt::Display;
-    pub use std::fmt::Formatter;
-    pub use std::fmt::{self};
     pub use std::io::Error as ioError;
     pub use std::io::Read;
     pub use std::io::Write;
     pub use std::ops::Deref;
     pub use std::ops::DerefMut;
     pub use std::result::Result;
-    pub use std::str::FromStr;
     pub use std::string::String;
     pub use std::sync;
     pub use std::vec;

--- a/crates/floresta-common/src/macros.rs
+++ b/crates/floresta-common/src/macros.rs
@@ -100,32 +100,32 @@ macro_rules! assert_err {
 }
 
 #[macro_export]
-/// Validates a block hash at compile time. Requires `FromStr` and `BlockHash` in scope.
+/// Validates a block hash at compile time. Requires `BlockHash` to be in scope.
 macro_rules! bhash {
-    ($s:expr) => {{
-        // Catch invalid literals at compile time
+    ($s:literal) => {{
+        // Catch invalid literals at compile time.
         const _: () = match $crate::macros::validate_hash_compile_time($s) {
             Ok(()) => (),
             Err(e) => panic!("{}", e),
         };
-        BlockHash::from_str($s).expect("Literal should be valid")
+        $s.parse::<BlockHash>().expect("Literal should be valid")
     }};
 }
 
 #[macro_export]
-/// Validates utreexo node hashes at compile time. Requires `FromStr` and `BitcoinNodeHash` in scope.
+/// Validates Utreexo node hashes at compile time. Requires `BitcoinNodeHash` to be in scope.
 ///
-/// - Accepts one or more comma-separated hash literal expressions.
+/// - Accepts one or more comma-separated hash literals.
 /// - Allows an optional trailing comma.
 macro_rules! acchashes {
-    ( $( $s:expr ),+ $(,)? ) => {
+    ( $( $s:literal ),+ $(,)? ) => {
         [ $( {
-            // Catch invalid literals at compile time
+            // Catch invalid literals at compile time.
             const _: () = match $crate::macros::validate_hash_compile_time($s) {
                 Ok(()) => (),
                 Err(e) => panic!("{}", e),
             };
-            BitcoinNodeHash::from_str($s).expect("Literal should be valid")
+            $s.parse::<BitcoinNodeHash>().expect("Literal should be valid")
         } ),+ ]
     };
 }
@@ -202,12 +202,12 @@ mod test {
             }
         }
 
-        // Invalid hex character at the end: 'g'.
+        // Invalid hex character at the end: 'g'
         let invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
         assert_eq!(invalid.len(), 64);
         assert_err!(validate_hash(invalid));
 
-        // Invalid ascii character in the middle: 'é'
+        // Invalid ASCII character in the middle: 'é'
         let invalid_ascii = "0123456789abcdef0123456789abcdéf0123456789abcdef0123456789abcde";
         assert_eq!(invalid_ascii.len(), 64);
         assert_err!(validate_hash(invalid_ascii));

--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -18,8 +18,10 @@
 )]
 #![allow(clippy::manual_is_multiple_of)]
 
+use core::fmt;
 use core::fmt::Debug;
-use std::fmt::Display;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::sync::PoisonError;
 use std::sync::RwLockWriteGuard;
 
@@ -53,7 +55,7 @@ pub enum IterableFilterStoreError {
 }
 
 impl Debug for IterableFilterStoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             IterableFilterStoreError::Io(e) => write!(f, "I/O error: {e}"),
             IterableFilterStoreError::Eof => write!(f, "End of file"),
@@ -70,7 +72,7 @@ impl From<std::io::Error> for IterableFilterStoreError {
 }
 
 impl Display for IterableFilterStoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self, f)
     }
 }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -933,8 +933,8 @@ macro_rules! get_arg {
 
 #[cfg(test)]
 mod test {
+    use core::str::FromStr;
     use std::io;
-    use std::str::FromStr;
     use std::sync::Arc;
     use std::time::Duration;
 

--- a/crates/floresta-electrum/src/error.rs
+++ b/crates/floresta-electrum/src/error.rs
@@ -10,13 +10,13 @@ pub enum Error {
     Parsing(#[from] serde_json::Error),
 
     #[error("Blockchain error")]
-    Blockchain(Box<dyn floresta_common::prelude::Error + Send + 'static>),
+    Blockchain(Box<dyn core::error::Error + Send + 'static>),
 
     #[error("IO error")]
     Io(#[from] std::io::Error),
 
     #[error("Mempool accept error")]
-    Mempool(Box<dyn floresta_common::prelude::Error + Send + 'static>),
+    Mempool(Box<dyn core::error::Error + Send + 'static>),
 
     #[error("Node isn't working")]
     NodeInterface(#[from] oneshot::error::RecvError),

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -3,10 +3,11 @@
 //! Once our transaction is included in a block, we remove it from the mempool.
 
 use core::error::Error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::fmt::Display;
-use std::fmt::Formatter;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -86,7 +87,7 @@ pub enum AcceptToMempoolError {
 }
 
 impl Display for AcceptToMempoolError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             AcceptToMempoolError::MemoryUsageTooHigh => write!(f, "we are running out of memory"),
             AcceptToMempoolError::ConflictingTransaction => {
@@ -366,7 +367,6 @@ impl Mempool {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::str::FromStr;
 
     use bitcoin::absolute;
     use bitcoin::block;

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -1,4 +1,7 @@
 use core::error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::net::AddrParseError;
 
 use bitcoin::consensus::encode;
@@ -127,8 +130,8 @@ pub enum FlorestadError {
     CouldNotLoadFlatChainStore(BlockchainError),
 }
 
-impl std::fmt::Display for FlorestadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for FlorestadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             FlorestadError::Encode(err) => write!(f, "Encode error: {err}"),
             FlorestadError::ParseNum(err) => write!(f, "int parse error: {err}"),

--- a/crates/floresta-node/src/json_rpc/request.rs
+++ b/crates/floresta-node/src/json_rpc/request.rs
@@ -27,7 +27,7 @@ pub struct RpcRequest {
 /// methods already handle the case where the parameter is missing or has an
 /// unexpected type, returning an error if so.
 pub mod arg_parser {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use serde_json::Value;
 

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -1,4 +1,7 @@
-use std::fmt::Display;
+use core::fmt;
+use core::fmt::Debug;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use axum::response::IntoResponse;
 use corepc_types::v30::GetBlockVerboseOne;
@@ -225,7 +228,7 @@ pub enum JsonRpcError {
 impl_error_from!(JsonRpcError, AcceptToMempoolError, MempoolAccept);
 
 impl Display for JsonRpcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             JsonRpcError::InvalidTimestamp => write!(f, "Invalid timestamp, ensure that it is between the genesis and the tip."),
             JsonRpcError::InvalidRescanVal => write!(f, "Your rescan request contains invalid values"),
@@ -285,7 +288,7 @@ impl From<HeaderExtError> for JsonRpcError {
 
 impl_error_from!(JsonRpcError, miniscript::Error, InvalidDescriptor);
 
-impl<T: std::fmt::Debug> From<floresta_watch_only::WatchOnlyError<T>> for JsonRpcError {
+impl<T: Debug> From<floresta_watch_only::WatchOnlyError<T>> for JsonRpcError {
     fn from(e: floresta_watch_only::WatchOnlyError<T>) -> Self {
         JsonRpcError::Wallet(e.to_string())
     }

--- a/crates/floresta-node/src/slip132.rs
+++ b/crates/floresta-node/src/slip132.rs
@@ -7,7 +7,7 @@
 //! Bitcoin SLIP-132 standard implementation for parsing custom xpub/xpriv key
 //! formats
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use bitcoin::base58;
 use bitcoin::bip32;

--- a/crates/floresta-node/src/wallet_input.rs
+++ b/crates/floresta-node/src/wallet_input.rs
@@ -1,6 +1,6 @@
 //! Handles different inputs, try to make sense out of it and store a sane descriptor at the end
 
-use std::str::FromStr;
+use core::str::FromStr;
 
 use bitcoin::Address;
 use bitcoin::Network;

--- a/crates/floresta-rpc/src/jsonrpc_client.rs
+++ b/crates/floresta-rpc/src/jsonrpc_client.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::Deserialize;
 

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -26,13 +26,13 @@ pub mod rpc_types;
 
 #[cfg(all(test, feature = "with-jsonrpc", not(target_os = "windows")))]
 mod tests {
+    use core::str::FromStr;
     use std::fs;
     use std::net::TcpListener;
     use std::path::Path;
     use std::process::Child;
     use std::process::Command;
     use std::process::Stdio;
-    use std::str::FromStr;
     use std::thread::sleep;
     use std::time::Duration;
 

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::BlockHash;

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -1,5 +1,7 @@
 use core::error;
-use std::fmt::Display;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use corepc_types::v30::GetBlockVerboseOne;
 use serde::Deserialize;
@@ -257,7 +259,7 @@ impl From<jsonrpc::Error> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             #[cfg(feature = "with-jsonrpc")]
             Error::JsonRpc(e) => write!(f, "JsonRpc returned an error {e}"),
@@ -333,7 +335,7 @@ pub enum AddNodeCommand {
 /// Useful for get the subcommand name of addnode with
 /// command.to_string()
 impl Display for AddNodeCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let cmd = match self {
             AddNodeCommand::Add => "add",
             AddNodeCommand::Remove => "remove",

--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -1,5 +1,10 @@
+use core::error::Error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
+
 use bitcoin::consensus::deserialize;
-use bitcoin::consensus::encode::Error;
+use bitcoin::consensus::encode::Error as EncodingError;
 use bitcoin::consensus::serialize;
 use bitcoin::hashes::Hash;
 use bitcoin::Txid;
@@ -29,12 +34,12 @@ pub enum KvDatabaseError {
     KvError(kv::Error),
     SerdeJsonError(serde_json::Error),
     WalletNotInitialized,
-    DeserializeError(Error),
+    DeserializeError(EncodingError),
     TransactionNotFound,
 }
 impl_error_from!(KvDatabaseError, serde_json::Error, SerdeJsonError);
 impl_error_from!(KvDatabaseError, kv::Error, KvError);
-impl_error_from!(KvDatabaseError, Error, DeserializeError);
+impl_error_from!(KvDatabaseError, EncodingError, DeserializeError);
 
 impl Display for KvDatabaseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -48,7 +53,7 @@ impl Display for KvDatabaseError {
     }
 }
 
-impl floresta_common::prelude::Error for KvDatabaseError {}
+impl Error for KvDatabaseError {}
 
 type Result<T> = floresta_common::prelude::Result<T, KvDatabaseError>;
 

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -9,7 +9,11 @@
 #![allow(clippy::manual_is_multiple_of)]
 
 use core::cmp::Ordering;
+use core::error::Error;
+use core::fmt;
 use core::fmt::Debug;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use bitcoin::hashes::sha256;
 use bitcoin::ScriptBuf;
@@ -41,14 +45,14 @@ use sync::RwLock;
 use tracing::error;
 
 #[derive(Debug)]
-pub enum WatchOnlyError<DatabaseError: fmt::Debug> {
+pub enum WatchOnlyError<DatabaseError: Debug> {
     WalletNotInitialized,
     TransactionNotFound,
     DatabaseError(DatabaseError),
 }
 
-impl<DatabaseError: fmt::Debug> Display for WatchOnlyError<DatabaseError> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<DatabaseError: Debug> Display for WatchOnlyError<DatabaseError> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             WatchOnlyError::WalletNotInitialized => {
                 write!(f, "Wallet isn't initialized")
@@ -63,13 +67,13 @@ impl<DatabaseError: fmt::Debug> Display for WatchOnlyError<DatabaseError> {
     }
 }
 
-impl<DatabaseError: fmt::Debug> From<DatabaseError> for WatchOnlyError<DatabaseError> {
+impl<DatabaseError: Debug> From<DatabaseError> for WatchOnlyError<DatabaseError> {
     fn from(e: DatabaseError) -> Self {
         WatchOnlyError::DatabaseError(e)
     }
 }
 
-impl<T: Debug> floresta_common::prelude::Error for WatchOnlyError<T> {}
+impl<T: Debug> Error for WatchOnlyError<T> {}
 
 /// Every address contains zero or more associated transactions, this struct defines what
 /// data we store for those.
@@ -139,7 +143,7 @@ pub struct Stats {
 
 /// Public trait defining a common interface for databases to be used with our cache
 pub trait AddressCacheDatabase {
-    type Error: fmt::Debug + Send + Sync + 'static;
+    type Error: Debug + Send + Sync + 'static;
     /// Saves a new address to the database. If the address already exists, `update` should
     /// be used instead
     fn save(&self, address: &CachedAddress);
@@ -786,6 +790,8 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
 
 #[cfg(test)]
 mod test {
+    use core::str::FromStr;
+
     use bitcoin::address::NetworkChecked;
     use bitcoin::consensus::deserialize;
     use bitcoin::consensus::Decodable;

--- a/crates/floresta-watch-only/src/merkle.rs
+++ b/crates/floresta-watch-only/src/merkle.rs
@@ -8,17 +8,20 @@ use bitcoin::Txid;
 use floresta_common::prelude::*;
 use serde::Deserialize;
 use serde::Serialize;
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MerkleProof {
     pub target: Txid,
     pub pos: u64,
     pub hashes: Vec<sha256d::Hash>,
 }
+
 impl Default for MerkleProof {
     fn default() -> Self {
         Self::new()
     }
 }
+
 impl MerkleProof {
     /// Creates an empty proof
     fn new() -> Self {
@@ -195,6 +198,8 @@ impl Encodable for MerkleProof {
 
 #[cfg(test)]
 mod test {
+    use core::str::FromStr;
+
     use bitcoin::consensus::deserialize;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::hashes::sha256d;

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -2,6 +2,7 @@
 //! metadata. This module is very important in keeping our node protected against targeted
 //! attacks, like eclipse attacks.
 
+use core::str::FromStr;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs::read_to_string;
@@ -9,7 +10,6 @@ use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
-use std::str::FromStr;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 

--- a/crates/floresta-wire/src/p2p_wire/block_proof.rs
+++ b/crates/floresta-wire/src/p2p_wire/block_proof.rs
@@ -278,8 +278,6 @@ impl Decodable for UtreexoProof {
 
 #[cfg(test)]
 mod utreexo_proof_tests {
-    use std::str::FromStr;
-
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::hashes::sha256;
     use bitcoin::Block;

--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -1,6 +1,6 @@
-use std::fmt::Display;
-use std::fmt::Formatter;
-use std::fmt::{self};
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::io;
 use std::net::IpAddr;
 
@@ -90,8 +90,8 @@ pub enum WireError {
     LeafDataNotFound,
 }
 
-impl std::fmt::Display for WireError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for WireError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             WireError::Blockchain(err) => write!(f, "Blockchain error: {err:?}"),
             WireError::ChannelSend(err) => write!(f, "Error while writing into channel: {err:?}"),

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -10,8 +10,8 @@ pub mod running_ctx;
 pub mod sync_ctx;
 mod user_req;
 
+use core::fmt::Debug;
 use std::collections::HashMap;
-use std::fmt::Debug;
 use std::net::IpAddr;
 use std::ops::Deref;
 use std::ops::DerefMut;

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -1,4 +1,7 @@
-use std::fmt::Debug;
+use core::fmt;
+use core::fmt::Debug;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -165,8 +168,8 @@ pub enum PeerError {
     Transport(TransportError),
 }
 
-impl std::fmt::Display for PeerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for PeerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             PeerError::Send => write!(f, "Error while sending to peer"),
             PeerError::Read(err) => write!(f, "Error while reading from peer: {err:?}"),
@@ -207,7 +210,7 @@ pub enum ReaderMessage {
 }
 
 impl<T: AsyncWrite + Unpin + Send + Sync> Debug for Peer<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.id)?;
         Ok(())
     }

--- a/crates/floresta-wire/src/p2p_wire/socks.rs
+++ b/crates/floresta-wire/src/p2p_wire/socks.rs
@@ -7,6 +7,9 @@
 //! they want.
 
 use core::error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
@@ -133,8 +136,8 @@ impl From<tokio::io::Error> for Socks5Error {
     }
 }
 
-impl std::fmt::Display for Socks5Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Socks5Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Socks5Error::InvalidVersion => write!(f, "Invalid SOCKS version"),
             Socks5Error::InvalidAuthMethod => write!(f, "Invalid authentication method"),

--- a/crates/floresta-wire/src/p2p_wire/tests/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/chain_selector.rs
@@ -1,7 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use bitcoin::BlockHash;
     use bitcoin::Network;
     use floresta_chain::pruned_utreexo::BlockchainInterface;

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -1,3 +1,6 @@
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::io;
 
 use bip324::serde::deserialize as deserialize_v2;
@@ -66,8 +69,8 @@ pub enum TransportError {
     Proxy(Socks5Error),
 }
 
-impl std::fmt::Display for TransportError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for TransportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             TransportError::Io(err) => write!(f, "IO error: {err:?}"),
             TransportError::Protocol(err) => write!(f, "V2 protocol error: {err:?}"),

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -5,7 +5,7 @@
 //! This will validate all blocks from genesis to the current tip, so it will take a while
 //! to sync.
 
-use std::str::FromStr;
+use core::str::FromStr;
 use std::sync::Arc;
 
 use bitcoin::BlockHash;

--- a/fuzz/fuzz_targets/local_address_str.rs
+++ b/fuzz/fuzz_targets/local_address_str.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use core::str;
-use std::str::FromStr;
+use core::str::FromStr;
 
 use floresta_wire::address_man::LocalAddress;
 use libfuzzer_sys::fuzz_target;


### PR DESCRIPTION
Closes #874 

Since `str` is stable since [1.6.0](https://doc.rust-lang.org/core/str/index.html), and `fmt` since [1.6.0](https://doc.rust-lang.org/core/fmt/index.html), we use `core::str` and `core::fmt` instead of `std::*`.

Also removes duplicate imports from `std` and `no-std` `floresta_commom::prelude`, and imports them in their respective call sites.