### PR TITLE
chore: implement Display for error types

### DIFF
--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::error::Error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use bitcoin::Block;
 use bitcoin::BlockHash;
@@ -103,6 +106,16 @@ pub enum HeaderExtError {
 
     /// You got an overflow while calculating the chain work.
     ChainWorkOverflow,
+}
+
+impl Display for HeaderExtError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            HeaderExtError::Chain(e) => write!(f, "Chain error: {e}"),
+            HeaderExtError::BlockNotFound => write!(f, "Block not found"),
+            HeaderExtError::ChainWorkOverflow => write!(f, "Chain work overflow"),
+        }
+    }
 }
 
 impl HeaderExt for Header {

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state_builder.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state_builder.rs
@@ -11,6 +11,10 @@
 //! - UTREEXO accumulator state
 //! - Current chain tip and header
 
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
+
 use bitcoin::BlockHash;
 use bitcoin::Network;
 use bitcoin::block::Header as BlockHeader;
@@ -40,6 +44,17 @@ pub enum BlockchainBuilderError {
 
     /// Error while trying to save initial data.
     Database(Box<dyn DatabaseError>),
+}
+
+impl Display for BlockchainBuilderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockchainBuilderError::MissingChainstore => write!(f, "Missing chainstore"),
+            BlockchainBuilderError::MissingChainParams => write!(f, "Missing chain parameters"),
+            BlockchainBuilderError::IncompleteTip => write!(f, "Incomplete tip"),
+            BlockchainBuilderError::Database(e) => write!(f, "Database error: {e}"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -230,6 +230,16 @@ pub mod proof_util {
         NotPushBytes,
     }
 
+    impl Display for LeafErrorKind {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            match self {
+                LeafErrorKind::EmptyStack => write!(f, "Empty stack"),
+                LeafErrorKind::InvalidInstruction(e) => write!(f, "Invalid instruction: {e}"),
+                LeafErrorKind::NotPushBytes => write!(f, "Not push bytes"),
+            }
+        }
+    }
+
     /// Error while reconstructing a leaf's scriptPubKey, returned by `process_proof`.
     ///
     /// This error is triggered if the input lacks the hashed data required by the

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -5,6 +5,9 @@
 //! It's not meant to use in production, but for the integrated testing framework
 //!
 //! For actual databases that can be used for production code, see [KvDatabase](crate::kv_database::KvDatabase).
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use bitcoin::Txid;
 use bitcoin::hashes::sha256;
@@ -39,6 +42,14 @@ pub struct MemoryDatabase {
 }
 
 type Result<T> = floresta_common::prelude::Result<T, MemoryDatabaseError>;
+
+impl Display for MemoryDatabaseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            MemoryDatabaseError::PoisonedLock => write!(f, "Poisoned lock"),
+        }
+    }
+}
 
 impl MemoryDatabase {
     /// Create a new [`MemoryDatabase`].


### PR DESCRIPTION
### Description
Closes #667.

Implements `Display` for all error types that were missing it, allowing them to be integrated into custom error types using `thiserror` and `#[error(transparent)]`.

### Error Types Updated
- **MemoryDatabaseError** — `floresta-watch-only`
- **HeaderExtError** — `floresta-chain`
- **FlatChainstoreError** — `floresta-chain`
- **BlockchainBuilderError** — `floresta-chain`
- **LeafErrorKind** — `floresta-chain`
- **slip132::Error** — `floresta-node`

*AI was used to help identify error types missing Display implementations across the codebase*