### PR TITLE
Add P2P addr/addrv2 tests + oversized/spam message checks

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -539,7 +539,11 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                     self.write(NetworkMessage::Inv(Vec::new())).await?;
                 }
                 NetworkMessage::GetAddr => {
-                    self.write(NetworkMessage::AddrV2(Vec::new())).await?;
+                    if self.wants_addrv2 {
+                        self.write(NetworkMessage::AddrV2(Vec::new())).await?;
+                        return Ok(());
+                    }
+                    self.write(NetworkMessage::Addr(Vec::new())).await?;
                 }
                 NetworkMessage::GetData(inv) => {
                     for inv_el in inv {
@@ -555,8 +559,8 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                     }
                 }
                 NetworkMessage::SendAddrV2 => {
-                    self.wants_addrv2 = true;
-                    self.write(NetworkMessage::SendAddrV2).await?;
+                    warn!("Peer {} sent SendAddrV2 after handshake completed", self.id);
+                    return Err(PeerError::UnexpectedMessage);
                 }
                 NetworkMessage::Pong(_) => {
                     self.last_ping = None;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ markers = [
     "example: marks tests that demonstrate how to use the Floresta test framework",
     "florestad: marks tests specific to the Florestad daemon",
     "rpc: marks tests focused on RPC calls",
+    "p2p: marks tests related to peer-to-peer interactions",
 ]
 
 minversion = "9.0"

--- a/tests/floresta-cli/getbestblockhash.py
+++ b/tests/floresta-cli/getbestblockhash.py
@@ -7,14 +7,11 @@ utreexod. Then, assert that the command returns the same hash of
 and utreexod, respectively.
 """
 
-import time
 import pytest
-
-TIMEOUT_SECONDS = 20
 
 
 @pytest.mark.rpc
-def test_get_best_block_hash(florestad_utreexod):
+def test_get_best_block_hash(node_manager, florestad_utreexod):
     """
     Test checks if Floresta can synchronize with the blockchain
     and retrieve the hash of the last block via the getbestblockhash RPC.
@@ -27,14 +24,8 @@ def test_get_best_block_hash(florestad_utreexod):
     assert floresta_best_block == utreexo_best_block
 
     utreexod.rpc.generate(10)
-    end = time.time() + TIMEOUT_SECONDS
-    while time.time() < end:
-        floresta_block = florestad.rpc.get_block_count()
-        utreexo_block = utreexod.rpc.get_block_count()
-        if floresta_block == utreexo_block:
-            break
 
-        time.sleep(1)
+    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
 
     utreexo_chain = utreexod.rpc.get_blockchain_info()
     floresta_best_block = florestad.rpc.get_bestblockhash()

--- a/tests/floresta-cli/getblock.py
+++ b/tests/floresta-cli/getblock.py
@@ -9,10 +9,7 @@ This functional test cli utility to interact with a Floresta node with `getblock
 import time
 import random
 from typing import Any
-
 import pytest
-
-TIMEOUT_SECONDS = 20
 
 
 class TestGetBlock:
@@ -44,14 +41,8 @@ class TestGetBlock:
         self.node_manager.connect_nodes(self.florestad, self.bitcoind)
 
         block_count = self.bitcoind.rpc.get_block_count()
-        end = time.time() + TIMEOUT_SECONDS
-        while time.time() < end:
-            floresta_count = self.florestad.rpc.get_block_count()
-            if floresta_count == block_count:
-                break
-            time.sleep(0.5)
 
-        assert floresta_count == block_count
+        self.node_manager.wait_for_sync_nodes(is_finished_ibd=False)
 
         self.log.info("Testing getblock RPC in the genesis block")
         self.compare_block(0)

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -9,12 +9,10 @@ treated as the source of truth, so future Core API changes surface as test
 failures rather than silent drift.
 """
 
-import time
 import pytest
 
-from test_framework.util import wait_for_chain_sync
+from test_framework.util import wait_until
 
-TIMEOUT_SECONDS = 30
 MINE_BLOCKS = 10
 EXTRA_BLOCKS = 5
 # Fields where florestad diverges from bitcoind:
@@ -23,19 +21,8 @@ EXTRA_BLOCKS = 5
 FLORESTA_SPECIFIC_FIELDS = ("pruned", "size_on_disk")
 
 
-def _wait_for_size_growth(node, baseline):
-    end = time.time() + TIMEOUT_SECONDS
-    current = baseline
-    while time.time() < end:
-        current = node.rpc.get_blockchain_info()["size_on_disk"]
-        if current > baseline:
-            return current
-        time.sleep(0.5)
-    return current
-
-
 @pytest.mark.rpc
-def test_get_blockchain_info(florestad_bitcoind_utreexod_with_chain):
+def test_get_blockchain_info(node_manager, florestad_bitcoind_utreexod_with_chain):
     """
     Compare florestad's getblockchaininfo response against bitcoind's after a
     small chain extension. Iterates bitcoind's keys so any new field added in
@@ -43,14 +30,7 @@ def test_get_blockchain_info(florestad_bitcoind_utreexod_with_chain):
     """
     florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
 
-    wait_for_chain_sync(
-        florestad,
-        bitcoind,
-        utreexod,
-        MINE_BLOCKS,
-        TIMEOUT_SECONDS,
-        wait_for_ibd_exit=True,
-    )
+    node_manager.wait_for_sync_nodes()
 
     floresta_info = florestad.rpc.get_blockchain_info()
     bitcoind_info = bitcoind.rpc.get_blockchain_info()
@@ -70,10 +50,10 @@ def test_get_blockchain_info(florestad_bitcoind_utreexod_with_chain):
     assert isinstance(size_before, int)
 
     utreexod.rpc.generate(EXTRA_BLOCKS)
+    node_manager.wait_for_sync_nodes()
+
     # Poll for growth: get_block_count moves on header receipt, but acc roots
     # are only written post-validation.
-    size_after = _wait_for_size_growth(florestad, size_before)
-    assert size_after > size_before, (
-        f"size_on_disk did not grow after mining {EXTRA_BLOCKS} blocks: "
-        f"before={size_before} after={size_after}"
+    wait_until(
+        lambda: florestad.rpc.get_blockchain_info()["size_on_disk"] > size_before
     )

--- a/tests/floresta-cli/getblockcount.py
+++ b/tests/floresta-cli/getblockcount.py
@@ -6,15 +6,13 @@ utreexod. Then, assert that the command returns the same number of
 `blocks` and `height/validated` fields given in `getblockchaininfo`
 of utreexod/bitcoind and floresta, respectively"""
 
-import time
 import pytest
 
 MINE_BLOCKS = 10
-TIMEOUT_SECONDS = 20
 
 
 @pytest.mark.rpc
-def test_get_block_count(florestad_utreexod):
+def test_get_block_count(florestad_utreexod, node_manager):
     """
     Test the `getblockcount` shows the block count changes before and after mining.
     """
@@ -28,15 +26,8 @@ def test_get_block_count(florestad_utreexod):
 
     # Mine blocks with utreexod
     utreexod.rpc.generate(MINE_BLOCKS)
-    timeout = time.time() + TIMEOUT_SECONDS
-    while time.time() < timeout:
-        if (
-            florestad.rpc.get_block_count()
-            == utreexod.rpc.get_block_count()
-            == MINE_BLOCKS
-        ):
-            break
-        time.sleep(1)
+
+    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
 
     # Get final block counts
     final_florestad_count = florestad.rpc.get_block_count()

--- a/tests/floresta-cli/getblockhash.py
+++ b/tests/floresta-cli/getblockhash.py
@@ -6,17 +6,15 @@ getblockhash.py
 This functional test cli utility to interact with a Floresta node with `getblockhash`
 """
 
-import time
 import pytest
 
 from test_framework.constants import GENESIS_BLOCK_HASH
 
 MINED_BLOCKS = 10
-TIMEOUT = 20
 
 
 @pytest.mark.rpc
-def test_get_block_hash(florestad_utreexod):
+def test_get_block_hash(florestad_utreexod, node_manager):
     """
     Test the `getblockhash` shows the block hash.
     """
@@ -30,15 +28,7 @@ def test_get_block_hash(florestad_utreexod):
 
     # Mine blocks with utreexod
     utreexod.rpc.generate(MINED_BLOCKS)
-    timeout = time.time() + TIMEOUT
-    while time.time() < timeout:
-        if (
-            florestad.rpc.get_block_count()
-            == utreexod.rpc.get_block_count()
-            == MINED_BLOCKS
-        ):
-            break
-        time.sleep(1)
+    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
 
     # Get final block hashes
     final_florestad_hash = florestad.rpc.get_blockhash(MINED_BLOCKS)

--- a/tests/floresta-cli/getdeploymentinfo.py
+++ b/tests/floresta-cli/getdeploymentinfo.py
@@ -14,9 +14,6 @@ response but skipped on the floresta side.
 
 import pytest
 
-from test_framework.util import wait_for_chain_sync
-
-TIMEOUT_SECONDS = 30
 MINE_BLOCKS = 10
 
 # Five buried deployments per Bitcoin Core's deploymentinfo.cpp enum
@@ -28,15 +25,15 @@ BURIED_DEPLOYMENTS = ("bip34", "bip66", "bip65", "csv", "segwit")
 
 # pylint: disable=too-many-locals
 @pytest.mark.rpc
-def test_get_deployment_info(florestad_bitcoind_utreexod_with_chain):
+def test_get_deployment_info(node_manager, florestad_bitcoind_utreexod_with_chain):
     """
     Compare florestad's getdeploymentinfo response against bitcoind's after a
     small chain extension. Each buried deployment must match by type, height
     and active flag. BIP9 entries are validated by absence on the floresta side.
     """
-    florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
+    florestad, bitcoind, _ = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
 
-    wait_for_chain_sync(florestad, bitcoind, utreexod, MINE_BLOCKS, TIMEOUT_SECONDS)
+    node_manager.wait_for_sync_nodes()
 
     floresta_info = florestad.rpc.get_deployment_info()
     bitcoind_info = bitcoind.rpc.get_deployment_info()

--- a/tests/floresta-cli/gettxout.py
+++ b/tests/floresta-cli/gettxout.py
@@ -6,50 +6,21 @@ gettxout.py
 This functional test cli utility to interact with a Floresta node with `gettxout` command.
 """
 
-import time
 import pytest
-
-TIMEOUT_SECONDS = 120
 
 
 # pylint: disable=too-many-locals
 @pytest.mark.rpc
-def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain):
+def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain, node_manager):
     """
     Test the `gettxout` command for a specific transaction output.
     """
     log = setup_logging
     blocks = 10
-    florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(blocks)
-
-    peer_info = bitcoind.rpc.get_peerinfo()
-    peer_id = next(peer["id"] for peer in peer_info if "utreexo" in peer["subver"])
-    best_block_hash = utreexod.rpc.get_blockhash(blocks)
+    florestad, bitcoind, _ = florestad_bitcoind_utreexod_with_chain(blocks)
 
     log.info("Waiting for Floresta and Bitcoind to sync with Utreexod...")
-    timeout = time.time() + TIMEOUT_SECONDS
-    while time.time() < timeout:
-        floresta_info = florestad.rpc.get_blockchain_info()
-        if (
-            floresta_info["headers"]
-            == utreexod.rpc.get_block_count()
-            == bitcoind.rpc.get_block_count()
-            == blocks
-            and not floresta_info["initialblockdownload"]
-        ):
-            break
-
-        time.sleep(1)
-        # Forcing a re-fetch of the block from the peer
-        try:
-            bitcoind.rpc.get_block_from_peer(best_block_hash, peer_id)
-        # pylint: disable=broad-exception-caught
-        except Exception as e:
-            log.error(f"Error fetching block from peer: {e}")
-
-    assert (
-        floresta_info["headers"] == blocks and not floresta_info["initialblockdownload"]
-    )
+    node_manager.wait_for_sync_nodes()
 
     log.info("Comparing gettxout results between Floresta and Bitcoind...")
     for height in range(2, blocks):

--- a/tests/florestad/reorg_chain.py
+++ b/tests/florestad/reorg_chain.py
@@ -9,23 +9,22 @@ make florestad switch to the new chain. We then compare the two node's main chai
 accumulator to make sure they are the same.
 """
 
-import time
 import pytest
 
 
 @pytest.mark.florestad
-def test_reorg_chain(setup_logging, florestad_utreexod):
+def test_reorg_chain(setup_logging, florestad_utreexod, node_manager):
     """Mine blocks, trigger a reorg and assert both nodes end up on the same chain."""
     log = setup_logging
     florestad, utreexod = florestad_utreexod
 
-    ChainReorgTest(log, florestad, utreexod).run()
+    ChainReorgTest(log, florestad, utreexod, node_manager).run()
 
 
 class ChainReorgTest:
     """Tests that Florestad follows Utreexod during a chain reorganization."""
 
-    def __init__(self, log, florestad, utreexod):
+    def __init__(self, log, florestad, utreexod, node_manager):
         """
         Attributes initialized to satisfy static analysis; real values are
         provided by pytest fixtures.
@@ -33,6 +32,7 @@ class ChainReorgTest:
         self.log = log
         self.florestad = florestad
         self.utreexod = utreexod
+        self.node_manager = node_manager
 
     def run(self):
         """Mine blocks, trigger a reorg and assert both nodes end up on the same chain."""
@@ -74,16 +74,4 @@ class ChainReorgTest:
         self.log.info(f"Utreexod node mine {blocks} blocks")
         self.utreexod.rpc.generate(blocks)
 
-        timeout = 30
-        end = time.time() + timeout
-        while time.time() < end:
-            florestad_block = self.florestad.rpc.get_block_count()
-            utreexod_block = self.utreexod.rpc.get_block_count()
-            if florestad_block == utreexod_block:
-                self.log.info(f"Nodes are in sync: {florestad_block} blocks")
-                break
-
-            time.sleep(1)
-
-        if florestad_block != utreexod_block:
-            pytest.fail("Florestad node did not sync with Utreexod node in time")
+        self.node_manager.wait_for_sync_nodes(is_finished_ibd=False)

--- a/tests/p2p/p2p_addr_relay.py
+++ b/tests/p2p/p2p_addr_relay.py
@@ -1,0 +1,243 @@
+"""
+p2p_addr_relay.py
+
+Test suite for P2P address relay functionality in Floresta.
+Verifies that the node correctly handles address messages (addr and addrv2),
+enforces message size limits, and responds to getaddr requests appropriately.
+"""
+
+import pytest
+
+from test_framework.messages import msg_addrv2, msg_sendaddrv2, msg_getaddr
+from test_framework.p2p import (
+    P2PInterface,
+)
+from test_framework.util import wait_until
+
+
+class AddrReceiver(P2PInterface):
+    """
+    A custom P2P interface that listens for and validates address messages.
+    Tracks whether addr (v1) and addrv2 messages are received.
+    """
+
+    addr_received_and_checked = False
+    addrv2_received_and_checked = False
+
+    def __init__(self, support_addrv2=True):
+        super().__init__(support_addrv2=support_addrv2)
+
+    def on_addr(self, message):
+        # Floresta does not send peer addresses to other nodes
+        if len(message.addrs) == 0:
+            self.addr_received_and_checked = True
+
+    def on_addrv2(self, message):
+        # Floresta does not send peer addresses to other nodes
+        if len(message.addrs) == 0:
+            self.addrv2_received_and_checked = True
+
+    def wait_for_addr(self):
+        """Wait for an addr message to be received."""
+        self.wait_until(lambda: "addr" in self.last_message)
+
+    def wait_for_addrv2(self):
+        """Wait for an addrv2 message to be received."""
+        self.wait_until(lambda: "addrv2" in self.last_message)
+
+
+class TestP2pAddrRelay:
+    """
+    Test that Floresta returns addresses when receiving GetAddr.
+    """
+
+    # define attributes at class level to avoid "defined outside __init__" warnings
+    florestad = None
+    log = None
+    node_manager = None
+    p2p_conn = None
+    p2p_receiver_v2 = None
+    p2p_receiver_v1 = None
+    default_msg = None
+
+    @pytest.mark.p2p
+    def test_addr_relay(self, setup_logging, node_manager, florestad_node):
+        """
+        Test relay of addr and addrv2 messages, including handling of oversized messages and
+        responses to getaddr requests.
+        """
+        self.florestad = florestad_node
+        self.log = setup_logging
+        self.node_manager = node_manager
+        self.default_msg = msg_addrv2()
+        self.default_msg.addrs = self.node_manager.create_node_address(10)
+
+        self.log.info("Testing sendaddrv2 message after handshake")
+        self.connect_p2p()
+
+        self.p2p_conn.send_without_ping(msg_sendaddrv2())
+        self.check_disconnection(self.p2p_conn)
+
+        self.log.info("Testing addrv2 message ")
+        self.connect_p2p()
+        self.p2p_conn.send_and_ping(self.default_msg)
+        assert self.p2p_conn.is_connected
+        assert self.floresta_has_peer_count(expected_peer_count=1)
+
+        # Generates I2P, Onion, IPv4, and IPv6 addresses; only IPv4/IPv6 are stored, others are
+        # rejected by node configuration.
+        self.check_addr_received(ipv4_expected=2, ipv6_expected=3)
+
+        self.log.info(
+            "Testing addrv2 message with varying number of addresses to check for disconnection on "
+            "oversized messages"
+        )
+        msg_oversized = msg_addrv2()
+
+        for quantity in range(998, 1002):
+            addr = self.node_manager.create_node_address(quantity)
+            msg_oversized.addrs = addr
+            msg_size = self.calc_addrv2_msg_size(addr)
+            self.log.info(
+                f"Testing addrv2 message with {len(msg_oversized.addrs)} addresses (size: "
+                f"{msg_size} bytes)"
+            )
+            if quantity > 1000:
+                self.p2p_conn.send_without_ping(msg_oversized)
+                self.check_disconnection(self.p2p_conn)
+            else:
+                self.p2p_conn.send_and_ping(msg_oversized)
+                assert self.p2p_conn.is_connected, (
+                    f"Node should still be connected after sending addrv2 message with "
+                    f"{len(msg_oversized.addrs)} addresses"
+                )
+
+        self.log.info(
+            "Node disconnected as expected after sending an oversized addrv2 message"
+        )
+        assert (
+            not self.p2p_conn.is_connected
+        ), "p2p_default should be disconnected after sending an oversized addrv2 message"
+        assert (
+            self.florestad.rpc.get_connectioncount() == 0
+        ), "Floresta node should have no peers connected"
+
+        self.log.info("Testing getaddr message")
+        self.p2p_receiver_v2 = self.node_manager.add_p2p_connection(
+            node=self.florestad, p2p_idx=0, p2p_conn=AddrReceiver()
+        )
+        self.p2p_receiver_v2.send_without_ping(msg_getaddr())
+        self.p2p_receiver_v2.wait_for_addrv2()
+        assert self.p2p_receiver_v2.addrv2_received_and_checked
+
+        self.p2p_receiver_v1 = self.node_manager.add_p2p_connection(
+            node=self.florestad,
+            p2p_idx=1,
+            p2p_conn=AddrReceiver(support_addrv2=False),
+        )
+        self.p2p_receiver_v1.send_without_ping(msg_getaddr())
+        self.p2p_receiver_v1.wait_for_addr()
+        assert self.p2p_receiver_v1.addr_received_and_checked
+
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def check_addr_received(
+        self,
+        ipv4_expected,
+        ipv6_expected,
+        i2p_expected=0,
+        onion_expected=0,
+        cjdns_expected=0,
+    ):
+        """Check that the received addr message contains the expected number of addresses by type"""
+        florestad_address = self.florestad.rpc.get_addrman_info()
+        total = (
+            ipv4_expected
+            + ipv6_expected
+            + i2p_expected
+            + onion_expected
+            + cjdns_expected
+        )
+        assert (
+            florestad_address["all_networks"]["total"]
+            == florestad_address["all_networks"]["new"]
+            == total
+        )
+        assert florestad_address["all_networks"]["tried"] == 0
+
+        assert (
+            florestad_address["ipv4"]["total"]
+            == florestad_address["ipv4"]["new"]
+            == ipv4_expected
+        )
+        assert florestad_address["ipv4"]["tried"] == 0
+
+        assert (
+            florestad_address["ipv6"]["total"]
+            == florestad_address["ipv6"]["new"]
+            == ipv6_expected
+        )
+        assert florestad_address["ipv6"]["tried"] == 0
+
+        assert (
+            florestad_address["i2p"]["total"]
+            == florestad_address["i2p"]["new"]
+            == i2p_expected
+        )
+        assert florestad_address["i2p"]["tried"] == 0
+
+        assert (
+            florestad_address["onion"]["total"]
+            == florestad_address["onion"]["new"]
+            == onion_expected
+        )
+        assert florestad_address["onion"]["tried"] == 0
+
+        assert (
+            florestad_address["cjdns"]["total"]
+            == florestad_address["cjdns"]["new"]
+            == cjdns_expected
+        )
+        assert florestad_address["cjdns"]["tried"] == 0
+
+    def connect_p2p(self, expected_peer_count: int = 1):
+        """Establish a P2P connection to the Floresta node."""
+        self.log.debug("Connecting to interface P2P...")
+        self.p2p_conn = self.node_manager.add_p2p_connection_default(
+            node=self.florestad,
+            p2p_idx=0,
+        )
+        wait_until(
+            predicate=lambda: self.floresta_has_peer_count(
+                expected_peer_count=expected_peer_count
+            ),
+            error_msg="Floresta node did not connect as expected",
+        )
+
+    def floresta_has_peer_count(self, expected_peer_count: int = 0) -> bool:
+        """Check if the Floresta node has the expected number of peers."""
+        self.florestad.rpc.ping()
+        return self.florestad.rpc.get_connectioncount() == expected_peer_count
+
+    def check_disconnection(self, p2p, expected_peer_count: int = 0):
+        """Check if the Floresta node has the expected number of peers after disconnection."""
+        self.log.debug("Checking disconnection...")
+        p2p.wait_for_disconnect()
+        wait_until(
+            predicate=lambda: self.floresta_has_peer_count(
+                expected_peer_count=expected_peer_count
+            ),
+            error_msg="Floresta node did not disconnect as expected",
+        )
+
+    def calc_addrv2_msg_size(self, addrs):
+        """Calculate the serialized size of an addrv2 message in bytes."""
+        size = 1  # vector length byte
+        for addr in addrs:
+            size += 4  # time
+            size += 1  # services, COMPACTSIZE(P2P_SERVICES)
+            size += 1  # network id
+            size += 1  # address length byte
+            size += addr.ADDRV2_ADDRESS_LENGTH[addr.net]  # address
+            size += 2  # port
+
+        return size

--- a/tests/p2p/p2p_resilience.py
+++ b/tests/p2p/p2p_resilience.py
@@ -1,0 +1,319 @@
+"""
+p2p_resilience.py
+
+Test Floresta's resilience against DoS attacks via P2P protocol.
+
+This test module verifies that the Floresta node properly defends against
+Denial of Service (DoS) attacks by validating its peer rejection and disconnection
+mechanisms across both v1 and v2 P2P protocol versions.
+"""
+
+from random import sample
+import time
+import pytest
+
+from test_framework.messages import (
+    msg_version,
+    msg_verack,
+    msg_addr,
+    msg_addrv2,
+    msg_sendaddrv2,
+    msg_inv,
+    msg_getdata,
+    msg_getblocks,
+    msg_tx,
+    msg_wtxidrelay,
+    msg_block,
+    msg_no_witness_block,
+    msg_getaddr,
+    msg_ping,
+    msg_pong,
+    msg_mempool,
+    msg_notfound,
+    msg_sendheaders,
+    msg_getheaders,
+    msg_headers,
+    msg_merkleblock,
+    msg_filterload,
+    msg_filteradd,
+    msg_filterclear,
+    msg_feefilter,
+    msg_sendcmpct,
+    msg_cmpctblock,
+    P2PHeaderAndShortIDs,
+    msg_getblocktxn,
+    msg_blocktxn,
+    msg_no_witness_blocktxn,
+    msg_getcfilters,
+    msg_cfilter,
+    msg_getcfheaders,
+    msg_cfheaders,
+    msg_getcfcheckpt,
+    msg_cfcheckpt,
+    msg_sendtxrcncl,
+)
+from test_framework.util import wait_until
+from test_framework.p2p import P2PInterface
+from test_framework.messages import MAX_PROTOCOL_MESSAGE_LENGTH, MAX_MSG_PER_SECOND
+
+
+class TestP2pResilience:
+    """
+    Test Floresta's resilience against DoS attacks via P2P protocol.
+
+    This test class validates the Floresta node's defense mechanisms against
+    various Denial of Service (DoS) attack vectors on the P2P interface,
+    ensuring the node properly rejects malicious peers across both v1 and v2
+    P2P protocol versions.
+    """
+
+    # Define attributes at class level to avoid "defined outside __init__" warnings
+    florestad = None
+    log = None
+    node_manager = None
+    p2p_conn_v1 = None
+    p2p_conn_v2 = None
+
+    @pytest.mark.p2p
+    def test_oversized_messages_disconnection(
+        self, setup_logging, node_manager, florestad_node
+    ):
+        """
+        Test oversized message rejection and peer disconnection.
+
+        Verifies that the Floresta node disconnects from peers sending messages
+        larger than the protocol maximum. Tests multiple message types across
+        both v1 (MAX_PROTOCOL_MESSAGE_LENGTH) and v2 (16 MiB) limits.
+        """
+        self.florestad = florestad_node
+        self.log = setup_logging
+        self.node_manager = node_manager
+
+        message_classes = [
+            msg_version,
+            msg_verack,
+            msg_addr,
+            msg_addrv2,
+            msg_sendaddrv2,
+            msg_inv,
+            msg_getdata,
+            msg_getblocks,
+            msg_tx,
+            msg_wtxidrelay,
+            msg_block,
+            msg_no_witness_block,
+            msg_getaddr,
+            msg_ping,
+            msg_pong,
+            msg_mempool,
+            msg_notfound,
+            msg_sendheaders,
+            msg_getheaders,
+            msg_headers,
+            msg_merkleblock,
+            msg_filterload,
+            msg_filteradd,
+            msg_filterclear,
+            msg_feefilter,
+            msg_sendcmpct,
+            msg_cmpctblock,
+            msg_getblocktxn,
+            msg_blocktxn,
+            msg_no_witness_blocktxn,
+            msg_getcfilters,
+            msg_cfilter,
+            msg_getcfheaders,
+            msg_cfheaders,
+            msg_getcfcheckpt,
+            msg_cfcheckpt,
+            msg_sendtxrcncl,
+        ]
+
+        # Limit to 8 random message types for performance reasons.
+        # Testing all supported message types would cause excessive test duration.
+        # Each message type requires two P2P connections (v1 and v2) and a spam cycle,
+        # so testing all ~37 types would be impractical for CI/CD pipelines.
+        selected = sample(message_classes, k=min(8, len(message_classes)))
+        self.log.info(f"Randomly selected messages: {[m.msgtype for m in selected]}")
+
+        for msg_class in selected:
+            self.log.info(f"Testing {msg_class.__name__}")
+            self.connect_p2p()
+
+            self.log.info(f"Testing {msg_class.__name__} with version v1")
+            msg = self.node_manager.create_msg_random(
+                msgtype=msg_class.msgtype, size=MAX_PROTOCOL_MESSAGE_LENGTH + 1
+            )
+            self.p2p_conn_v1.send_without_ping(msg)
+            self.check_disconnection(self.p2p_conn_v1, expected_peer_count=1)
+
+            self.log.info(f"Testing {msg_class.__name__} with version v2")
+            msg = self.node_manager.create_msg_random(
+                msgtype=msg_class.msgtype, size=16777216 + 1
+            )  # 16 MiB + 1 byte
+            self.p2p_conn_v2.send_without_ping(msg)
+            self.check_disconnection(self.p2p_conn_v2)
+
+    @pytest.mark.p2p
+    def test_spam_rate_limiting(self, setup_logging, node_manager, florestad_node):
+        """
+        Test message spam protection and rate limit enforcement.
+
+        Verifies that the Floresta node enforces rate limiting to reject peers
+        sending excessive message volumes. Tests multiple message types across
+        both v1 and v2 P2P protocol versions.
+        """
+        self.florestad = florestad_node
+        self.log = setup_logging
+        self.node_manager = node_manager
+
+        message_classes = [
+            msg_version(),
+            msg_verack(),
+            msg_addr(),
+            msg_addrv2(),
+            msg_sendaddrv2(),
+            msg_inv(),
+            msg_getdata(),
+            msg_getblocks(),
+            msg_tx(),
+            msg_wtxidrelay(),
+            msg_block(),
+            msg_no_witness_block(),
+            msg_getaddr(),
+            msg_ping(),
+            msg_pong(),
+            msg_mempool(),
+            msg_notfound(),
+            msg_sendheaders(),
+            msg_getheaders(),
+            msg_headers(),
+            msg_merkleblock(),
+            msg_filterload(),
+            msg_filteradd(data=b"\x00" * 32),
+            msg_filterclear(),
+            msg_feefilter(),
+            msg_sendcmpct(),
+            msg_cmpctblock(P2PHeaderAndShortIDs()),
+            msg_getblocktxn(),
+            msg_blocktxn(),
+            msg_no_witness_blocktxn(),
+            msg_getcfilters(),
+            msg_cfilter(),
+            msg_getcfheaders(),
+            msg_cfheaders(),
+            msg_getcfcheckpt(),
+            msg_cfcheckpt(),
+            msg_sendtxrcncl(),
+        ]
+
+        # Limit to 2 random message types for performance reasons.
+        # Testing all supported message types would cause excessive test duration.
+        # Each message type requires two P2P connections (v1 and v2) and a spam cycle,
+        # so testing all ~37 types would be impractical for CI/CD pipelines.
+        selected = sample(message_classes, k=min(2, len(message_classes)))
+        self.log.info(f"Randomly selected messages: {[m.msgtype for m in selected]}")
+
+        for msg in selected:
+            msg_type = msg.msgtype
+            self.log.info(f"Testing {msg_type}")
+            self.connect_p2p()
+
+            self.log.info(f"Testing {msg_type} - small-message spam on v1")
+            self.send_spam_p2p_messages(msg=msg, p2p_conn=self.p2p_conn_v1)
+            self.check_disconnection(self.p2p_conn_v1, expected_peer_count=1)
+
+            self.log.info(f"Testing {msg_type} - small-message spam on v2")
+            self.send_spam_p2p_messages(msg=msg, p2p_conn=self.p2p_conn_v2)
+            self.check_disconnection(self.p2p_conn_v2)
+
+    def connect_p2p(self):
+        """
+        Establish P2P connections to the Floresta node.
+
+        Creates two connections: one using v1 P2P protocol and one using v2.
+        Both connections are validated to ensure the node recognizes them.
+        """
+        self.log.info("Connecting to interface P2P...")
+        self.log.info("Connecting with v1 P2P protocol...")
+        self.p2p_conn_v1 = self.node_manager.add_p2p_connection_default(
+            node=self.florestad, p2p_idx=0, supports_v2_p2p=False
+        )
+        wait_until(
+            predicate=lambda: self.floresta_has_peer_count(expected_peer_count=1),
+            error_msg="Floresta node did not connect as expected",
+        )
+
+        self.log.info("Connecting with v2 P2P protocol...")
+        self.p2p_conn_v2 = self.node_manager.add_p2p_connection_default(
+            node=self.florestad, p2p_idx=1, supports_v2_p2p=True
+        )
+        wait_until(
+            predicate=lambda: self.floresta_has_peer_count(expected_peer_count=2),
+            error_msg="Floresta node did not connect as expected",
+        )
+
+    def floresta_has_peer_count(self, expected_peer_count: int = 0) -> bool:
+        """
+        Check if the Floresta node has the expected number of peers.
+        """
+        self.florestad.rpc.ping()
+        return self.florestad.rpc.get_connectioncount() == expected_peer_count
+
+    def check_disconnection(self, p2p, expected_peer_count: int = 0):
+        """
+        Verify peer disconnection after DoS attack.
+
+        Waits for the P2P connection to close and validates that the Floresta
+        node properly updated its peer count after disconnection.
+        """
+        self.log.info("Checking disconnection...")
+        p2p.wait_for_disconnect()
+        wait_until(
+            predicate=lambda: self.floresta_has_peer_count(
+                expected_peer_count=expected_peer_count
+            ),
+            error_msg="Floresta node did not disconnect as expected",
+        )
+
+    def send_spam_p2p_messages(
+        self,
+        p2p_conn: P2PInterface,
+        msg,
+        message_count: int = MAX_MSG_PER_SECOND * 50,
+        check_disconnection: bool = True,
+    ):
+        """
+        Flood a P2P connection with excessive messages to trigger rate limiting.
+
+        Sends a large batch of messages in rapid succession to test the node's
+        rate limiting and spam protection mechanisms. Verifies that the node
+        disconnects the peer when rate limits are exceeded.
+        """
+        start = time.time()
+
+        try:
+            # Build all messages first to avoid timing issues with message construction during
+            # sending.
+            messages = [p2p_conn.build_message(msg) for _ in range(message_count)]
+            elapsed = time.time() - start
+            self.log.debug(f"Built messages in: {elapsed:.2f}s")
+            start = time.time()
+            for message in messages:
+                p2p_conn.send_raw_message(message)
+
+        except IOError as e:
+            self.log.debug(f"IOError during message sending: {e}")
+
+        elapsed = time.time() - start
+        self.log.debug(f"Sent messages in: {elapsed:.2f}s")
+
+        if check_disconnection:
+            if p2p_conn.is_connected:
+                time.sleep(1)  # Allow time for potential disconnection to occur
+                assert (
+                    not p2p_conn.is_connected
+                ), "Connection should have closed but is still open"
+            self.log.debug("Connection closed during spam (as expected)")
+        elif not p2p_conn.is_connected:
+            raise RuntimeError("Connection closed unexpectedly")

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -36,6 +36,8 @@ from test_framework.rpc import ConfigRPC
 from test_framework.electrum import ConfigElectrum, ConfigTls
 from test_framework.node import Node, NodeType
 from test_framework.util import Utility, wait_until
+from test_framework.p2p import P2P_SERVICES, P2PInterface, NetworkThread
+from test_framework.messages import NODE_P2P_V2
 
 
 # pylint: disable=too-many-public-methods
@@ -81,6 +83,7 @@ class FlorestaTestFramework:
         self._test_name = test_name
         self._nodes = []
         self._log = logger
+        self._p2p_interface = []
 
     @property
     def test_name(self) -> str:
@@ -256,6 +259,14 @@ class FlorestaTestFramework:
         for i in range(len(self._nodes)):
             self.stop_node(i)
 
+        if (
+            hasattr(self, "_network_thread")
+            and NetworkThread.network_event_loop is not None
+            and self._network_thread.is_alive()
+        ):
+            self._network_thread.close(timeout=1)
+            NetworkThread.network_event_loop = None
+
     def check_connection(self, peer_one: Node, peer_two: Node, is_connected: bool):
         """
         Check if two peers are connected/disconnected to each other.
@@ -394,3 +405,141 @@ class FlorestaTestFramework:
         wait_until(lambda: self.check_sync_nodes(is_finished_ibd=is_finished_ibd))
 
         self.log.debug("All nodes are synced")
+
+    def add_p2p_connection(
+        self,
+        node: Node,
+        p2p_conn,
+        *,
+        wait_for_verack=True,
+        wait_for_disconnect=False,
+        p2p_idx,
+        connection_type="outbound-full-relay",
+        supports_v2_p2p=True,
+        advertise_v2_p2p=True,
+        method="onetry",
+        **kwargs,
+    ):
+        """Add an outbound p2p connection from node.
+
+        An outbound connection is made from Node -------> P2PConnection
+        - if P2PConnection doesn't advertise_v2_p2p, Node sends version message and v1 P2P is
+          followed
+        - if P2PConnection both supports_v2_p2p and advertise_v2_p2p, Node sends ellswift bytes and
+          v2 P2P is followed
+
+        Parameters:
+            p2p_conn: The P2PConnection object
+            p2p_idx: Index for the connection (must be different for simultaneous peers)
+            supports_v2_p2p: whether p2p_conn supports v2 P2P
+            advertise_v2_p2p: whether p2p_conn is advertised to support v2 P2P
+            connection_type: Type of connection ("outbound-full-relay", "block-relay-only",
+             "addr-fetch", "feeler")
+        """
+        node_peers = node.rpc.get_connectioncount()
+
+        if NetworkThread.network_event_loop is None:
+            network_thread = NetworkThread()
+            network_thread.start()
+            # pylint: disable=attribute-defined-outside-init
+            self._network_thread = network_thread
+
+        def add_connection_callback(address, port):
+            self.log.debug(f"Connecting to {address}:{port} ({connection_type})")
+            node.connect_node_by_url(
+                url=f"{address}:{port}", method=method, v2transport=supports_v2_p2p
+            )
+
+        if supports_v2_p2p is None:
+            supports_v2_p2p = (
+                node.use_v2transport if hasattr(node, "use_v2transport") else False
+            )
+        if advertise_v2_p2p is None:
+            advertise_v2_p2p = (
+                node.use_v2transport if hasattr(node, "use_v2transport") else False
+            )
+
+        # Handle v2 P2P advertisement
+        if advertise_v2_p2p:
+            kwargs["services"] = kwargs.get("services", P2P_SERVICES) | NODE_P2P_V2
+
+        # If advertised v2 but doesn't support it, reconnection needed
+        reconnect = advertise_v2_p2p and not supports_v2_p2p
+        supports_v2_p2p = supports_v2_p2p and advertise_v2_p2p
+
+        p2p_conn.peer_accept_connection(
+            connect_cb=add_connection_callback,
+            connect_id=p2p_idx + 1,
+            net=node.chain if hasattr(node, "chain") else "regtest",
+            timeout_factor=1.0,
+            supports_v2_p2p=supports_v2_p2p,
+            reconnect=reconnect,
+            **kwargs,
+        )()
+
+        if reconnect:
+            p2p_conn.wait_for_reconnect()
+
+        if connection_type == "feeler" or wait_for_disconnect:
+            p2p_conn.wait_until(
+                lambda: p2p_conn.message_count.get("version", 0) == 1,
+                check_connected=False,
+            )
+            p2p_conn.wait_until(
+                lambda: not p2p_conn.is_connected, check_connected=False
+            )
+        else:
+            p2p_conn.wait_for_connect()
+            self._p2p_interface.append((node, p2p_conn))
+
+            if supports_v2_p2p:
+                p2p_conn.wait_until(lambda: p2p_conn.v2_state.tried_v2_handshake)
+            p2p_conn.wait_until(lambda: not p2p_conn.on_connection_send_msg)
+            if wait_for_verack:
+                p2p_conn.wait_for_verack()
+                p2p_conn.sync_with_ping()
+
+        wait_until(predicate=lambda: node.rpc.get_connectioncount() == node_peers + 1)
+
+        return p2p_conn
+
+    def add_p2p_connection_default(
+        self,
+        node: Node,
+        *,
+        wait_for_verack=True,
+        p2p_idx,
+        connection_type="outbound-full-relay",
+        supports_v2_p2p=True,
+        advertise_v2_p2p=True,
+        method="onetry",
+        **kwargs,
+    ):
+        """Add an outbound p2p connection with a default P2PInterface.
+
+        This method creates a default P2PInterface and connects it to the first node.
+
+        Parameters:
+            p2p_idx: Index for the connection
+            connection_type: Type of connection
+            supports_v2_p2p: whether to support v2 P2P
+            advertise_v2_p2p: whether to advertise v2 P2P support
+
+        Returns:
+            The P2PInterface object
+        """
+        # Create default P2PInterface
+        p2p_interface = P2PInterface()
+
+        # Use the custom version to do the actual connection
+        return self.add_p2p_connection(
+            node=node,
+            p2p_conn=p2p_interface,
+            wait_for_verack=wait_for_verack,
+            p2p_idx=p2p_idx,
+            connection_type=connection_type,
+            supports_v2_p2p=supports_v2_p2p,
+            advertise_v2_p2p=advertise_v2_p2p,
+            method=method,
+            **kwargs,
+        )

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -16,7 +16,6 @@ import os
 import re
 import sys
 import copy
-import random
 import socket
 import shutil
 import signal
@@ -37,7 +36,13 @@ from test_framework.electrum import ConfigElectrum, ConfigTls
 from test_framework.node import Node, NodeType
 from test_framework.util import Utility, wait_until
 from test_framework.p2p import P2P_SERVICES, P2PInterface, NetworkThread
-from test_framework.messages import NODE_P2P_V2, CAddress
+from test_framework.messages import (
+    NODE_P2P_V2,
+    CAddress,
+    msg_generic,
+    MAX_PROTOCOL_MESSAGE_LENGTH,
+    MAX_MSG_PER_SECOND,
+)
 
 
 # pylint: disable=too-many-public-methods
@@ -264,7 +269,7 @@ class FlorestaTestFramework:
             and NetworkThread.network_event_loop is not None
             and self._network_thread.is_alive()
         ):
-            self._network_thread.close(timeout=1)
+            self._network_thread.close(timeout=10)
             NetworkThread.network_event_loop = None
 
     def check_connection(self, peer_one: Node, peer_two: Node, is_connected: bool):
@@ -543,6 +548,15 @@ class FlorestaTestFramework:
             method=method,
             **kwargs,
         )
+
+    def create_msg_random(self, msgtype, size: int):
+        """
+        Create a message of a given size.
+        """
+        oversized_payload = b"\x00" * size
+
+        # Create a generic message
+        return msg_generic(msgtype, oversized_payload)
 
     def create_node_address(self, quantity: int):
         """

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -37,7 +37,7 @@ from test_framework.electrum import ConfigElectrum, ConfigTls
 from test_framework.node import Node, NodeType
 from test_framework.util import Utility, wait_until
 from test_framework.p2p import P2P_SERVICES, P2PInterface, NetworkThread
-from test_framework.messages import NODE_P2P_V2
+from test_framework.messages import NODE_P2P_V2, CAddress
 
 
 # pylint: disable=too-many-public-methods
@@ -543,3 +543,34 @@ class FlorestaTestFramework:
             method=method,
             **kwargs,
         )
+
+    def create_node_address(self, quantity: int):
+        """
+        Create a list of node addresses.
+        """
+
+        i2p_addr = "c4gfnttsuwqomiygupdqqqyy5y5emnk5c73hrfvatri67prd7vyq.b32.i2p"
+        onion_addr = "nix2iapg23s2g6tog6vmmr2xgywfly5522c27hnp7qwm5qyk73mufvyd.onion"
+
+        address_list = []
+        for i in range(quantity):
+            addr = CAddress()
+            addr.time = int(time.time()) + i
+            addr.port = 8333 + i
+            addr.nServices = P2P_SERVICES
+            # Add one I2P and one onion V3 address at an arbitrary position.
+            if i % 5 == 0:
+                addr.net = addr.NET_I2P
+                addr.ip = i2p_addr
+                addr.port = 0
+            elif i % 3 == 0:
+                addr.net = addr.NET_TORV3
+                addr.ip = onion_addr
+            elif i % 2 == 0:
+                addr.net = addr.NET_IPV6
+                addr.ip = f"2001:db8::{i % 65536}"
+            else:
+                addr.ip = f"192.42.116.{i % 256}"
+            address_list.append(addr)
+
+        return address_list

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -35,7 +35,7 @@ from test_framework.daemon import ConfigP2P
 from test_framework.rpc import ConfigRPC
 from test_framework.electrum import ConfigElectrum, ConfigTls
 from test_framework.node import Node, NodeType
-from test_framework.util import Utility
+from test_framework.util import Utility, wait_until
 
 
 # pylint: disable=too-many-public-methods
@@ -274,6 +274,9 @@ class FlorestaTestFramework:
                 f"Peer one running: {peer_one_running}, Peer two running: {peer_two_running}"
             )
 
+        # Send pings to both peers to trigger a peer state update
+        self._send_peer_pings(peer_one, peer_two)
+
         peer_two_in_peer_one = (
             peer_one.is_peer_connected(peer_two) if peer_one_running else False
         )
@@ -293,41 +296,39 @@ class FlorestaTestFramework:
         Wait for two peers to connect/disconnect to each other.
         """
         attempts = 0
-        timeout = time.time() + 30
-        while time.time() < timeout:
-            if self.check_connection(peer_one, peer_two, is_connected):
-                self.log.debug(
-                    f"Peers {peer_one.variant} and {peer_two.variant} are in the expected "
-                    f"connection state."
-                )
-                return
 
-            if attempts < 10:
+        def check_peers_connection():
+            nonlocal attempts
+
+            if attempts > 10:
                 time.sleep(1)
-            else:
-                time.sleep(2)
 
             attempts += 1
 
-            # Send a ping to both peers to trigger a peer state update
-            if peer_one.daemon.is_running:
-                peer_one.rpc.ping()
-                self.log.debug(
-                    f"Peer one {peer_one.variant} is connected to peer two {peer_two.variant}: "
-                    f"{peer_one.is_peer_connected(peer_two)}"
-                )
+            return self.check_connection(peer_one, peer_two, is_connected)
 
-            if peer_two.daemon.is_running:
-                peer_two.rpc.ping()
-                self.log.debug(
-                    f"Peer two {peer_two.variant} is connected to peer one {peer_one.variant}: "
-                    f"{peer_two.is_peer_connected(peer_one)}"
-                )
+        wait_until(predicate=check_peers_connection)
 
-        raise AssertionError(
-            f"Peers {peer_one.variant} and {peer_two.variant} failed to reach the expected "
-            f"connection state within the timeout. Expected connected: {is_connected}."
+        self.log.debug(
+            f"Peers {peer_one.variant} and {peer_two.variant} are "
+            f"{'connected' if is_connected else 'disconnected'}"
         )
+
+    def _send_peer_pings(self, peer_one: Node, peer_two: Node):
+        """Send pings to both peers and log connection status."""
+        if peer_one.daemon.is_running:
+            peer_one.rpc.ping()
+            self.log.debug(
+                f"Peer one {peer_one.variant} is connected to peer two {peer_two.variant}: "
+                f"{peer_one.is_peer_connected(peer_two)}"
+            )
+
+        if peer_two.daemon.is_running:
+            peer_two.rpc.ping()
+            self.log.debug(
+                f"Peer two {peer_two.variant} is connected to peer one {peer_one.variant}: "
+                f"{peer_two.is_peer_connected(peer_one)}"
+            )
 
     def connect_nodes(
         self,
@@ -347,3 +348,49 @@ class FlorestaTestFramework:
         assert result is None
 
         self.wait_for_peers_connections(peer_one, peer_two)
+
+    def check_sync_nodes(self, is_finished_ibd: bool = True) -> bool:
+        """
+        Check if all nodes are synced.
+
+        If is_finished_ibd is True, it will check if all florestad nodes have finished the
+        initial block download (IBD) process. Otherwise, it will check if all
+        nodes are fully synced with the network.
+        """
+        if not self._nodes:
+            raise AssertionError("No nodes to check for synchronization")
+
+        expected_block = self._nodes[0].rpc.get_block_count()
+        for node in self._nodes:
+            block_count = node.rpc.get_block_count()
+
+            if (
+                node.variant == NodeType.FLORESTAD
+                and is_finished_ibd
+                and node.rpc.get_blockchain_info()["initialblockdownload"]
+            ):
+                self.log.debug(
+                    f"Node '{node.variant}' has not finished IBD. Block count: {block_count}"
+                )
+                return False
+
+            if block_count != expected_block:
+                self.log.debug(
+                    f"Node '{node.variant}' is not synced. Block count: {block_count}, "
+                    f"expected: {expected_block}"
+                )
+                return False
+
+        return True
+
+    def wait_for_sync_nodes(self, is_finished_ibd: bool = True):
+        """
+        Wait for all nodes to be synced.
+
+        If is_finished_ibd is True, it will wait until all florestad nodes have finished the
+        initial block download (IBD) process. Otherwise, it will wait until all
+        nodes are fully synced with the network.
+        """
+        wait_until(lambda: self.check_sync_nodes(is_finished_ibd=is_finished_ibd))
+
+        self.log.debug("All nodes are synced")

--- a/tests/test_framework/crypto/bip324_cipher.py
+++ b/tests/test_framework/crypto/bip324_cipher.py
@@ -1,0 +1,93 @@
+# pylint: disable=all
+#!/usr/bin/env python3
+# Copyright (c) 2022-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test-only implementation of ChaCha20 Poly1305 AEAD Construction in RFC 8439 and FSChaCha20Poly1305 for BIP 324
+
+It is designed for ease of understanding, not performance.
+
+WARNING: This code is slow and trivially vulnerable to side channel attacks. Do not use for
+anything but tests.
+"""
+
+import unittest
+
+from .chacha20 import chacha20_block, REKEY_INTERVAL
+from .poly1305 import Poly1305
+
+
+def pad16(x):
+    if len(x) % 16 == 0:
+        return b""
+    return b"\x00" * (16 - (len(x) % 16))
+
+
+def aead_chacha20_poly1305_encrypt(key, nonce, aad, plaintext):
+    """Encrypt a plaintext using ChaCha20Poly1305."""
+    if plaintext is None:
+        return None
+    ret = bytearray()
+    msg_len = len(plaintext)
+    for i in range((msg_len + 63) // 64):
+        now = min(64, msg_len - 64 * i)
+        keystream = chacha20_block(key, nonce, i + 1)
+        for j in range(now):
+            ret.append(plaintext[j + 64 * i] ^ keystream[j])
+    poly1305 = Poly1305(chacha20_block(key, nonce, 0)[:32])
+    mac_data = aad + pad16(aad)
+    mac_data += ret + pad16(ret)
+    mac_data += len(aad).to_bytes(8, "little") + msg_len.to_bytes(8, "little")
+    ret += poly1305.tag(mac_data)
+    return bytes(ret)
+
+
+def aead_chacha20_poly1305_decrypt(key, nonce, aad, ciphertext):
+    """Decrypt a ChaCha20Poly1305 ciphertext."""
+    if ciphertext is None or len(ciphertext) < 16:
+        return None
+    msg_len = len(ciphertext) - 16
+    poly1305 = Poly1305(chacha20_block(key, nonce, 0)[:32])
+    mac_data = aad + pad16(aad)
+    mac_data += ciphertext[:-16] + pad16(ciphertext[:-16])
+    mac_data += len(aad).to_bytes(8, "little") + msg_len.to_bytes(8, "little")
+    if ciphertext[-16:] != poly1305.tag(mac_data):
+        return None
+    ret = bytearray()
+    for i in range((msg_len + 63) // 64):
+        now = min(64, msg_len - 64 * i)
+        keystream = chacha20_block(key, nonce, i + 1)
+        for j in range(now):
+            ret.append(ciphertext[j + 64 * i] ^ keystream[j])
+    return bytes(ret)
+
+
+class FSChaCha20Poly1305:
+    """Rekeying wrapper AEAD around ChaCha20Poly1305."""
+
+    def __init__(self, initial_key):
+        self._key = initial_key
+        self._packet_counter = 0
+
+    def _crypt(self, aad, text, is_decrypt):
+        nonce = (self._packet_counter % REKEY_INTERVAL).to_bytes(4, "little") + (
+            self._packet_counter // REKEY_INTERVAL
+        ).to_bytes(8, "little")
+        if is_decrypt:
+            ret = aead_chacha20_poly1305_decrypt(self._key, nonce, aad, text)
+        else:
+            ret = aead_chacha20_poly1305_encrypt(self._key, nonce, aad, text)
+        if (self._packet_counter + 1) % REKEY_INTERVAL == 0:
+            rekey_nonce = b"\xff\xff\xff\xff" + nonce[4:]
+            self._key = aead_chacha20_poly1305_encrypt(
+                self._key, rekey_nonce, b"", b"\x00" * 32
+            )[:32]
+        self._packet_counter += 1
+        return ret
+
+    def decrypt(self, aad, ciphertext):
+        return self._crypt(aad, ciphertext, True)
+
+    def encrypt(self, aad, plaintext):
+        return self._crypt(aad, plaintext, False)

--- a/tests/test_framework/crypto/chacha20.py
+++ b/tests/test_framework/crypto/chacha20.py
@@ -1,0 +1,103 @@
+# pylint: disable=all
+#!/usr/bin/env python3
+# Copyright (c) 2022-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test-only implementation of ChaCha20 cipher and FSChaCha20 for BIP 324
+
+It is designed for ease of understanding, not performance.
+
+WARNING: This code is slow and trivially vulnerable to side channel attacks. Do not use for
+anything but tests.
+"""
+
+import unittest
+
+CHACHA20_INDICES = (
+    (0, 4, 8, 12),
+    (1, 5, 9, 13),
+    (2, 6, 10, 14),
+    (3, 7, 11, 15),
+    (0, 5, 10, 15),
+    (1, 6, 11, 12),
+    (2, 7, 8, 13),
+    (3, 4, 9, 14),
+)
+
+CHACHA20_CONSTANTS = (0x61707865, 0x3320646E, 0x79622D32, 0x6B206574)
+REKEY_INTERVAL = 224  # packets
+
+
+def rotl32(v, bits):
+    """Rotate the 32-bit value v left by bits bits."""
+    bits %= 32  # Make sure the term below does not throw an exception
+    return ((v << bits) & 0xFFFFFFFF) | (v >> (32 - bits))
+
+
+def chacha20_doubleround(s):
+    """Apply a ChaCha20 double round to 16-element state array s.
+    See https://cr.yp.to/chacha/chacha-20080128.pdf and https://tools.ietf.org/html/rfc8439
+    """
+    for a, b, c, d in CHACHA20_INDICES:
+        s[a] = (s[a] + s[b]) & 0xFFFFFFFF
+        s[d] = rotl32(s[d] ^ s[a], 16)
+        s[c] = (s[c] + s[d]) & 0xFFFFFFFF
+        s[b] = rotl32(s[b] ^ s[c], 12)
+        s[a] = (s[a] + s[b]) & 0xFFFFFFFF
+        s[d] = rotl32(s[d] ^ s[a], 8)
+        s[c] = (s[c] + s[d]) & 0xFFFFFFFF
+        s[b] = rotl32(s[b] ^ s[c], 7)
+
+
+def chacha20_block(key, nonce, cnt):
+    """Compute the 64-byte output of the ChaCha20 block function.
+    Takes as input a 32-byte key, 12-byte nonce, and 32-bit integer counter.
+    """
+    # Initial state.
+    init = [0] * 16
+    init[:4] = CHACHA20_CONSTANTS[:4]
+    init[4:12] = [int.from_bytes(key[i : i + 4], "little") for i in range(0, 32, 4)]
+    init[12] = cnt
+    init[13:16] = [int.from_bytes(nonce[i : i + 4], "little") for i in range(0, 12, 4)]
+    # Perform 20 rounds.
+    state = list(init)
+    for _ in range(10):
+        chacha20_doubleround(state)
+    # Add initial values back into state.
+    for i in range(16):
+        state[i] = (state[i] + init[i]) & 0xFFFFFFFF
+    # Produce byte output
+    return b"".join(state[i].to_bytes(4, "little") for i in range(16))
+
+
+class FSChaCha20:
+    """Rekeying wrapper stream cipher around ChaCha20."""
+
+    def __init__(self, initial_key, rekey_interval=REKEY_INTERVAL):
+        self._key = initial_key
+        self._rekey_interval = rekey_interval
+        self._block_counter = 0
+        self._chunk_counter = 0
+        self._keystream = b""
+
+    def _get_keystream_bytes(self, nbytes):
+        while len(self._keystream) < nbytes:
+            nonce = (0).to_bytes(4, "little") + (
+                self._chunk_counter // self._rekey_interval
+            ).to_bytes(8, "little")
+            self._keystream += chacha20_block(self._key, nonce, self._block_counter)
+            self._block_counter += 1
+        ret = self._keystream[:nbytes]
+        self._keystream = self._keystream[nbytes:]
+        return ret
+
+    def crypt(self, chunk):
+        ks = self._get_keystream_bytes(len(chunk))
+        ret = bytes([ks[i] ^ chunk[i] for i in range(len(chunk))])
+        if ((self._chunk_counter + 1) % self._rekey_interval) == 0:
+            self._key = self._get_keystream_bytes(32)
+            self._block_counter = 0
+            self._keystream = b""
+        self._chunk_counter += 1
+        return ret

--- a/tests/test_framework/crypto/ellswift.py
+++ b/tests/test_framework/crypto/ellswift.py
@@ -1,0 +1,94 @@
+# pylint: disable=all
+#!/usr/bin/env python3
+# Copyright (c) 2022-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test-only Elligator Swift implementation
+
+WARNING: This code is slow and uses bad randomness.
+Do not use for anything but tests."""
+
+import csv
+import os
+import random
+import unittest
+
+from test_framework.crypto.secp256k1 import FE, G, GE
+
+# Precomputed constant square root of -3 (mod p).
+MINUS_3_SQRT = FE(-3).sqrt()
+
+
+def xswiftec(u, t):
+    """Decode field elements (u, t) to an X coordinate on the curve."""
+    if u == 0:
+        u = FE(1)
+    if t == 0:
+        t = FE(1)
+    if u**3 + t**2 + 7 == 0:
+        t = 2 * t
+    X = (u**3 + 7 - t**2) / (2 * t)
+    Y = (X + t) / (MINUS_3_SQRT * u)
+    for x in (u + 4 * Y**2, (-X / Y - u) / 2, (X / Y - u) / 2):
+        if GE.is_valid_x(x):
+            return x
+    assert False
+
+
+def xswiftec_inv(x, u, case):
+    """Given x and u, find t such that xswiftec(u, t) = x, or return None.
+
+    Case selects which of the up to 8 results to return."""
+
+    if case & 2 == 0:
+        if GE.is_valid_x(-x - u):
+            return None
+        v = x
+        s = -(u**3 + 7) / (u**2 + u * v + v**2)
+    else:
+        s = x - u
+        if s == 0:
+            return None
+        r = (-s * (4 * (u**3 + 7) + 3 * s * u**2)).sqrt()
+        if r is None:
+            return None
+        if case & 1 and r == 0:
+            return None
+        v = (-u + r / s) / 2
+    w = s.sqrt()
+    if w is None:
+        return None
+    if case & 5 == 0:
+        return -w * (u * (1 - MINUS_3_SQRT) / 2 + v)
+    if case & 5 == 1:
+        return w * (u * (1 + MINUS_3_SQRT) / 2 + v)
+    if case & 5 == 4:
+        return w * (u * (1 - MINUS_3_SQRT) / 2 + v)
+    if case & 5 == 5:
+        return -w * (u * (1 + MINUS_3_SQRT) / 2 + v)
+
+
+def xelligatorswift(x):
+    """Given a field element X on the curve, find (u, t) that encode them."""
+    assert GE.is_valid_x(x)
+    while True:
+        u = FE(random.randrange(1, FE.SIZE))
+        case = random.randrange(0, 8)
+        t = xswiftec_inv(x, u, case)
+        if t is not None:
+            return u, t
+
+
+def ellswift_create():
+    """Generate a (privkey, ellswift_pubkey) pair."""
+    priv = random.randrange(1, GE.ORDER)
+    u, t = xelligatorswift((priv * G).x)
+    return priv.to_bytes(32, "big"), u.to_bytes() + t.to_bytes()
+
+
+def ellswift_ecdh_xonly(pubkey_theirs, privkey):
+    """Compute X coordinate of shared ECDH point between ellswift pubkey and privkey."""
+    u = FE(int.from_bytes(pubkey_theirs[:32], "big"))
+    t = FE(int.from_bytes(pubkey_theirs[32:], "big"))
+    d = int.from_bytes(privkey, "big")
+    return (d * GE.lift_x(xswiftec(u, t))).x.to_bytes()

--- a/tests/test_framework/crypto/hkdf.py
+++ b/tests/test_framework/crypto/hkdf.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test-only HKDF-SHA256 implementation
+
+It is designed for ease of understanding, not performance.
+
+WARNING: This code is slow and trivially vulnerable to side channel attacks. Do not use for
+anything but tests.
+"""
+
+import hashlib
+import hmac
+
+
+def hmac_sha256(key, data):
+    """Compute HMAC-SHA256 from specified byte arrays key and data."""
+    return hmac.new(key, data, hashlib.sha256).digest()
+
+
+def hkdf_sha256(length, ikm, salt, info):
+    """Derive a key using HKDF-SHA256."""
+    if len(salt) == 0:
+        salt = bytes([0] * 32)
+    prk = hmac_sha256(salt, ikm)
+    t = b""
+    okm = b""
+    for i in range((length + 32 - 1) // 32):
+        t = hmac_sha256(prk, t + info + bytes([i + 1]))
+        okm += t
+    return okm[:length]

--- a/tests/test_framework/crypto/poly1305.py
+++ b/tests/test_framework/crypto/poly1305.py
@@ -1,0 +1,36 @@
+# pylint: disable=all
+#!/usr/bin/env python3
+# Copyright (c) 2022-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test-only implementation of Poly1305 authenticator
+
+It is designed for ease of understanding, not performance.
+
+WARNING: This code is slow and trivially vulnerable to side channel attacks. Do not use for
+anything but tests.
+"""
+
+import unittest
+
+
+class Poly1305:
+    """Class representing a running poly1305 computation."""
+
+    MODULUS = 2**130 - 5
+
+    def __init__(self, key):
+        self.r = int.from_bytes(key[:16], "little") & 0xFFFFFFC0FFFFFFC0FFFFFFC0FFFFFFF
+        self.s = int.from_bytes(key[16:], "little")
+
+    def tag(self, data):
+        """Compute the poly1305 tag."""
+        acc, length = 0, len(data)
+        for i in range((length + 15) // 16):
+            chunk = data[i * 16 : min(length, (i + 1) * 16)]
+            val = int.from_bytes(chunk, "little") + 256 ** len(chunk)
+            acc = (self.r * (acc + val)) % Poly1305.MODULUS
+        return ((acc + self.s) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF).to_bytes(
+            16, "little"
+        )

--- a/tests/test_framework/crypto/siphash.py
+++ b/tests/test_framework/crypto/siphash.py
@@ -1,0 +1,67 @@
+# pylint: disable=all
+#!/usr/bin/env python3
+# Copyright (c) 2016-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""SipHash-2-4 implementation.
+
+This implements SipHash-2-4. For convenience, an interface taking 256-bit
+integers is provided in addition to the one accepting generic data.
+"""
+
+
+def rotl64(n, b):
+    return n >> (64 - b) | (n & ((1 << (64 - b)) - 1)) << b
+
+
+def siphash_round(v0, v1, v2, v3):
+    v0 = (v0 + v1) & ((1 << 64) - 1)
+    v1 = rotl64(v1, 13)
+    v1 ^= v0
+    v0 = rotl64(v0, 32)
+    v2 = (v2 + v3) & ((1 << 64) - 1)
+    v3 = rotl64(v3, 16)
+    v3 ^= v2
+    v0 = (v0 + v3) & ((1 << 64) - 1)
+    v3 = rotl64(v3, 21)
+    v3 ^= v0
+    v2 = (v2 + v1) & ((1 << 64) - 1)
+    v1 = rotl64(v1, 17)
+    v1 ^= v2
+    v2 = rotl64(v2, 32)
+    return (v0, v1, v2, v3)
+
+
+def siphash(k0, k1, data):
+    assert type(data) is bytes
+    v0 = 0x736F6D6570736575 ^ k0
+    v1 = 0x646F72616E646F6D ^ k1
+    v2 = 0x6C7967656E657261 ^ k0
+    v3 = 0x7465646279746573 ^ k1
+    c = 0
+    t = 0
+    for d in data:
+        t |= d << (8 * (c % 8))
+        c = (c + 1) & 0xFF
+        if (c & 7) == 0:
+            v3 ^= t
+            v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+            v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+            v0 ^= t
+            t = 0
+    t = t | (c << 56)
+    v3 ^= t
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0 ^= t
+    v2 ^= 0xFF
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    return v0 ^ v1 ^ v2 ^ v3
+
+
+def siphash256(k0, k1, num):
+    assert type(num) is int
+    return siphash(k0, k1, num.to_bytes(32, "little"))

--- a/tests/test_framework/key.py
+++ b/tests/test_framework/key.py
@@ -10,7 +10,7 @@ anything but tests."""
 import hashlib
 import hmac
 import random
-from tests.test_framework.crypto import secp256k1
+from .crypto import secp256k1
 
 # Point with no known discrete log.
 H_POINT = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"

--- a/tests/test_framework/messages.py
+++ b/tests/test_framework/messages.py
@@ -55,7 +55,7 @@ SEQUENCE_FINAL = (
 )
 
 MAX_PROTOCOL_MESSAGE_LENGTH = 5000000  # Maximum length of incoming protocol messages
-MAX_MSG_PER_SECOND = 1000
+MAX_MSG_PER_SECOND = 10000
 MAX_HEADERS_RESULTS = 2000  # Number of headers sent in one getheaders result
 MAX_INV_SIZE = 50000  # Maximum number of entries in an 'inv' protocol message
 
@@ -1837,7 +1837,7 @@ class msg_getblocktxn:
     msgtype = b"getblocktxn"
 
     def __init__(self):
-        self.block_txn_request = None
+        self.block_txn_request = BlockTransactionsRequest()
 
     def deserialize(self, f):
         self.block_txn_request = BlockTransactionsRequest()
@@ -1882,7 +1882,7 @@ class msg_getcfilters:
     __slots__ = ("filter_type", "start_height", "stop_hash")
     msgtype = b"getcfilters"
 
-    def __init__(self, filter_type=None, start_height=None, stop_hash=None):
+    def __init__(self, filter_type=0, start_height=0, stop_hash=0):
         self.filter_type = filter_type
         self.start_height = start_height
         self.stop_hash = stop_hash
@@ -1909,7 +1909,7 @@ class msg_cfilter:
     __slots__ = ("filter_type", "block_hash", "filter_data")
     msgtype = b"cfilter"
 
-    def __init__(self, filter_type=None, block_hash=None, filter_data=None):
+    def __init__(self, filter_type=0, block_hash=0, filter_data=b""):
         self.filter_type = filter_type
         self.block_hash = block_hash
         self.filter_data = filter_data
@@ -1936,7 +1936,7 @@ class msg_getcfheaders:
     __slots__ = ("filter_type", "start_height", "stop_hash")
     msgtype = b"getcfheaders"
 
-    def __init__(self, filter_type=None, start_height=None, stop_hash=None):
+    def __init__(self, filter_type=0, start_height=0, stop_hash=0):
         self.filter_type = filter_type
         self.start_height = start_height
         self.stop_hash = stop_hash
@@ -1963,7 +1963,7 @@ class msg_cfheaders:
     __slots__ = ("filter_type", "stop_hash", "prev_header", "hashes")
     msgtype = b"cfheaders"
 
-    def __init__(self, filter_type=None, stop_hash=None, prev_header=None, hashes=None):
+    def __init__(self, filter_type=0, stop_hash=0, prev_header=0, hashes=[]):
         self.filter_type = filter_type
         self.stop_hash = stop_hash
         self.prev_header = prev_header
@@ -1993,7 +1993,7 @@ class msg_getcfcheckpt:
     __slots__ = ("filter_type", "stop_hash")
     msgtype = b"getcfcheckpt"
 
-    def __init__(self, filter_type=None, stop_hash=None):
+    def __init__(self, filter_type=0, stop_hash=0):
         self.filter_type = filter_type
         self.stop_hash = stop_hash
 
@@ -2017,7 +2017,7 @@ class msg_cfcheckpt:
     __slots__ = ("filter_type", "stop_hash", "headers")
     msgtype = b"cfcheckpt"
 
-    def __init__(self, filter_type=None, stop_hash=None, headers=None):
+    def __init__(self, filter_type=0, stop_hash=0, headers=[]):
         self.filter_type = filter_type
         self.stop_hash = stop_hash
         self.headers = headers

--- a/tests/test_framework/messages.py
+++ b/tests/test_framework/messages.py
@@ -1,0 +1,2062 @@
+#!/usr/bin/env python3
+
+# pylint: skip-file
+# Note: This file was copied from the Bitcoin Core project and does not follow Pylint rules.
+# It is excluded from Pylint checks to maintain compatibility with the original code.
+
+# Copyright (c) 2010 ArtForz -- public domain half-a-node
+# Copyright (c) 2012 Jeff Garzik
+# Copyright (c) 2010-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Bitcoin test framework primitive and message structures
+
+CBlock, CTransaction, CBlockHeader, CTxIn, CTxOut, etc....:
+    data structures that should map to corresponding structures in
+    bitcoin/primitives
+
+msg_block, msg_tx, msg_headers, etc.:
+    data structures that represent network messages
+
+sere_*, deser_*: functions that handle serialization/deserialization.
+
+Classes use __slots__ to ensure extraneous attributes aren't accidentally added
+by tests, compromising their intended effect.
+"""
+
+from base64 import b32decode, b32encode
+import copy
+import hashlib
+from io import BytesIO
+import math
+import random
+import socket
+import time
+import unittest
+
+from test_framework.crypto.siphash import siphash256
+
+MAX_LOCATOR_SZ = 101
+MAX_BLOCK_WEIGHT = 4000000
+DEFAULT_BLOCK_RESERVED_WEIGHT = 8000
+MINIMUM_BLOCK_RESERVED_WEIGHT = 2000
+MAX_BLOOM_FILTER_SIZE = 36000
+MAX_BLOOM_HASH_FUNCS = 50
+
+COIN = 100000000  # 1 btc in satoshis
+MAX_MONEY = 21000000 * COIN
+
+MAX_BIP125_RBF_SEQUENCE = (
+    0xFFFFFFFD  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
+)
+MAX_SEQUENCE_NONFINAL = 0xFFFFFFFE  # Sequence number that is csv-opt-out (BIP 68)
+SEQUENCE_FINAL = (
+    0xFFFFFFFF  # Sequence number that disables nLockTime if set for every input of a tx
+)
+
+MAX_PROTOCOL_MESSAGE_LENGTH = 5000000  # Maximum length of incoming protocol messages
+MAX_MSG_PER_SECOND = 1000
+MAX_HEADERS_RESULTS = 2000  # Number of headers sent in one getheaders result
+MAX_INV_SIZE = 50000  # Maximum number of entries in an 'inv' protocol message
+
+NODE_NONE = 0
+NODE_NETWORK = 1 << 0
+NODE_BLOOM = 1 << 2
+NODE_WITNESS = 1 << 3
+NODE_COMPACT_FILTERS = 1 << 6
+NODE_NETWORK_LIMITED = 1 << 10
+NODE_P2P_V2 = 1 << 11
+
+MSG_TX = 1
+MSG_BLOCK = 2
+MSG_FILTERED_BLOCK = 3
+MSG_CMPCT_BLOCK = 4
+MSG_WTX = 5
+MSG_WITNESS_FLAG = 1 << 30
+MSG_TYPE_MASK = 0xFFFFFFFF >> 2
+MSG_WITNESS_TX = MSG_TX | MSG_WITNESS_FLAG
+
+FILTER_TYPE_BASIC = 0
+
+WITNESS_SCALE_FACTOR = 4
+
+DEFAULT_ANCESTOR_LIMIT = 25  # default max number of in-mempool ancestors
+DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
+DEFAULT_CLUSTER_LIMIT = 64  # default max number of transactions in a cluster
+
+
+# Default setting for -datacarriersize.
+MAX_OP_RETURN_RELAY = 100_000
+
+
+DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
+
+TX_MIN_STANDARD_VERSION = 1
+TX_MAX_STANDARD_VERSION = 3
+
+MAGIC_BYTES = {
+    "mainnet": b"\xf9\xbe\xb4\xd9",
+    "testnet4": b"\x1c\x16\x3f\x28",
+    "regtest": b"\xfa\xbf\xb5\xda",
+    "signet": b"\x0a\x03\xcf\x40",
+}
+
+
+def sha256(s):
+    """Calculate the SHA-256 hash of the input bytes."""
+    return hashlib.sha256(s).digest()
+
+
+def sha3(s):
+    """Calculate the SHA3-256 hash of the input bytes."""
+    return hashlib.sha3_256(s).digest()
+
+
+def hash256(s):
+    """Calculate the double SHA-256 hash of the input bytes."""
+    return sha256(sha256(s))
+
+
+def sere_compact_size(length):
+    """Serialize a compact size integer."""
+    if length < 253:
+        return length.to_bytes(1, "little")
+    if length < 0x10000:
+        return b"\xfd" + length.to_bytes(2, "little")
+    if length < 0x100000000:
+        return b"\xfe" + length.to_bytes(4, "little")
+    return b"\xff" + length.to_bytes(8, "little")
+
+
+def deser_compact_size(file):
+    """Deserialize a compact size integer from a file-like object."""
+    size = int.from_bytes(file.read(1), "little")
+    if size == 253:
+        return int.from_bytes(file.read(2), "little")
+    if size == 254:
+        return int.from_bytes(file.read(4), "little")
+    if size == 255:
+        return int.from_bytes(file.read(8), "little")
+    return size
+
+
+def deser_string(file):
+    """Deserialize a string from a file-like object."""
+    size = deser_compact_size(file)
+    return file.read(size)
+
+
+def sere_string(string):
+    """Serialize a string to bytes."""
+    return sere_compact_size(len(string)) + string
+
+
+def deser_uint256(file):
+    """Deserialize a 256-bit unsigned integer from a file-like object."""
+    return int.from_bytes(file.read(32), "little")
+
+
+def sere_uint256(value):
+    """Serialize a 256-bit unsigned integer to bytes."""
+    return value.to_bytes(32, "little")
+
+
+def uint256_from_str(s):
+    return int.from_bytes(s[:32], "little")
+
+
+def uint256_from_compact(c):
+    nbytes = (c >> 24) & 0xFF
+    v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
+    return v
+
+
+# deser_function_name: Allow for an alternate deserialization function on the
+# entries in the vector.
+def deser_vector(f, c, deser_function_name=None):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = c()
+        if deser_function_name:
+            getattr(t, deser_function_name)(f)
+        else:
+            t.deserialize(f)
+        r.append(t)
+    return r
+
+
+# sere_function_name: Allow for an alternate serialization function on the
+# entries in the vector (we use this for serializing the vector of transactions
+# for a witness block).
+def sere_vector(l, sere_function_name=None):
+    r = sere_compact_size(len(l))
+    for i in l:
+        if sere_function_name:
+            r += getattr(i, sere_function_name)()
+        else:
+            r += i.serialize()
+    return r
+
+
+def deser_uint256_vector(f):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = deser_uint256(f)
+        r.append(t)
+    return r
+
+
+def sere_uint256_vector(l):
+    r = sere_compact_size(len(l))
+    for i in l:
+        r += sere_uint256(i)
+    return r
+
+
+def deser_string_vector(f):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = deser_string(f)
+        r.append(t)
+    return r
+
+
+def sere_string_vector(l):
+    r = sere_compact_size(len(l))
+    for sv in l:
+        r += sere_string(sv)
+    return r
+
+
+def deser_block_spent_outputs(f):
+    nit = deser_compact_size(f)
+    return [deser_vector(f, CTxOut) for _ in range(nit)]
+
+
+def from_hex(obj, hex_string):
+    """Deserialize from a hex string representation (e.g. from RPC)
+
+    Note that there is no complementary helper like e.g. `to_hex` for the
+    inverse operation. To serialize a message object to a hex string, simply
+    use obj.serialize().hex()"""
+    obj.deserialize(BytesIO(bytes.fromhex(hex_string)))
+    return obj
+
+
+def tx_from_hex(hex_string):
+    """Deserialize from hex string to a transaction object"""
+    return from_hex(CTransaction(), hex_string)
+
+
+def malleate_tx_to_invalid_witness(tx):
+    """
+    Create a malleated version of the tx where the witness is replaced with garbage data.
+    Returns a CTransaction object.
+    """
+    tx_bad_wit = tx_from_hex(tx["hex"])
+    tx_bad_wit.wit.vtxinwit = [CTxInWitness()]
+    # Add garbage data to witness 0. We cannot simply strip the witness, as the node would
+    # classify it as a transaction in which the witness was missing rather than wrong.
+    tx_bad_wit.wit.vtxinwit[0].scriptWitness.stack = [b"garbage"]
+
+    assert tx["txid"] == tx_bad_wit.txid_hex
+    assert tx["wtxid"] != tx_bad_wit.wtxid_hex
+
+    return tx_bad_wit
+
+
+# like from_hex, but without the hex part
+def from_binary(cls, stream):
+    """deserialize a binary stream (or bytes object) into an object"""
+    # handle bytes object by turning it into a stream
+    was_bytes = isinstance(stream, bytes)
+    if was_bytes:
+        stream = BytesIO(stream)
+    obj = cls()
+    obj.deserialize(stream)
+    if was_bytes:
+        assert len(stream.read()) == 0
+    return obj
+
+
+# Objects that map to bitcoind objects, which can be serialized/deserialized
+
+
+class CAddress:
+    """Represents a network address with serialization and deserialization methods."""
+
+    __slots__ = ("net", "ip", "nServices", "port", "time")
+
+    # see https://github.com/bitcoin/bips/blob/master/bip-0155.mediawiki
+    NET_IPV4 = 1
+    NET_IPV6 = 2
+    NET_TORV3 = 4
+    NET_I2P = 5
+    NET_CJDNS = 6
+
+    ADDRV2_NET_NAME = {
+        NET_IPV4: "IPv4",
+        NET_IPV6: "IPv6",
+        NET_TORV3: "TorV3",
+        NET_I2P: "I2P",
+        NET_CJDNS: "CJDNS",
+    }
+
+    ADDRV2_ADDRESS_LENGTH = {
+        NET_IPV4: 4,
+        NET_IPV6: 16,
+        NET_TORV3: 32,
+        NET_I2P: 32,
+        NET_CJDNS: 16,
+    }
+
+    I2P_PAD = "===="
+
+    def __init__(self):
+        self.time = 0
+        self.nServices = 1
+        self.net = self.NET_IPV4
+        self.ip = "0.0.0.0"
+        self.port = 0
+
+    def __eq__(self, other):
+        return (
+            self.net == other.net
+            and self.ip == other.ip
+            and self.nServices == other.nServices
+            and self.port == other.port
+            and self.time == other.time
+        )
+
+    def deserialize(self, file, *, with_time=True):
+        """Deserialize from addrv1 format (pre-BIP155)."""
+        if with_time:
+            # VERSION messages serialize CAddress objects without time
+            self.time = int.from_bytes(file.read(4), "little")
+        self.nServices = int.from_bytes(file.read(8), "little")
+        # We only support IPv4 which means skip 12 bytes and read the next 4 as IPv4 address.
+        file.read(12)
+        self.net = self.NET_IPV4
+        self.ip = socket.inet_ntoa(file.read(4))
+        self.port = int.from_bytes(file.read(2), "big")
+
+    def serialize(self, *, with_time=True):
+        """Serialize in addrv1 format (pre-BIP155)."""
+        assert self.net == self.NET_IPV4
+        result = b""
+        if with_time:
+            # VERSION messages serialize CAddress objects without time
+            result += self.time.to_bytes(4, "little")
+        result += self.nServices.to_bytes(8, "little")
+        result += b"\x00" * 10 + b"\xff" * 2
+        result += socket.inet_aton(self.ip)
+        result += self.port.to_bytes(2, "big")
+        return result
+
+    def deserialize_v2(self, f):
+        """Deserialize from addrv2 format (BIP155)"""
+        self.time = int.from_bytes(f.read(4), "little")
+
+        self.nServices = deser_compact_size(f)
+
+        self.net = int.from_bytes(f.read(1), "little")
+        assert self.net in self.ADDRV2_NET_NAME
+
+        address_length = deser_compact_size(f)
+        assert address_length == self.ADDRV2_ADDRESS_LENGTH[self.net]
+
+        addr_bytes = f.read(address_length)
+        if self.net == self.NET_IPV4:
+            self.ip = socket.inet_ntoa(addr_bytes)
+        elif self.net == self.NET_IPV6:
+            self.ip = socket.inet_ntop(socket.AF_INET6, addr_bytes)
+        elif self.net == self.NET_TORV3:
+            prefix = b".onion checksum"
+            version = bytes([3])
+            checksum = sha3(prefix + addr_bytes + version)[:2]
+            self.ip = (
+                b32encode(addr_bytes + checksum + version).decode("ascii").lower()
+                + ".onion"
+            )
+        elif self.net == self.NET_I2P:
+            self.ip = (
+                b32encode(addr_bytes)[0 : -len(self.I2P_PAD)].decode("ascii").lower()
+                + ".b32.i2p"
+            )
+        elif self.net == self.NET_CJDNS:
+            self.ip = socket.inet_ntop(socket.AF_INET6, addr_bytes)
+        else:
+            raise ValueError("Address type not supported")
+
+        self.port = int.from_bytes(f.read(2), "big")
+
+    def serialize_v2(self):
+        """Serialize in addrv2 format (BIP155)"""
+        assert self.net in self.ADDRV2_NET_NAME
+        r = b""
+        r += self.time.to_bytes(4, "little")
+        r += sere_compact_size(self.nServices)
+        r += self.net.to_bytes(1, "little")
+        r += sere_compact_size(self.ADDRV2_ADDRESS_LENGTH[self.net])
+        if self.net == self.NET_IPV4:
+            r += socket.inet_aton(self.ip)
+        elif self.net == self.NET_IPV6:
+            r += socket.inet_pton(socket.AF_INET6, self.ip)
+        elif self.net == self.NET_TORV3:
+            sfx = ".onion"
+            assert self.ip.endswith(sfx)
+            r += b32decode(self.ip[0 : -len(sfx)], True)[0:32]
+        elif self.net == self.NET_I2P:
+            sfx = ".b32.i2p"
+            assert self.ip.endswith(sfx)
+            r += b32decode(self.ip[0 : -len(sfx)] + self.I2P_PAD, True)
+        elif self.net == self.NET_CJDNS:
+            r += socket.inet_pton(socket.AF_INET6, self.ip)
+        else:
+            raise ValueError("Address type not supported")
+        r += self.port.to_bytes(2, "big")
+        return r
+
+    def __repr__(self):
+        return (
+            f"CAddress(nServices={self.nServices}, net={self.ADDRV2_NET_NAME[self.net]}, "
+            f"addr={self.ip}, port={self.port})"
+        )
+
+
+class CInv:
+    __slots__ = ("hash", "type")
+
+    typemap = {
+        0: "Error",
+        MSG_TX: "TX",
+        MSG_BLOCK: "Block",
+        MSG_TX | MSG_WITNESS_FLAG: "WitnessTx",
+        MSG_BLOCK | MSG_WITNESS_FLAG: "WitnessBlock",
+        MSG_FILTERED_BLOCK: "filtered Block",
+        MSG_CMPCT_BLOCK: "CompactBlock",
+        MSG_WTX: "WTX",
+    }
+
+    def __init__(self, t=0, h=0):
+        self.type = t
+        self.hash = h
+
+    def deserialize(self, f):
+        self.type = int.from_bytes(f.read(4), "little")
+        self.hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.type.to_bytes(4, "little")
+        r += sere_uint256(self.hash)
+        return r
+
+    def __repr__(self):
+        return "CInv(type=%s hash=%064x)" % (self.typemap[self.type], self.hash)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, CInv)
+            and self.hash == other.hash
+            and self.type == other.type
+        )
+
+
+class CBlockLocator:
+    __slots__ = ("nVersion", "vHave")
+
+    def __init__(self):
+        self.vHave = []
+
+    def deserialize(self, f):
+        int.from_bytes(f.read(4), "little", signed=True)  # Ignore version field.
+        self.vHave = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += (0).to_bytes(
+            4, "little", signed=True
+        )  # Bitcoin Core ignores the version field. Set it to 0.
+        r += sere_uint256_vector(self.vHave)
+        return r
+
+    def __repr__(self):
+        return "CBlockLocator(vHave=%s)" % (repr(self.vHave))
+
+
+class COutPoint:
+    """Represents a transaction outpoint with a hash and index."""
+
+    __slots__ = ("hash", "index")
+
+    def __init__(self, hash=0, index=0):
+        self.hash = hash
+        self.index = index
+
+    def deserialize(self, file):
+        """Deserialize the outpoint from a file-like object."""
+        self.hash = deser_uint256(file)
+        self.index = int.from_bytes(file.read(4), "little")
+
+    def serialize(self):
+        """Serialize the outpoint to bytes."""
+        result = b""
+        result += sere_uint256(self.hash)
+        result += self.index.to_bytes(4, "little")
+        return result
+
+    def __repr__(self):
+        return f"COutPoint(hash={self.hash:064x}, index={self.index})"
+
+
+class CTxIn:
+    """Represents a transaction input."""
+
+    __slots__ = ("sequence", "prevout", "script_sig")
+
+    def __init__(self, outpoint=None, script_sig=b"", sequence=0):
+        self.prevout = outpoint if outpoint else COutPoint()
+        self.script_sig = script_sig
+        self.sequence = sequence
+
+    def deserialize(self, file):
+        """Deserialize the transaction input from a file-like object."""
+        self.prevout = COutPoint()
+        self.prevout.deserialize(file)
+        self.script_sig = deser_string(file)
+        self.sequence = int.from_bytes(file.read(4), "little")
+
+    def serialize(self):
+        """Serialize the transaction input to bytes."""
+        result = b""
+        result += self.prevout.serialize()
+        result += sere_string(self.script_sig)
+        result += self.sequence.to_bytes(4, "little")
+        return result
+
+    def __repr__(self):
+        return (
+            f"CTxIn(prevout={repr(self.prevout)}, script_sig={self.script_sig.hex()}, "
+            f"sequence={self.sequence})"
+        )
+
+
+class CTxOut:
+    __slots__ = ("nValue", "scriptPubKey")
+
+    def __init__(self, nValue=0, scriptPubKey=b""):
+        self.nValue = nValue
+        self.scriptPubKey = scriptPubKey
+
+    def deserialize(self, f):
+        self.nValue = int.from_bytes(f.read(8), "little", signed=True)
+        self.scriptPubKey = deser_string(f)
+
+    def serialize(self):
+        r = b""
+        r += self.nValue.to_bytes(8, "little", signed=True)
+        r += sere_string(self.scriptPubKey)
+        return r
+
+    def __repr__(self):
+        return "CTxOut(nValue=%i.%08i scriptPubKey=%s)" % (
+            self.nValue // COIN,
+            self.nValue % COIN,
+            self.scriptPubKey.hex(),
+        )
+
+
+class CScriptWitness:
+    __slots__ = ("stack",)
+
+    def __init__(self):
+        # stack is a vector of strings
+        self.stack = []
+
+    def __repr__(self):
+        return "CScriptWitness(%s)" % (",".join([x.hex() for x in self.stack]))
+
+    def is_null(self):
+        if self.stack:
+            return False
+        return True
+
+
+class CTxInWitness:
+    __slots__ = ("scriptWitness",)
+
+    def __init__(self):
+        self.scriptWitness = CScriptWitness()
+
+    def deserialize(self, f):
+        self.scriptWitness.stack = deser_string_vector(f)
+
+    def serialize(self):
+        return sere_string_vector(self.scriptWitness.stack)
+
+    def __repr__(self):
+        return repr(self.scriptWitness)
+
+    def is_null(self):
+        return self.scriptWitness.is_null()
+
+
+class CTxWitness:
+    __slots__ = ("vtxinwit",)
+
+    def __init__(self):
+        self.vtxinwit = []
+
+    def deserialize(self, f):
+        for i in range(len(self.vtxinwit)):
+            self.vtxinwit[i].deserialize(f)
+
+    def serialize(self):
+        r = b""
+        # This is different than the usual vector serialization --
+        # we omit the length of the vector, which is required to be
+        # the same length as the transaction's vin vector.
+        for x in self.vtxinwit:
+            r += x.serialize()
+        return r
+
+    def __repr__(self):
+        return "CTxWitness(%s)" % (";".join([repr(x) for x in self.vtxinwit]))
+
+    def is_null(self):
+        for x in self.vtxinwit:
+            if not x.is_null():
+                return False
+        return True
+
+
+class CTransaction:
+    __slots__ = ("nLockTime", "version", "vin", "vout", "wit")
+
+    def __init__(self, tx=None):
+        if tx is None:
+            self.version = 2
+            self.vin = []
+            self.vout = []
+            self.wit = CTxWitness()
+            self.nLockTime = 0
+        else:
+            self.version = tx.version
+            self.vin = copy.deepcopy(tx.vin)
+            self.vout = copy.deepcopy(tx.vout)
+            self.nLockTime = tx.nLockTime
+            self.wit = copy.deepcopy(tx.wit)
+
+    def deserialize(self, f):
+        self.version = int.from_bytes(f.read(4), "little")
+        self.vin = deser_vector(f, CTxIn)
+        flags = 0
+        if len(self.vin) == 0:
+            flags = int.from_bytes(f.read(1), "little")
+            # Not sure why flags can't be zero, but this
+            # matches the implementation in bitcoind
+            if flags != 0:
+                self.vin = deser_vector(f, CTxIn)
+                self.vout = deser_vector(f, CTxOut)
+        else:
+            self.vout = deser_vector(f, CTxOut)
+        if flags != 0:
+            self.wit.vtxinwit = [CTxInWitness() for _ in range(len(self.vin))]
+            self.wit.deserialize(f)
+        else:
+            self.wit = CTxWitness()
+        self.nLockTime = int.from_bytes(f.read(4), "little")
+
+    def serialize_without_witness(self):
+        r = b""
+        r += self.version.to_bytes(4, "little")
+        r += sere_vector(self.vin)
+        r += sere_vector(self.vout)
+        r += self.nLockTime.to_bytes(4, "little")
+        return r
+
+    # Only serialize with witness when explicitly called for
+    def serialize_with_witness(self):
+        flags = 0
+        if not self.wit.is_null():
+            flags |= 1
+        r = b""
+        r += self.version.to_bytes(4, "little")
+        if flags:
+            dummy = []
+            r += sere_vector(dummy)
+            r += flags.to_bytes(1, "little")
+        r += sere_vector(self.vin)
+        r += sere_vector(self.vout)
+        if flags & 1:
+            if len(self.wit.vtxinwit) != len(self.vin):
+                # vtxinwit must have the same length as vin
+                self.wit.vtxinwit = self.wit.vtxinwit[: len(self.vin)]
+                for _ in range(len(self.wit.vtxinwit), len(self.vin)):
+                    self.wit.vtxinwit.append(CTxInWitness())
+            r += self.wit.serialize()
+        r += self.nLockTime.to_bytes(4, "little")
+        return r
+
+    # Regular serialization is with witness -- must explicitly
+    # call serialize_without_witness to exclude witness data.
+    def serialize(self):
+        return self.serialize_with_witness()
+
+    @property
+    def wtxid_hex(self):
+        """Return wtxid (transaction hash with witness) as hex string."""
+        return hash256(self.serialize())[::-1].hex()
+
+    @property
+    def wtxid_int(self):
+        """Return wtxid (transaction hash with witness) as integer."""
+        return uint256_from_str(hash256(self.serialize_with_witness()))
+
+    @property
+    def txid_hex(self):
+        """Return txid (transaction hash without witness) as hex string."""
+        return hash256(self.serialize_without_witness())[::-1].hex()
+
+    @property
+    def txid_int(self):
+        """Return txid (transaction hash without witness) as integer."""
+        return uint256_from_str(hash256(self.serialize_without_witness()))
+
+    def is_valid(self):
+        for tout in self.vout:
+            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
+                return False
+        return True
+
+    # Calculate the transaction weight using witness and non-witness
+    # serialization size (does NOT use sigops).
+    def get_weight(self):
+        with_witness_size = len(self.serialize_with_witness())
+        without_witness_size = len(self.serialize_without_witness())
+        return (WITNESS_SCALE_FACTOR - 1) * without_witness_size + with_witness_size
+
+    def get_vsize(self):
+        return math.ceil(self.get_weight() / WITNESS_SCALE_FACTOR)
+
+    def __repr__(self):
+        return "CTransaction(version=%i vin=%s vout=%s wit=%s nLockTime=%i)" % (
+            self.version,
+            repr(self.vin),
+            repr(self.vout),
+            repr(self.wit),
+            self.nLockTime,
+        )
+
+
+class CBlockHeader:
+    __slots__ = (
+        "hashMerkleRoot",
+        "hashPrevBlock",
+        "nBits",
+        "nNonce",
+        "nTime",
+        "nVersion",
+    )
+
+    def __init__(self, header=None):
+        if header is None:
+            self.set_null()
+        else:
+            self.nVersion = header.nVersion
+            self.hashPrevBlock = header.hashPrevBlock
+            self.hashMerkleRoot = header.hashMerkleRoot
+            self.nTime = header.nTime
+            self.nBits = header.nBits
+            self.nNonce = header.nNonce
+
+    def set_null(self):
+        self.nVersion = 4
+        self.hashPrevBlock = 0
+        self.hashMerkleRoot = 0
+        self.nTime = 0
+        self.nBits = 0
+        self.nNonce = 0
+
+    def deserialize(self, f):
+        self.nVersion = int.from_bytes(f.read(4), "little", signed=True)
+        self.hashPrevBlock = deser_uint256(f)
+        self.hashMerkleRoot = deser_uint256(f)
+        self.nTime = int.from_bytes(f.read(4), "little")
+        self.nBits = int.from_bytes(f.read(4), "little")
+        self.nNonce = int.from_bytes(f.read(4), "little")
+
+    def serialize(self):
+        return self._serialize_header()
+
+    def _serialize_header(self):
+        r = b""
+        r += self.nVersion.to_bytes(4, "little", signed=True)
+        r += sere_uint256(self.hashPrevBlock)
+        r += sere_uint256(self.hashMerkleRoot)
+        r += self.nTime.to_bytes(4, "little")
+        r += self.nBits.to_bytes(4, "little")
+        r += self.nNonce.to_bytes(4, "little")
+        return r
+
+    @property
+    def hash_hex(self):
+        """Return block header hash as hex string."""
+        return hash256(self._serialize_header())[::-1].hex()
+
+    @property
+    def hash_int(self):
+        """Return block header hash as integer."""
+        return uint256_from_str(hash256(self._serialize_header()))
+
+    def __repr__(self):
+        return (
+            "CBlockHeader(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x)"
+            % (
+                self.nVersion,
+                self.hashPrevBlock,
+                self.hashMerkleRoot,
+                time.ctime(self.nTime),
+                self.nBits,
+                self.nNonce,
+            )
+        )
+
+
+BLOCK_HEADER_SIZE = len(CBlockHeader().serialize())
+assert BLOCK_HEADER_SIZE == 80
+
+
+class CBlock(CBlockHeader):
+    __slots__ = ("vtx",)
+
+    def __init__(self, header=None):
+        super().__init__(header)
+        self.vtx = []
+
+    def deserialize(self, f):
+        super().deserialize(f)
+        self.vtx = deser_vector(f, CTransaction)
+
+    def serialize(self, with_witness=True):
+        r = b""
+        r += super().serialize()
+        if with_witness:
+            r += sere_vector(self.vtx, "serialize_with_witness")
+        else:
+            r += sere_vector(self.vtx, "serialize_without_witness")
+        return r
+
+    # Calculate the merkle root given a vector of transaction hashes
+    @classmethod
+    def get_merkle_root(cls, hashes):
+        while len(hashes) > 1:
+            newhashes = []
+            for i in range(0, len(hashes), 2):
+                i2 = min(i + 1, len(hashes) - 1)
+                newhashes.append(hash256(hashes[i] + hashes[i2]))
+            hashes = newhashes
+        return uint256_from_str(hashes[0])
+
+    def calc_merkle_root(self):
+        hashes = []
+        for tx in self.vtx:
+            hashes.append(sere_uint256(tx.txid_int))
+        return self.get_merkle_root(hashes)
+
+    def calc_witness_merkle_root(self):
+        # For witness root purposes, the hash of the
+        # coinbase, with witness, is defined to be 0...0
+        hashes = [sere_uint256(0)]
+
+        for tx in self.vtx[1:]:
+            # Calculate the hashes with witness data
+            hashes.append(sere_uint256(tx.wtxid_int))
+
+        return self.get_merkle_root(hashes)
+
+    def is_valid(self):
+        target = uint256_from_compact(self.nBits)
+        if self.hash_int > target:
+            return False
+        for tx in self.vtx:
+            if not tx.is_valid():
+                return False
+        if self.calc_merkle_root() != self.hashMerkleRoot:
+            return False
+        return True
+
+    def solve(self):
+        target = uint256_from_compact(self.nBits)
+        while self.hash_int > target:
+            self.nNonce += 1
+
+    # Calculate the block weight using witness and non-witness
+    # serialization size (does NOT use sigops).
+    def get_weight(self):
+        with_witness_size = len(self.serialize(with_witness=True))
+        without_witness_size = len(self.serialize(with_witness=False))
+        return (WITNESS_SCALE_FACTOR - 1) * without_witness_size + with_witness_size
+
+    def __repr__(self):
+        return (
+            "CBlock(nVersion=%i hashPrevBlock=%064x hashMerkleRoot=%064x nTime=%s nBits=%08x nNonce=%08x vtx=%s)"
+            % (
+                self.nVersion,
+                self.hashPrevBlock,
+                self.hashMerkleRoot,
+                time.ctime(self.nTime),
+                self.nBits,
+                self.nNonce,
+                repr(self.vtx),
+            )
+        )
+
+
+class PrefilledTransaction:
+    __slots__ = ("index", "tx")
+
+    def __init__(self, index=0, tx=None):
+        self.index = index
+        self.tx = tx
+
+    def deserialize(self, f):
+        self.index = deser_compact_size(f)
+        self.tx = CTransaction()
+        self.tx.deserialize(f)
+
+    def serialize(self, with_witness=True):
+        r = b""
+        r += sere_compact_size(self.index)
+        if with_witness:
+            r += self.tx.serialize_with_witness()
+        else:
+            r += self.tx.serialize_without_witness()
+        return r
+
+    def serialize_without_witness(self):
+        return self.serialize(with_witness=False)
+
+    def serialize_with_witness(self):
+        return self.serialize(with_witness=True)
+
+    def __repr__(self):
+        return "PrefilledTransaction(index=%d, tx=%s)" % (self.index, repr(self.tx))
+
+
+# This is what we send on the wire, in a cmpctblock message.
+class P2PHeaderAndShortIDs:
+    __slots__ = (
+        "header",
+        "nonce",
+        "prefilled_txn",
+        "prefilled_txn_length",
+        "shortids",
+        "shortids_length",
+    )
+
+    def __init__(self):
+        self.header = CBlockHeader()
+        self.nonce = 0
+        self.shortids_length = 0
+        self.shortids = []
+        self.prefilled_txn_length = 0
+        self.prefilled_txn = []
+
+    def deserialize(self, f):
+        self.header.deserialize(f)
+        self.nonce = int.from_bytes(f.read(8), "little")
+        self.shortids_length = deser_compact_size(f)
+        for _ in range(self.shortids_length):
+            # shortids are defined to be 6 bytes in the spec, so append
+            # two zero bytes and read it in as an 8-byte number
+            self.shortids.append(int.from_bytes(f.read(6) + b"\x00\x00", "little"))
+        self.prefilled_txn = deser_vector(f, PrefilledTransaction)
+        self.prefilled_txn_length = len(self.prefilled_txn)
+
+    # When using version 2 compact blocks, we must serialize with_witness.
+    def serialize(self, with_witness=False):
+        r = b""
+        r += self.header.serialize()
+        r += self.nonce.to_bytes(8, "little")
+        r += sere_compact_size(self.shortids_length)
+        for x in self.shortids:
+            # We only want the first 6 bytes
+            r += x.to_bytes(8, "little")[0:6]
+        if with_witness:
+            r += sere_vector(self.prefilled_txn, "serialize_with_witness")
+        else:
+            r += sere_vector(self.prefilled_txn, "serialize_without_witness")
+        return r
+
+    def __repr__(self):
+        return (
+            "P2PHeaderAndShortIDs(header=%s, nonce=%d, shortids_length=%d, shortids=%s, prefilled_txn_length=%d, prefilledtxn=%s"
+            % (
+                repr(self.header),
+                self.nonce,
+                self.shortids_length,
+                repr(self.shortids),
+                self.prefilled_txn_length,
+                repr(self.prefilled_txn),
+            )
+        )
+
+
+# P2P version of the above that will use witness serialization (for compact
+# block version 2)
+class P2PHeaderAndShortWitnessIDs(P2PHeaderAndShortIDs):
+    __slots__ = ()
+
+    def serialize(self):  # pylint: disable=arguments-differ
+        return super().serialize(with_witness=True)
+
+
+# Calculate the BIP 152-compact blocks shortid for a given transaction hash
+def calculate_shortid(k0, k1, tx_hash):
+    expected_shortid = siphash256(k0, k1, tx_hash)
+    expected_shortid &= 0x0000FFFFFFFFFFFF
+    return expected_shortid
+
+
+# This version gets rid of the array lengths, and reinterprets the differential
+# encoding into indices that can be used for lookup.
+class HeaderAndShortIDs:
+    __slots__ = ("header", "nonce", "prefilled_txn", "shortids", "use_witness")
+
+    def __init__(self, p2pheaders_and_shortids=None):
+        self.header = CBlockHeader()
+        self.nonce = 0
+        self.shortids = []
+        self.prefilled_txn = []
+        self.use_witness = False
+
+        if p2pheaders_and_shortids is not None:
+            self.header = p2pheaders_and_shortids.header
+            self.nonce = p2pheaders_and_shortids.nonce
+            self.shortids = p2pheaders_and_shortids.shortids
+            last_index = -1
+            for x in p2pheaders_and_shortids.prefilled_txn:
+                self.prefilled_txn.append(
+                    PrefilledTransaction(x.index + last_index + 1, x.tx)
+                )
+                last_index = self.prefilled_txn[-1].index
+
+    def to_p2p(self):
+        if self.use_witness:
+            ret = P2PHeaderAndShortWitnessIDs()
+        else:
+            ret = P2PHeaderAndShortIDs()
+        ret.header = self.header
+        ret.nonce = self.nonce
+        ret.shortids_length = len(self.shortids)
+        ret.shortids = self.shortids
+        ret.prefilled_txn_length = len(self.prefilled_txn)
+        ret.prefilled_txn = []
+        last_index = -1
+        for x in self.prefilled_txn:
+            ret.prefilled_txn.append(
+                PrefilledTransaction(x.index - last_index - 1, x.tx)
+            )
+            last_index = x.index
+        return ret
+
+    def get_siphash_keys(self):
+        header_nonce = self.header.serialize()
+        header_nonce += self.nonce.to_bytes(8, "little")
+        hash_header_nonce_as_str = sha256(header_nonce)
+        key0 = int.from_bytes(hash_header_nonce_as_str[0:8], "little")
+        key1 = int.from_bytes(hash_header_nonce_as_str[8:16], "little")
+        return [key0, key1]
+
+    # Version 2 compact blocks use wtxid in shortids (rather than txid)
+    def initialize_from_block(
+        self, block, nonce=0, prefill_list=None, use_witness=False
+    ):
+        if prefill_list is None:
+            prefill_list = [0]
+        self.header = CBlockHeader(block)
+        self.nonce = nonce
+        self.prefilled_txn = [
+            PrefilledTransaction(i, block.vtx[i]) for i in prefill_list
+        ]
+        self.shortids = []
+        self.use_witness = use_witness
+        [k0, k1] = self.get_siphash_keys()
+        for i in range(len(block.vtx)):
+            if i not in prefill_list:
+                tx_hash = block.vtx[i].txid_int
+                if use_witness:
+                    tx_hash = block.vtx[i].wtxid_int
+                self.shortids.append(calculate_shortid(k0, k1, tx_hash))
+
+    def __repr__(self):
+        return "HeaderAndShortIDs(header=%s, nonce=%d, shortids=%s, prefilledtxn=%s" % (
+            repr(self.header),
+            self.nonce,
+            repr(self.shortids),
+            repr(self.prefilled_txn),
+        )
+
+
+class BlockTransactionsRequest:
+    __slots__ = ("blockhash", "indexes")
+
+    def __init__(self, blockhash=0, indexes=None):
+        self.blockhash = blockhash
+        self.indexes = indexes if indexes is not None else []
+
+    def deserialize(self, f):
+        self.blockhash = deser_uint256(f)
+        indexes_length = deser_compact_size(f)
+        for _ in range(indexes_length):
+            self.indexes.append(deser_compact_size(f))
+
+    def serialize(self):
+        r = b""
+        r += sere_uint256(self.blockhash)
+        r += sere_compact_size(len(self.indexes))
+        for x in self.indexes:
+            r += sere_compact_size(x)
+        return r
+
+    # helper to set the differentially encoded indexes from absolute ones
+    def from_absolute(self, absolute_indexes):
+        self.indexes = []
+        last_index = -1
+        for x in absolute_indexes:
+            self.indexes.append(x - last_index - 1)
+            last_index = x
+
+    def to_absolute(self):
+        absolute_indexes = []
+        last_index = -1
+        for x in self.indexes:
+            absolute_indexes.append(x + last_index + 1)
+            last_index = absolute_indexes[-1]
+        return absolute_indexes
+
+    def __repr__(self):
+        return "BlockTransactionsRequest(hash=%064x indexes=%s)" % (
+            self.blockhash,
+            repr(self.indexes),
+        )
+
+
+class BlockTransactions:
+    __slots__ = ("blockhash", "transactions")
+
+    def __init__(self, blockhash=0, transactions=None):
+        self.blockhash = blockhash
+        self.transactions = transactions if transactions is not None else []
+
+    def deserialize(self, f):
+        self.blockhash = deser_uint256(f)
+        self.transactions = deser_vector(f, CTransaction)
+
+    def serialize(self, with_witness=True):
+        r = b""
+        r += sere_uint256(self.blockhash)
+        if with_witness:
+            r += sere_vector(self.transactions, "serialize_with_witness")
+        else:
+            r += sere_vector(self.transactions, "serialize_without_witness")
+        return r
+
+    def __repr__(self):
+        return "BlockTransactions(hash=%064x transactions=%s)" % (
+            self.blockhash,
+            repr(self.transactions),
+        )
+
+
+class CPartialMerkleTree:
+    __slots__ = ("nTransactions", "vBits", "vHash")
+
+    def __init__(self):
+        self.nTransactions = 0
+        self.vHash = []
+        self.vBits = []
+
+    def deserialize(self, f):
+        self.nTransactions = int.from_bytes(f.read(4), "little")
+        self.vHash = deser_uint256_vector(f)
+        vBytes = deser_string(f)
+        self.vBits = []
+        for i in range(len(vBytes) * 8):
+            self.vBits.append(vBytes[i // 8] & (1 << (i % 8)) != 0)
+
+    def serialize(self):
+        r = b""
+        r += self.nTransactions.to_bytes(4, "little")
+        r += sere_uint256_vector(self.vHash)
+        vBytesArray = bytearray([0x00] * ((len(self.vBits) + 7) // 8))
+        for i in range(len(self.vBits)):
+            vBytesArray[i // 8] |= self.vBits[i] << (i % 8)
+        r += sere_string(bytes(vBytesArray))
+        return r
+
+    def __repr__(self):
+        return "CPartialMerkleTree(nTransactions=%d, vHash=%s, vBits=%s)" % (
+            self.nTransactions,
+            repr(self.vHash),
+            repr(self.vBits),
+        )
+
+
+class CMerkleBlock:
+    __slots__ = ("header", "txn")
+
+    def __init__(self):
+        self.header = CBlockHeader()
+        self.txn = CPartialMerkleTree()
+
+    def deserialize(self, f):
+        self.header.deserialize(f)
+        self.txn.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.header.serialize()
+        r += self.txn.serialize()
+        return r
+
+    def __repr__(self):
+        return "CMerkleBlock(header=%s, txn=%s)" % (repr(self.header), repr(self.txn))
+
+
+# Objects that correspond to messages on the wire
+class msg_version:
+    __slots__ = (
+        "addrFrom",
+        "addrTo",
+        "nNonce",
+        "relay",
+        "nServices",
+        "nStartingHeight",
+        "nTime",
+        "nVersion",
+        "strSubVer",
+    )
+    msgtype = b"version"
+
+    def __init__(self):
+        self.nVersion = 0
+        self.nServices = 0
+        self.nTime = int(time.time())
+        self.addrTo = CAddress()
+        self.addrFrom = CAddress()
+        self.nNonce = random.getrandbits(64)
+        self.strSubVer = ""
+        self.nStartingHeight = -1
+        self.relay = 0
+
+    def deserialize(self, f):
+        self.nVersion = int.from_bytes(f.read(4), "little", signed=True)
+        self.nServices = int.from_bytes(f.read(8), "little")
+        self.nTime = int.from_bytes(f.read(8), "little", signed=True)
+        self.addrTo = CAddress()
+        self.addrTo.deserialize(f, with_time=False)
+
+        self.addrFrom = CAddress()
+        self.addrFrom.deserialize(f, with_time=False)
+        self.nNonce = int.from_bytes(f.read(8), "little")
+        self.strSubVer = deser_string(f).decode("utf-8")
+
+        self.nStartingHeight = int.from_bytes(f.read(4), "little", signed=True)
+
+        # Relay field is optional for version 70001 onwards
+        # But, unconditionally check it to match behaviour in bitcoind
+        self.relay = int.from_bytes(
+            f.read(1), "little"
+        )  # f.read(1) may return an empty b''
+
+    def serialize(self):
+        r = b""
+        r += self.nVersion.to_bytes(4, "little", signed=True)
+        r += self.nServices.to_bytes(8, "little")
+        r += self.nTime.to_bytes(8, "little", signed=True)
+        r += self.addrTo.serialize(with_time=False)
+        r += self.addrFrom.serialize(with_time=False)
+        r += self.nNonce.to_bytes(8, "little")
+        r += sere_string(self.strSubVer.encode("utf-8"))
+        r += self.nStartingHeight.to_bytes(4, "little", signed=True)
+        r += self.relay.to_bytes(1, "little")
+        return r
+
+    def __repr__(self):
+        return (
+            "msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X strSubVer=%s nStartingHeight=%i relay=%i)"
+            % (
+                self.nVersion,
+                self.nServices,
+                time.ctime(self.nTime),
+                repr(self.addrTo),
+                repr(self.addrFrom),
+                self.nNonce,
+                self.strSubVer,
+                self.nStartingHeight,
+                self.relay,
+            )
+        )
+
+
+class msg_verack:
+    __slots__ = ()
+    msgtype = b"verack"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_verack()"
+
+
+class msg_addr:
+    __slots__ = ("addrs",)
+    msgtype = b"addr"
+
+    def __init__(self):
+        self.addrs = []
+
+    def deserialize(self, f):
+        self.addrs = deser_vector(f, CAddress)
+
+    def serialize(self):
+        return sere_vector(self.addrs)
+
+    def __repr__(self):
+        return "msg_addr(addrs=%s)" % (repr(self.addrs))
+
+
+class msg_addrv2:
+    __slots__ = ("addrs",)
+    msgtype = b"addrv2"
+
+    def __init__(self):
+        self.addrs = []
+
+    def deserialize(self, f):
+        self.addrs = deser_vector(f, CAddress, "deserialize_v2")
+
+    def serialize(self):
+        return sere_vector(self.addrs, "serialize_v2")
+
+    def __repr__(self):
+        return "msg_addrv2(addrs=%s)" % (repr(self.addrs))
+
+
+class msg_sendaddrv2:
+    __slots__ = ()
+    msgtype = b"sendaddrv2"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_sendaddrv2()"
+
+
+class msg_inv:
+    __slots__ = ("inv",)
+    msgtype = b"inv"
+
+    def __init__(self, inv=None):
+        if inv is None:
+            self.inv = []
+        else:
+            self.inv = inv
+
+    def deserialize(self, f):
+        self.inv = deser_vector(f, CInv)
+
+    def serialize(self):
+        return sere_vector(self.inv)
+
+    def __repr__(self):
+        return "msg_inv(inv=%s)" % (repr(self.inv))
+
+
+class msg_getdata:
+    __slots__ = ("inv",)
+    msgtype = b"getdata"
+
+    def __init__(self, inv=None):
+        self.inv = inv if inv is not None else []
+
+    def deserialize(self, f):
+        self.inv = deser_vector(f, CInv)
+
+    def serialize(self):
+        return sere_vector(self.inv)
+
+    def __repr__(self):
+        return "msg_getdata(inv=%s)" % (repr(self.inv))
+
+
+class msg_getblocks:
+    __slots__ = ("locator", "hashstop")
+    msgtype = b"getblocks"
+
+    def __init__(self):
+        self.locator = CBlockLocator()
+        self.hashstop = 0
+
+    def deserialize(self, f):
+        self.locator = CBlockLocator()
+        self.locator.deserialize(f)
+        self.hashstop = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.locator.serialize()
+        r += sere_uint256(self.hashstop)
+        return r
+
+    def __repr__(self):
+        return "msg_getblocks(locator=%s hashstop=%064x)" % (
+            repr(self.locator),
+            self.hashstop,
+        )
+
+
+class msg_tx:
+    __slots__ = ("tx",)
+    msgtype = b"tx"
+
+    def __init__(self, tx=None):
+        if tx is None:
+            self.tx = CTransaction()
+        else:
+            self.tx = tx
+
+    def deserialize(self, f):
+        self.tx.deserialize(f)
+
+    def serialize(self):
+        return self.tx.serialize_with_witness()
+
+    def __repr__(self):
+        return "msg_tx(tx=%s)" % (repr(self.tx))
+
+
+class msg_wtxidrelay:
+    __slots__ = ()
+    msgtype = b"wtxidrelay"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_wtxidrelay()"
+
+
+class msg_no_witness_tx(msg_tx):
+    __slots__ = ()
+
+    def serialize(self):
+        return self.tx.serialize_without_witness()
+
+
+class msg_block:
+    __slots__ = ("block",)
+    msgtype = b"block"
+
+    def __init__(self, block=None):
+        if block is None:
+            self.block = CBlock()
+        else:
+            self.block = block
+
+    def deserialize(self, f):
+        self.block.deserialize(f)
+
+    def serialize(self):
+        return self.block.serialize()
+
+    def __repr__(self):
+        return "msg_block(block=%s)" % (repr(self.block))
+
+
+# Generic type to control the raw bytes sent over the wire.
+# The msgtype and the data must be provided.
+class msg_generic:
+    __slots__ = ("msgtype", "data")
+
+    def __init__(self, msgtype, data=None):
+        self.msgtype = msgtype
+        self.data = data
+
+    def serialize(self):
+        return self.data
+
+    def __repr__(self):
+        return "msg_generic()"
+
+
+class msg_no_witness_block(msg_block):
+    __slots__ = ()
+
+    def serialize(self):
+        return self.block.serialize(with_witness=False)
+
+
+class msg_getaddr:
+    __slots__ = ()
+    msgtype = b"getaddr"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_getaddr()"
+
+
+class msg_ping:
+    __slots__ = ("nonce",)
+    msgtype = b"ping"
+
+    def __init__(self, nonce=0):
+        self.nonce = nonce
+
+    def deserialize(self, f):
+        self.nonce = int.from_bytes(f.read(8), "little")
+
+    def serialize(self):
+        r = b""
+        r += self.nonce.to_bytes(8, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_ping(nonce=%08x)" % self.nonce
+
+
+class msg_pong:
+    __slots__ = ("nonce",)
+    msgtype = b"pong"
+
+    def __init__(self, nonce=0):
+        self.nonce = nonce
+
+    def deserialize(self, f):
+        self.nonce = int.from_bytes(f.read(8), "little")
+
+    def serialize(self):
+        r = b""
+        r += self.nonce.to_bytes(8, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_pong(nonce=%08x)" % self.nonce
+
+
+class msg_mempool:
+    __slots__ = ()
+    msgtype = b"mempool"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_mempool()"
+
+
+class msg_notfound:
+    __slots__ = ("vec",)
+    msgtype = b"notfound"
+
+    def __init__(self, vec=None):
+        self.vec = vec or []
+
+    def deserialize(self, f):
+        self.vec = deser_vector(f, CInv)
+
+    def serialize(self):
+        return sere_vector(self.vec)
+
+    def __repr__(self):
+        return "msg_notfound(vec=%s)" % (repr(self.vec))
+
+
+class msg_sendheaders:
+    __slots__ = ()
+    msgtype = b"sendheaders"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_sendheaders()"
+
+
+# getheaders message has
+# number of entries
+# vector of hashes
+# hash_stop (hash of last desired block header, 0 to get as many as possible)
+class msg_getheaders:
+    __slots__ = (
+        "hashstop",
+        "locator",
+    )
+    msgtype = b"getheaders"
+
+    def __init__(self):
+        self.locator = CBlockLocator()
+        self.hashstop = 0
+
+    def deserialize(self, f):
+        self.locator = CBlockLocator()
+        self.locator.deserialize(f)
+        self.hashstop = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.locator.serialize()
+        r += sere_uint256(self.hashstop)
+        return r
+
+    def __repr__(self):
+        return "msg_getheaders(locator=%s, stop=%064x)" % (
+            repr(self.locator),
+            self.hashstop,
+        )
+
+
+# headers message has
+# <count> <vector of block headers>
+class msg_headers:
+    __slots__ = ("headers",)
+    msgtype = b"headers"
+
+    def __init__(self, headers=None):
+        self.headers = headers if headers is not None else []
+
+    def deserialize(self, f):
+        # comment in bitcoind indicates these should be deserialized as blocks
+        blocks = deser_vector(f, CBlock)
+        for x in blocks:
+            self.headers.append(CBlockHeader(x))
+
+    def serialize(self):
+        blocks = [CBlock(x) for x in self.headers]
+        return sere_vector(blocks)
+
+    def __repr__(self):
+        return "msg_headers(headers=%s)" % repr(self.headers)
+
+
+class msg_merkleblock:
+    __slots__ = ("merkleblock",)
+    msgtype = b"merkleblock"
+
+    def __init__(self, merkleblock=None):
+        if merkleblock is None:
+            self.merkleblock = CMerkleBlock()
+        else:
+            self.merkleblock = merkleblock
+
+    def deserialize(self, f):
+        self.merkleblock.deserialize(f)
+
+    def serialize(self):
+        return self.merkleblock.serialize()
+
+    def __repr__(self):
+        return "msg_merkleblock(merkleblock=%s)" % (repr(self.merkleblock))
+
+
+class msg_filterload:
+    __slots__ = ("data", "nHashFuncs", "nTweak", "nFlags")
+    msgtype = b"filterload"
+
+    def __init__(self, data=b"00", nHashFuncs=0, nTweak=0, nFlags=0):
+        self.data = data
+        self.nHashFuncs = nHashFuncs
+        self.nTweak = nTweak
+        self.nFlags = nFlags
+
+    def deserialize(self, f):
+        self.data = deser_string(f)
+        self.nHashFuncs = int.from_bytes(f.read(4), "little")
+        self.nTweak = int.from_bytes(f.read(4), "little")
+        self.nFlags = int.from_bytes(f.read(1), "little")
+
+    def serialize(self):
+        r = b""
+        r += sere_string(self.data)
+        r += self.nHashFuncs.to_bytes(4, "little")
+        r += self.nTweak.to_bytes(4, "little")
+        r += self.nFlags.to_bytes(1, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_filterload(data={}, nHashFuncs={}, nTweak={}, nFlags={})".format(
+            self.data, self.nHashFuncs, self.nTweak, self.nFlags
+        )
+
+
+class msg_filteradd:
+    __slots__ = "data"
+    msgtype = b"filteradd"
+
+    def __init__(self, data):
+        self.data = data
+
+    def deserialize(self, f):
+        self.data = deser_string(f)
+
+    def serialize(self):
+        r = b""
+        r += sere_string(self.data)
+        return r
+
+    def __repr__(self):
+        return "msg_filteradd(data={})".format(self.data)
+
+
+class msg_filterclear:
+    __slots__ = ()
+    msgtype = b"filterclear"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_filterclear()"
+
+
+class msg_feefilter:
+    __slots__ = ("feerate",)
+    msgtype = b"feefilter"
+
+    def __init__(self, feerate=0):
+        self.feerate = feerate
+
+    def deserialize(self, f):
+        self.feerate = int.from_bytes(f.read(8), "little")
+
+    def serialize(self):
+        r = b""
+        r += self.feerate.to_bytes(8, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_feefilter(feerate=%08x)" % self.feerate
+
+
+class msg_sendcmpct:
+    __slots__ = ("announce", "version")
+    msgtype = b"sendcmpct"
+
+    def __init__(self, announce=False, version=1):
+        self.announce = announce
+        self.version = version
+
+    def deserialize(self, f):
+        self.announce = bool(int.from_bytes(f.read(1), "little"))
+        self.version = int.from_bytes(f.read(8), "little")
+
+    def serialize(self):
+        r = b""
+        r += int(self.announce).to_bytes(1, "little")
+        r += self.version.to_bytes(8, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_sendcmpct(announce=%s, version=%lu)" % (self.announce, self.version)
+
+
+class msg_cmpctblock:
+    __slots__ = ("header_and_shortids",)
+    msgtype = b"cmpctblock"
+
+    def __init__(self, header_and_shortids=None):
+        self.header_and_shortids = header_and_shortids
+
+    def deserialize(self, f):
+        self.header_and_shortids = P2PHeaderAndShortIDs()
+        self.header_and_shortids.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.header_and_shortids.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_cmpctblock(HeaderAndShortIDs=%s)" % repr(self.header_and_shortids)
+
+
+class msg_getblocktxn:
+    __slots__ = ("block_txn_request",)
+    msgtype = b"getblocktxn"
+
+    def __init__(self):
+        self.block_txn_request = None
+
+    def deserialize(self, f):
+        self.block_txn_request = BlockTransactionsRequest()
+        self.block_txn_request.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.block_txn_request.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_getblocktxn(block_txn_request=%s)" % (repr(self.block_txn_request))
+
+
+class msg_blocktxn:
+    __slots__ = ("block_transactions",)
+    msgtype = b"blocktxn"
+
+    def __init__(self):
+        self.block_transactions = BlockTransactions()
+
+    def deserialize(self, f):
+        self.block_transactions.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.block_transactions.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_blocktxn(block_transactions=%s)" % (repr(self.block_transactions))
+
+
+class msg_no_witness_blocktxn(msg_blocktxn):
+    __slots__ = ()
+
+    def serialize(self):
+        return self.block_transactions.serialize(with_witness=False)
+
+
+class msg_getcfilters:
+    __slots__ = ("filter_type", "start_height", "stop_hash")
+    msgtype = b"getcfilters"
+
+    def __init__(self, filter_type=None, start_height=None, stop_hash=None):
+        self.filter_type = filter_type
+        self.start_height = start_height
+        self.stop_hash = stop_hash
+
+    def deserialize(self, f):
+        self.filter_type = int.from_bytes(f.read(1), "little")
+        self.start_height = int.from_bytes(f.read(4), "little")
+        self.stop_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.filter_type.to_bytes(1, "little")
+        r += self.start_height.to_bytes(4, "little")
+        r += sere_uint256(self.stop_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_getcfilters(filter_type={:#x}, start_height={}, stop_hash={:x})".format(
+            self.filter_type, self.start_height, self.stop_hash
+        )
+
+
+class msg_cfilter:
+    __slots__ = ("filter_type", "block_hash", "filter_data")
+    msgtype = b"cfilter"
+
+    def __init__(self, filter_type=None, block_hash=None, filter_data=None):
+        self.filter_type = filter_type
+        self.block_hash = block_hash
+        self.filter_data = filter_data
+
+    def deserialize(self, f):
+        self.filter_type = int.from_bytes(f.read(1), "little")
+        self.block_hash = deser_uint256(f)
+        self.filter_data = deser_string(f)
+
+    def serialize(self):
+        r = b""
+        r += self.filter_type.to_bytes(1, "little")
+        r += sere_uint256(self.block_hash)
+        r += sere_string(self.filter_data)
+        return r
+
+    def __repr__(self):
+        return "msg_cfilter(filter_type={:#x}, block_hash={:x})".format(
+            self.filter_type, self.block_hash
+        )
+
+
+class msg_getcfheaders:
+    __slots__ = ("filter_type", "start_height", "stop_hash")
+    msgtype = b"getcfheaders"
+
+    def __init__(self, filter_type=None, start_height=None, stop_hash=None):
+        self.filter_type = filter_type
+        self.start_height = start_height
+        self.stop_hash = stop_hash
+
+    def deserialize(self, f):
+        self.filter_type = int.from_bytes(f.read(1), "little")
+        self.start_height = int.from_bytes(f.read(4), "little")
+        self.stop_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.filter_type.to_bytes(1, "little")
+        r += self.start_height.to_bytes(4, "little")
+        r += sere_uint256(self.stop_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_getcfheaders(filter_type={:#x}, start_height={}, stop_hash={:x})".format(
+            self.filter_type, self.start_height, self.stop_hash
+        )
+
+
+class msg_cfheaders:
+    __slots__ = ("filter_type", "stop_hash", "prev_header", "hashes")
+    msgtype = b"cfheaders"
+
+    def __init__(self, filter_type=None, stop_hash=None, prev_header=None, hashes=None):
+        self.filter_type = filter_type
+        self.stop_hash = stop_hash
+        self.prev_header = prev_header
+        self.hashes = hashes
+
+    def deserialize(self, f):
+        self.filter_type = int.from_bytes(f.read(1), "little")
+        self.stop_hash = deser_uint256(f)
+        self.prev_header = deser_uint256(f)
+        self.hashes = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += self.filter_type.to_bytes(1, "little")
+        r += sere_uint256(self.stop_hash)
+        r += sere_uint256(self.prev_header)
+        r += sere_uint256_vector(self.hashes)
+        return r
+
+    def __repr__(self):
+        return "msg_cfheaders(filter_type={:#x}, stop_hash={:x})".format(
+            self.filter_type, self.stop_hash
+        )
+
+
+class msg_getcfcheckpt:
+    __slots__ = ("filter_type", "stop_hash")
+    msgtype = b"getcfcheckpt"
+
+    def __init__(self, filter_type=None, stop_hash=None):
+        self.filter_type = filter_type
+        self.stop_hash = stop_hash
+
+    def deserialize(self, f):
+        self.filter_type = int.from_bytes(f.read(1), "little")
+        self.stop_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += self.filter_type.to_bytes(1, "little")
+        r += sere_uint256(self.stop_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_getcfcheckpt(filter_type={:#x}, stop_hash={:x})".format(
+            self.filter_type, self.stop_hash
+        )
+
+
+class msg_cfcheckpt:
+    __slots__ = ("filter_type", "stop_hash", "headers")
+    msgtype = b"cfcheckpt"
+
+    def __init__(self, filter_type=None, stop_hash=None, headers=None):
+        self.filter_type = filter_type
+        self.stop_hash = stop_hash
+        self.headers = headers
+
+    def deserialize(self, f):
+        self.filter_type = int.from_bytes(f.read(1), "little")
+        self.stop_hash = deser_uint256(f)
+        self.headers = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += self.filter_type.to_bytes(1, "little")
+        r += sere_uint256(self.stop_hash)
+        r += sere_uint256_vector(self.headers)
+        return r
+
+    def __repr__(self):
+        return "msg_cfcheckpt(filter_type={:#x}, stop_hash={:x})".format(
+            self.filter_type, self.stop_hash
+        )
+
+
+class msg_sendtxrcncl:
+    __slots__ = ("version", "salt")
+    msgtype = b"sendtxrcncl"
+
+    def __init__(self):
+        self.version = 0
+        self.salt = 0
+
+    def deserialize(self, f):
+        self.version = int.from_bytes(f.read(4), "little")
+        self.salt = int.from_bytes(f.read(8), "little")
+
+    def serialize(self):
+        r = b""
+        r += self.version.to_bytes(4, "little")
+        r += self.salt.to_bytes(8, "little")
+        return r
+
+    def __repr__(self):
+        return "msg_sendtxrcncl(version=%lu, salt=%lu)" % (self.version, self.salt)

--- a/tests/test_framework/netutil.py
+++ b/tests/test_framework/netutil.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# pylint: skip-file
+# Note: This file was copied from the Bitcoin Core project and does not follow Pylint rules.
+# It is excluded from Pylint checks to maintain compatibility with the original code.
+
+# Copyright (c) 2014-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Linux network utilities.
+
+Roughly based on https://web.archive.org/web/20190424172231/http://voorloopnul.com/blog/a-python-netstat-in-less-than-100-lines-of-code/ by Ricardo Pascal
+"""
+
+import sys
+import socket
+import struct
+import array
+import os
+
+# Easily unreachable address. Attempts to connect to it will stay within the machine.
+# Used to avoid non-loopback traffic or DNS queries.
+UNREACHABLE_PROXY_ARG = "-proxy=127.0.0.1:1"
+
+# STATE_ESTABLISHED = '01'
+# STATE_SYN_SENT  = '02'
+# STATE_SYN_RECV = '03'
+# STATE_FIN_WAIT1 = '04'
+# STATE_FIN_WAIT2 = '05'
+# STATE_TIME_WAIT = '06'
+# STATE_CLOSE = '07'
+# STATE_CLOSE_WAIT = '08'
+# STATE_LAST_ACK = '09'
+STATE_LISTEN = "0A"
+# STATE_CLOSING = '0B'
+
+# Address manager size constants as defined in addrman_impl.h
+ADDRMAN_NEW_BUCKET_COUNT = 1 << 10
+ADDRMAN_TRIED_BUCKET_COUNT = 1 << 8
+ADDRMAN_BUCKET_SIZE = 1 << 6
+
+
+def get_socket_inodes(pid):
+    """
+    Get list of socket inodes for process pid.
+    """
+    base = "/proc/%i/fd" % pid
+    inodes = []
+    for item in os.listdir(base):
+        try:
+            target = os.readlink(os.path.join(base, item))
+            if target.startswith("socket:"):
+                inodes.append(int(target[8:-1]))
+        except FileNotFoundError:
+            pass
+    return inodes
+
+
+def _remove_empty(arr):
+    return [x for x in arr if x != ""]
+
+
+def _convert_ip_port(addr_string):
+    host, port = addr_string.split(":")
+    # convert host from mangled-per-four-bytes form as used by kernel
+    host = bytes.fromhex(host)
+    host_out = ""
+    for x in range(0, len(host) // 4):
+        (val,) = struct.unpack("=I", host[x * 4 : (x + 1) * 4])
+        host_out += "%08x" % val
+
+    return host_out, int(port, 16)
+
+
+def netstat(typ="tcp"):
+    """
+    Function to return a list with status of tcp connections at linux systems
+    To get pid of all network process running on system, you must run this script
+    as superuser
+    """
+    with open("/proc/net/" + typ, "r", encoding="utf-8") as f:
+        content = f.readlines()
+        content.pop(0)
+    result = []
+    for line in content:
+        line_array = _remove_empty(
+            line.split(" ")
+        )  # Split lines and remove empty spaces.
+        tcp_id = line_array[0]
+        l_addr = _convert_ip_port(line_array[1])
+        r_addr = _convert_ip_port(line_array[2])
+        state = line_array[3]
+        inode = int(line_array[9])  # Need the inode to match with process pid.
+        nline = [tcp_id, l_addr, r_addr, state, inode]
+        result.append(nline)
+    return result
+
+
+def get_bind_addrs(pid):
+    """
+    Get bind addresses as (host,port) tuples for process pid.
+    """
+    inodes = get_socket_inodes(pid)
+    bind_addrs = []
+    for conn in netstat("tcp") + netstat("tcp6"):
+        if conn[3] == STATE_LISTEN and conn[4] in inodes:
+            bind_addrs.append(conn[1])
+    return bind_addrs
+
+
+# from: https://code.activestate.com/recipes/439093/
+def all_interfaces():
+    """
+    Return all interfaces that are up
+    """
+    import fcntl  # Linux only, so only import when required
+
+    is_64bits = sys.maxsize > 2**32
+    struct_size = 40 if is_64bits else 32
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    max_possible = 8  # initial value
+    while True:
+        num_bytes = max_possible * struct_size
+        names = array.array("B", b"\0" * num_bytes)
+        outbytes = struct.unpack(
+            "iL",
+            fcntl.ioctl(
+                s.fileno(),
+                0x8912,  # SIOCGIFCONF
+                struct.pack("iL", num_bytes, names.buffer_info()[0]),
+            ),
+        )[0]
+        if outbytes == num_bytes:
+            max_possible *= 2
+        else:
+            break
+    namestr = names.tobytes()
+    return [
+        (
+            namestr[i : i + 16].split(b"\0", 1)[0],
+            socket.inet_ntoa(namestr[i + 20 : i + 24]),
+        )
+        for i in range(0, outbytes, struct_size)
+    ]
+
+
+def addr_to_hex(addr):
+    """
+    Convert string IPv4 or IPv6 address to binary address as returned by
+    get_bind_addrs.
+    Very naive implementation that certainly doesn't work for all IPv6 variants.
+    """
+    if "." in addr:  # IPv4
+        addr = [int(x) for x in addr.split(".")]
+    elif ":" in addr:  # IPv6
+        sub = [[], []]  # prefix, suffix
+        x = 0
+        addr = addr.split(":")
+        for i, comp in enumerate(addr):
+            if comp == "":
+                if i == 0 or i == (
+                    len(addr) - 1
+                ):  # skip empty component at beginning or end
+                    continue
+                x += 1  # :: skips to suffix
+                assert x < 2
+            else:  # two bytes per component
+                val = int(comp, 16)
+                sub[x].append(val >> 8)
+                sub[x].append(val & 0xFF)
+        nullbytes = 16 - len(sub[0]) - len(sub[1])
+        assert (x == 0 and nullbytes == 0) or (x == 1 and nullbytes > 0)
+        addr = sub[0] + ([0] * nullbytes) + sub[1]
+    else:
+        raise ValueError("Could not parse address %s" % addr)
+    return bytearray(addr).hex()
+
+
+def format_addr_port(addr, port):
+    """Return either "addr:port" or "[addr]:port" based on whether addr looks like an IPv6 address."""
+    if ":" in addr:
+        return f"[{addr}]:{port}"
+    else:
+        return f"{addr}:{port}"
+
+
+def set_ephemeral_port_range(sock):
+    """On FreeBSD, set socket to use the high ephemeral port range (49152-65535).
+
+    FreeBSD's default ephemeral port range (10000-65535) overlaps with the test
+    framework's static port range starting at TEST_RUNNER_PORT_MIN (default=11000).
+    Using IP_PORTRANGE_HIGH avoids this overlap when binding to port 0 for dynamic
+    port allocation.
+    """
+    if sys.platform.startswith("freebsd"):
+        # Constants from FreeBSD's netinet/in.h and netinet6/in6.h
+        IP_PORTRANGE = 19
+        IPV6_PORTRANGE = 14
+        IP_PORTRANGE_HIGH = 1  # Same value for both IPv4 and IPv6
+        if sock.family == socket.AF_INET6:
+            sock.setsockopt(socket.IPPROTO_IPV6, IPV6_PORTRANGE, IP_PORTRANGE_HIGH)
+        else:
+            sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_HIGH)

--- a/tests/test_framework/node.py
+++ b/tests/test_framework/node.py
@@ -322,6 +322,17 @@ class Node:
 
         self.rpc.addnode(node.p2p_url, method, v2transport=v2transport)
 
+    def connect_node_by_url(self, url, method: str = "add", v2transport: bool = True):
+        """
+        Connect to a node by URL.
+        """
+        if not self.daemon.is_running:
+            raise ValueError(
+                f"Node '{self.variant}' must be running to connect to a node."
+            )
+
+        self.rpc.addnode(url, method, v2transport=v2transport)
+
     def get_connection_info(self) -> Tuple[str, Optional[str]]:
         """
         Get the user agent and host for the current node.

--- a/tests/test_framework/p2p.py
+++ b/tests/test_framework/p2p.py
@@ -1,0 +1,1183 @@
+#!/usr/bin/env python3
+# pylint: skip-file
+# Note: This file was copied from the Bitcoin Core project and does not follow Pylint rules.
+# It is excluded from Pylint checks to maintain compatibility with the original code.
+
+# Copyright (c) 2010 ArtForz -- public domain half-a-node
+# Copyright (c) 2012 Jeff Garzik
+# Copyright (c) 2010-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test objects for interacting with a bitcoind node over the p2p protocol.
+
+The P2PInterface objects interact with the bitcoind nodes under test using the
+node's p2p interface. They can be used to send messages to the node, and
+callbacks can be registered that execute when messages are received from the
+node. Messages are sent to/received from the node on an asyncio event loop.
+State held inside the objects must be guarded by the p2p_lock to avoid data
+races between the main testing thread and the event loop.
+
+P2PConnection: A low-level connection object to a node's P2P interface
+P2PInterface: A high-level interface object for communicating to a node over P2P
+P2PDataStore: A p2p interface class that keeps a store of transactions and blocks
+              and can respond correctly to getdata and getheaders messages
+P2PTxInvStore: A p2p interface class that inherits from P2PDataStore, and keeps
+              a count of how many times each txid has been announced."""
+
+import asyncio
+from collections import defaultdict
+import ipaddress
+from io import BytesIO
+import logging
+import platform
+import socket
+import struct
+import sys
+import threading
+
+from test_framework.messages import (
+    CBlockHeader,
+    MAX_HEADERS_RESULTS,
+    msg_addr,
+    msg_addrv2,
+    msg_block,
+    MSG_BLOCK,
+    msg_blocktxn,
+    msg_cfcheckpt,
+    msg_cfheaders,
+    msg_cfilter,
+    msg_cmpctblock,
+    msg_feefilter,
+    msg_filteradd,
+    msg_filterclear,
+    msg_filterload,
+    msg_getaddr,
+    msg_getblocks,
+    msg_getblocktxn,
+    msg_getcfcheckpt,
+    msg_getcfheaders,
+    msg_getcfilters,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_mempool,
+    msg_merkleblock,
+    msg_notfound,
+    msg_ping,
+    msg_pong,
+    msg_sendaddrv2,
+    msg_sendcmpct,
+    msg_sendheaders,
+    msg_sendtxrcncl,
+    msg_tx,
+    MSG_TX,
+    MSG_TYPE_MASK,
+    msg_verack,
+    msg_version,
+    MSG_WTX,
+    msg_wtxidrelay,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    MAGIC_BYTES,
+    sha256,
+)
+from test_framework.netutil import (
+    set_ephemeral_port_range,
+)
+from test_framework.util import (
+    wait_until_helper_internal,
+)
+from test_framework.v2_p2p import (
+    EncryptedP2PState,
+    MSGTYPE_TO_SHORTID,
+    SHORTID,
+)
+from test_framework.util import Utility
+
+logger = logging.getLogger("TestFramework.p2p")
+
+# The minimum P2P version that this test framework supports
+MIN_P2P_VERSION_SUPPORTED = 60001
+# The P2P version that this test framework implements and sends in its `version` message
+# Version 70016 supports wtxid relay
+P2P_VERSION = 70016
+# The services that this test framework offers in its `version` message
+P2P_SERVICES = NODE_NETWORK | NODE_WITNESS
+# The P2P user agent string that this test framework sends in its `version` message
+P2P_SUBVERSION = "/python-p2p-tester:0.0.3/"
+# Value for relay that this test framework sends in its `version` message
+P2P_VERSION_RELAY = 1
+# Delay after receiving a tx inv before requesting transactions from non-preferred peers, in seconds
+NONPREF_PEER_TX_DELAY = 2
+# Delay for requesting transactions via txids if we have wtxid-relaying peers, in seconds
+TXID_RELAY_DELAY = 2
+# Delay for requesting transactions if the peer has MAX_PEER_TX_REQUEST_IN_FLIGHT or more requests
+OVERLOADED_PEER_TX_DELAY = 2
+# How long to wait before downloading a transaction from an additional peer
+GETDATA_TX_INTERVAL = 60
+
+MESSAGEMAP = {
+    b"addr": msg_addr,
+    b"addrv2": msg_addrv2,
+    b"block": msg_block,
+    b"blocktxn": msg_blocktxn,
+    b"cfcheckpt": msg_cfcheckpt,
+    b"cfheaders": msg_cfheaders,
+    b"cfilter": msg_cfilter,
+    b"cmpctblock": msg_cmpctblock,
+    b"feefilter": msg_feefilter,
+    b"filteradd": msg_filteradd,
+    b"filterclear": msg_filterclear,
+    b"filterload": msg_filterload,
+    b"getaddr": msg_getaddr,
+    b"getblocks": msg_getblocks,
+    b"getblocktxn": msg_getblocktxn,
+    b"getcfcheckpt": msg_getcfcheckpt,
+    b"getcfheaders": msg_getcfheaders,
+    b"getcfilters": msg_getcfilters,
+    b"getdata": msg_getdata,
+    b"getheaders": msg_getheaders,
+    b"headers": msg_headers,
+    b"inv": msg_inv,
+    b"mempool": msg_mempool,
+    b"merkleblock": msg_merkleblock,
+    b"notfound": msg_notfound,
+    b"ping": msg_ping,
+    b"pong": msg_pong,
+    b"sendaddrv2": msg_sendaddrv2,
+    b"sendcmpct": msg_sendcmpct,
+    b"sendheaders": msg_sendheaders,
+    b"sendtxrcncl": msg_sendtxrcncl,
+    b"tx": msg_tx,
+    b"verack": msg_verack,
+    b"version": msg_version,
+    b"wtxidrelay": msg_wtxidrelay,
+}
+
+
+class P2PConnection(asyncio.Protocol):
+    """A low-level connection object to a node's P2P interface.
+
+    This class is responsible for:
+
+    - opening and closing the TCP connection to the node
+    - reading bytes from and writing bytes to the socket
+    - deserializing and serializing the P2P message header
+    - logging messages as they are sent and received
+
+    This class contains no logic for handing the P2P message payloads. It must be
+    sub-classed and the on_message() callback overridden."""
+
+    def __init__(self):
+        # The underlying transport of the connection.
+        # Should only call methods on this from the NetworkThread, c.f. call_soon_threadsafe
+        self._transport = None
+        # This lock is acquired before sending messages over the socket. There's an implied lock
+        # order and p2p_lock must not be acquired after _send_lock as it could result in deadlocks.
+        self._send_lock = threading.Lock()
+        self.v2_state = None  # EncryptedP2PState object needed for v2 p2p connections
+        self.reconnect = False  # set if reconnection needs to happen
+        # Initialize attributes that are set in peer_connect_helper
+        self.timeout_factor = 0
+        self.dstaddr = ""
+        self.dstport = 0
+        self.on_connection_send_msg = None
+        self.recvbuf = b""
+        self.magic_bytes = b""
+        self.p2p_connected_to_node = False
+
+    @property
+    def is_connected(self):
+        return self._transport is not None
+
+    @property
+    def supports_v2_p2p(self):
+        return self.v2_state is not None
+
+    def peer_connect_helper(self, dstaddr, dstport, net, timeout_factor):
+        assert not self.is_connected
+        self.timeout_factor = timeout_factor
+        self.dstaddr = dstaddr
+        self.dstport = dstport
+        # The initial message to send after the connection was made:
+        self.on_connection_send_msg = None
+        self.recvbuf = b""
+        self.magic_bytes = MAGIC_BYTES[net]
+        self.p2p_connected_to_node = dstport != 0
+
+    def peer_connect(self, dstaddr, dstport, *, net, timeout_factor, supports_v2_p2p):
+        self.peer_connect_helper(dstaddr, dstport, net, timeout_factor)
+        if supports_v2_p2p:
+            self.v2_state = EncryptedP2PState(initiating=True, net=net)
+
+        loop = NetworkThread.network_event_loop
+        logger.debug("Connecting to Bitcoin Node: %s:%d", self.dstaddr, self.dstport)
+        coroutine = loop.create_connection(
+            lambda: self, host=self.dstaddr, port=self.dstport
+        )
+        return lambda: loop.call_soon_threadsafe(loop.create_task, coroutine)
+
+    def peer_accept_connection(
+        self,
+        connect_id,
+        connect_cb=lambda: None,
+        *,
+        net,
+        timeout_factor,
+        supports_v2_p2p,
+        reconnect,
+    ):
+        self.peer_connect_helper("0", 0, net, timeout_factor)
+        self.reconnect = reconnect
+        if supports_v2_p2p:
+            self.v2_state = EncryptedP2PState(initiating=False, net=net)
+
+        logger.debug("Listening for Bitcoin Node with id: %s", connect_id)
+        return lambda: NetworkThread.listen(self, connect_cb, idx=connect_id)
+
+    def peer_disconnect(self):
+        # Connection could have already been closed by other end.
+        NetworkThread.network_event_loop.call_soon_threadsafe(
+            lambda: self._transport and self._transport.abort()
+        )
+
+    # Connection and disconnection methods
+
+    def connection_made(self, transport):
+        """asyncio callback when a connection is opened."""
+        assert not self._transport
+        info = transport.get_extra_info("socket")
+        us = info.getsockname()
+        them = info.getpeername()
+        logger.debug("Connected: us=%s:%s, them=%s:%s", us[0], us[1], them[0], them[1])
+        self.dstaddr = them[0]
+        self.dstport = them[1]
+        self._transport = transport
+        # in an inbound connection to the TestNode with P2PConnection as the initiator,
+        # [TestNode <---- P2PConnection] send the initial handshake immediately
+        if (
+            self.supports_v2_p2p
+            and self.v2_state.initiating
+            and not self.v2_state.tried_v2_handshake
+        ):
+            send_handshake_bytes = self.v2_state.initiate_v2_handshake()
+            logger.debug(
+                "sending %d bytes of garbage data", len(self.v2_state.sent_garbage)
+            )
+            self.send_raw_message(send_handshake_bytes)
+        # for v1 outbound connections, send version message immediately after opening
+        # (for v2 outbound connections, send it after the initial v2 handshake)
+        if self.p2p_connected_to_node and not self.supports_v2_p2p:
+            self.send_version()
+        self.on_open()
+
+    def connection_lost(self, exc):
+        """asyncio callback when a connection is closed."""
+        # don't display warning if reconnection needs to be attempted using v1 P2P
+        if exc and not self.reconnect:
+            logger.warning(
+                "Connection lost to %s:%d due to %s", self.dstaddr, self.dstport, exc
+            )
+        else:
+            logger.debug("Closed connection to: %s:%d", self.dstaddr, self.dstport)
+        self._transport = None
+        self.recvbuf = b""
+        self.on_close()
+
+    # v2 handshake method
+    def _on_data_v2_handshake(self):
+        """v2 handshake performed before P2P messages are exchanged (see BIP324). P2PConnection is
+        the initiator (in inbound connections to TestNode) and the responder (in outbound
+        connections from TestNode). Performed by:
+            * initiator using `initiate_v2_handshake()`, `complete_handshake()` and
+            `authenticate_handshake()`
+            * responder using `respond_v2_handshake()`, `complete_handshake()` and
+            `authenticate_handshake()`
+
+        `initiate_v2_handshake()` is immediately done by the initiator when the connection is
+        established in `connection_made()`. The rest of the initial v2 handshake functions are
+        handled here.
+        """
+        if not self.v2_state.peer:
+            if not self.v2_state.initiating and not self.v2_state.sent_garbage:
+                # if the responder hasn't sent garbage yet, the responder is still reading ellswift
+                # bytes reads ellswift bytes till the first mismatch from 12 bytes V1_PREFIX
+                length, send_handshake_bytes = self.v2_state.respond_v2_handshake(
+                    BytesIO(self.recvbuf)
+                )
+                self.recvbuf = self.recvbuf[length:]
+                if send_handshake_bytes == -1:
+                    self.v2_state = None
+                    return
+                elif send_handshake_bytes:
+                    logger.debug(
+                        "sending %d bytes of garbage data",
+                        len(self.v2_state.sent_garbage),
+                    )
+                    self.send_raw_message(send_handshake_bytes)
+                elif send_handshake_bytes == b"":
+                    return  # only after send_handshake_bytes are sent can `complete_handshake()`
+                    # be done
+
+            # `complete_handshake()` reads the remaining ellswift bytes from recvbuf
+            # and sends response after deriving shared ECDH secret using received ellswift bytes
+            length, response = self.v2_state.complete_handshake(BytesIO(self.recvbuf))
+            self.recvbuf = self.recvbuf[length:]
+            if response:
+                self.send_raw_message(response)
+            else:
+                return  # only after response is sent can `authenticate_handshake()` be done
+
+        # `self.v2_state.peer` is instantiated only after shared ECDH secret/BIP324 derived keys
+        # and ciphers is derived in `complete_handshake()`.
+        # so `authenticate_handshake()` which uses the BIP324 derived ciphers gets called after
+        # `complete_handshake()`.
+        assert self.v2_state.peer
+        length, is_mac_auth = self.v2_state.authenticate_handshake(self.recvbuf)
+        if not is_mac_auth:
+            raise ValueError("invalid v2 mac tag in handshake authentication")
+        self.recvbuf = self.recvbuf[length:]
+        if self.v2_state.tried_v2_handshake:
+            # for v2 outbound connections, send version message immediately after v2 handshake
+            if self.p2p_connected_to_node:
+                self.send_version()
+            # process post-v2-handshake data immediately, if available
+            if len(self.recvbuf) > 0:
+                self._on_data()
+
+    # Socket read methods
+
+    def data_received(self, t):  # pylint: disable=arguments-renamed
+        """asyncio callback when data is read from the socket."""
+        if len(t) > 0:
+            self.recvbuf += t
+            if self.supports_v2_p2p and not self.v2_state.tried_v2_handshake:
+                self._on_data_v2_handshake()
+            else:
+                self._on_data()
+
+    def _on_data(self):
+        """Try to read P2P messages from the recv buffer.
+
+        This method reads data from the buffer in a loop. It deserializes,
+        parses and verifies the P2P header, then passes the P2P payload to
+        the on_message callback for processing."""
+        try:
+            while True:
+                if self.supports_v2_p2p:
+                    # v2 P2P messages are read
+                    msglen, msg = self.v2_state.v2_receive_packet(self.recvbuf)
+                    if msglen == -1:
+                        raise ValueError("invalid v2 mac tag " + repr(self.recvbuf))
+                    elif msglen == 0:  # need to receive more bytes in recvbuf
+                        return
+                    self.recvbuf = self.recvbuf[msglen:]
+
+                    if msg is None:  # ignore decoy messages
+                        return
+                    assert msg  # application layer messages (which aren't decoy messages) are
+                    # non-empty
+                    shortid = msg[0]  # 1-byte short message type ID
+                    if shortid == 0:
+                        # next 12 bytes are interpreted as ASCII message type if shortid is b'\x00'
+                        if len(msg) < 13:
+                            raise IndexError(
+                                "msg needs minimum required length of 13 bytes"
+                            )
+                        msgtype = msg[1:13].rstrip(b"\x00")
+                        msg = msg[13:]  # msg is set to be payload
+                    else:
+                        # a 1-byte short message type ID
+                        msgtype = SHORTID.get(shortid, f"unknown-{shortid}")
+                        msg = msg[1:]
+                else:
+                    # v1 P2P messages are read
+                    if len(self.recvbuf) < 4:
+                        return
+                    if self.recvbuf[:4] != self.magic_bytes:
+                        raise ValueError(
+                            "magic bytes mismatch: {} != {}".format(
+                                repr(self.magic_bytes), repr(self.recvbuf)
+                            )
+                        )
+                    if len(self.recvbuf) < 4 + 12 + 4 + 4:
+                        return
+                    msgtype = self.recvbuf[4 : 4 + 12].split(b"\x00", 1)[0]
+                    msglen = struct.unpack("<i", self.recvbuf[4 + 12 : 4 + 12 + 4])[0]
+                    checksum = self.recvbuf[4 + 12 + 4 : 4 + 12 + 4 + 4]
+                    if len(self.recvbuf) < 4 + 12 + 4 + 4 + msglen:
+                        return
+                    msg = self.recvbuf[4 + 12 + 4 + 4 : 4 + 12 + 4 + 4 + msglen]
+                    th = sha256(msg)
+                    h = sha256(th)
+                    if checksum != h[:4]:
+                        raise ValueError("got bad checksum " + repr(self.recvbuf))
+                    self.recvbuf = self.recvbuf[4 + 12 + 4 + 4 + msglen :]
+                if msgtype not in MESSAGEMAP:
+                    raise ValueError(
+                        "Received unknown msgtype from %s:%d: '%s' %s"
+                        % (self.dstaddr, self.dstport, msgtype, repr(msg))
+                    )
+                f = BytesIO(msg)
+                t = MESSAGEMAP[msgtype]()
+                t.deserialize(f)
+                self._log_message("receive", t)
+                self.on_message(t)
+        except Exception as e:
+            if not self.reconnect:
+                logger.exception("Error reading message: %s", repr(e))
+            raise
+
+    def on_message(self, message):
+        """Callback for processing a P2P payload. Must be overridden by derived class."""
+        raise NotImplementedError
+
+    # Socket write methods
+
+    def send_without_ping(self, message, is_decoy=False):
+        """Send a P2P message over the socket.
+
+        This method takes a P2P payload, builds the P2P header and adds
+        the message to the send buffer to be sent over the socket.
+
+        When a message does not lead to a disconnect, send_and_ping is usually
+        preferred to send a message. This can help to reduce intermittent test
+        failures due to a missing sync. Also, it includes a call to
+        sync_with_ping, allowing for concise test code.
+        """
+        with self._send_lock:
+            tmsg = self.build_message(message, is_decoy)
+            self._log_message("send", message)
+            return self.send_raw_message(tmsg)
+
+    def send_raw_message(self, raw_message_bytes):
+        if not self.is_connected:
+            raise IOError("Not connected")
+
+        def maybe_write():
+            if not self._transport:
+                return
+            if self._transport.is_closing():
+                return
+            self._transport.write(raw_message_bytes)
+
+        NetworkThread.network_event_loop.call_soon_threadsafe(maybe_write)
+
+    def send_version(self):
+        """Send version message (to be overridden by subclasses)."""
+
+    def on_open(self):
+        """Callback when connection is opened (to be overridden by subclasses)."""
+
+    def on_close(self):
+        """Callback when connection is closed (to be overridden by subclasses)."""
+
+    # Class utility methods
+
+    def build_message(self, message, is_decoy=False):
+        """Build a serialized P2P message"""
+        msgtype = message.msgtype
+        data = message.serialize()
+        if self.supports_v2_p2p:
+            if msgtype in SHORTID.values():
+                tmsg = MSGTYPE_TO_SHORTID.get(msgtype).to_bytes(1, "big")
+            else:
+                tmsg = b"\x00"
+                tmsg += msgtype
+                tmsg += b"\x00" * (12 - len(msgtype))
+            tmsg += data
+            return self.v2_state.v2_enc_packet(tmsg, ignore=is_decoy)
+        else:
+            tmsg = self.magic_bytes
+            tmsg += msgtype
+            tmsg += b"\x00" * (12 - len(msgtype))
+            tmsg += len(data).to_bytes(4, "little")
+            th = sha256(data)
+            h = sha256(th)
+            tmsg += h[:4]
+            tmsg += data
+            return tmsg
+
+    def _log_message(self, direction, msg):
+        """Logs a message being sent or received over the connection."""
+        if direction == "send":
+            log_message = "Send message to "
+        elif direction == "receive":
+            log_message = "Received message from "
+        else:
+            log_message = ""
+        log_message += "%s:%d: %s" % (self.dstaddr, self.dstport, repr(msg)[:500])
+        if len(log_message) > 500:
+            log_message += "... (msg truncated)"
+        logger.debug(log_message)
+
+
+class P2PInterface(P2PConnection):
+    """A high-level P2P interface class for communicating with a Bitcoin node.
+
+    This class provides high-level callbacks for processing P2P message
+    payloads, as well as convenience methods for interacting with the
+    node over P2P.
+
+    Individual testcases should subclass this and override the on_* methods
+    if they want to alter message handling behaviour."""
+
+    def __init__(self, support_addrv2=True, wtxidrelay=True):
+        super().__init__()
+
+        # Track number of messages of each type received.
+        # Should be read-only in a test.
+        self.message_count = defaultdict(int)
+
+        # Track the most recent message of each type.
+        # To wait for a message to be received, pop that message from
+        # this and use self.wait_until.
+        self.last_message = {}
+
+        # A count of the number of ping messages we've sent to the node
+        self.ping_counter = 1
+
+        # The network services received from the peer
+        self.nServices = 0
+
+        self.support_addrv2 = support_addrv2
+
+        # If the peer supports wtxid-relay
+        self.wtxidrelay = wtxidrelay
+
+        # Relay setting from the peer
+        self.relay = False
+
+    def peer_connect_send_version(self, services):
+        # Send a version msg
+        vt = msg_version()
+        vt.nVersion = P2P_VERSION
+        vt.strSubVer = P2P_SUBVERSION
+        vt.relay = P2P_VERSION_RELAY
+        vt.nServices = services
+        vt.addrTo.ip = self.dstaddr
+        vt.addrTo.port = self.dstport
+        vt.addrFrom.ip = "0.0.0.0"
+        vt.addrFrom.port = 0
+        self.on_connection_send_msg = vt  # Will be sent in connection_made callback
+
+    def peer_connect(
+        self, *, services=P2P_SERVICES, send_version, **kwargs
+    ):  # pylint: disable=arguments-differ
+        create_conn = super().peer_connect(**kwargs)
+
+        if send_version:
+            self.peer_connect_send_version(services)
+
+        return create_conn
+
+    def peer_accept_connection(self, *args, services=P2P_SERVICES, **kwargs):
+        create_conn = super().peer_accept_connection(*args, **kwargs)
+        self.peer_connect_send_version(services)
+
+        return create_conn
+
+    # Message receiving methods
+
+    def on_message(self, message):
+        """Receive message and dispatch message to appropriate callback.
+
+        We keep a count of how many of each message type has been received
+        and the most recent message of each type."""
+        with p2p_lock:
+            try:
+                msgtype = message.msgtype.decode("ascii")
+                self.message_count[msgtype] += 1
+                self.last_message[msgtype] = message
+                getattr(self, "on_" + msgtype)(message)
+            except Exception:
+                print("ERROR delivering %s (%s)" % (repr(message), sys.exc_info()[0]))
+                raise
+
+    # Callback methods. Can be overridden by subclasses in individual test
+    # cases to provide custom message handling behaviour.
+
+    def on_open(self):
+        pass
+
+    def on_close(self):
+        pass
+
+    def on_addr(self, message):
+        pass
+
+    def on_addrv2(self, message):
+        pass
+
+    def on_block(self, message):
+        pass
+
+    def on_blocktxn(self, message):
+        pass
+
+    def on_cfcheckpt(self, message):
+        pass
+
+    def on_cfheaders(self, message):
+        pass
+
+    def on_cfilter(self, message):
+        pass
+
+    def on_cmpctblock(self, message):
+        pass
+
+    def on_feefilter(self, message):
+        pass
+
+    def on_filteradd(self, message):
+        pass
+
+    def on_filterclear(self, message):
+        pass
+
+    def on_filterload(self, message):
+        pass
+
+    def on_getaddr(self, message):
+        pass
+
+    def on_getblocks(self, message):
+        pass
+
+    def on_getblocktxn(self, message):
+        pass
+
+    def on_getdata(self, message):
+        pass
+
+    def on_getheaders(self, message):
+        pass
+
+    def on_headers(self, message):
+        pass
+
+    def on_mempool(self, message):
+        pass
+
+    def on_merkleblock(self, message):
+        pass
+
+    def on_notfound(self, message):
+        pass
+
+    def on_pong(self, message):
+        pass
+
+    def on_sendaddrv2(self, message):
+        pass
+
+    def on_sendcmpct(self, message):
+        pass
+
+    def on_sendheaders(self, message):
+        pass
+
+    def on_sendtxrcncl(self, message):
+        pass
+
+    def on_tx(self, message):
+        pass
+
+    def on_wtxidrelay(self, message):
+        pass
+
+    def on_inv(self, message):
+        want = msg_getdata()
+        for i in message.inv:
+            if i.type != 0:
+                want.inv.append(i)
+        if len(want.inv):
+            self.send_without_ping(want)
+
+    def on_ping(self, message):
+        self.send_without_ping(msg_pong(message.nonce))
+
+    def on_verack(self, message):
+        pass
+
+    def on_version(self, message):
+        assert (
+            message.nVersion >= MIN_P2P_VERSION_SUPPORTED
+        ), "Version {} received. Test framework only supports versions greater than {}".format(
+            message.nVersion, MIN_P2P_VERSION_SUPPORTED
+        )
+        # for inbound connections, reply to version with own version message
+        # (could be due to v1 reconnect after a failed v2 handshake)
+        if not self.p2p_connected_to_node:
+            self.send_version()
+            self.reconnect = False
+        if message.nVersion >= 70016 and self.wtxidrelay:
+            self.send_without_ping(msg_wtxidrelay())
+        if self.support_addrv2:
+            self.send_without_ping(msg_sendaddrv2())
+        self.send_without_ping(msg_verack())
+        self.nServices = message.nServices
+        self.relay = message.relay
+        if self.p2p_connected_to_node:
+            self.send_without_ping(msg_getaddr())
+
+    # Connection helper methods
+
+    def wait_until(
+        self, test_function_in, *, timeout=60, check_connected=True, check_interval=0.05
+    ):
+        def test_function():
+            if check_connected:
+                assert self.is_connected
+            return test_function_in()
+
+        wait_until_helper_internal(
+            test_function,
+            timeout=timeout,
+            lock=p2p_lock,
+            timeout_factor=self.timeout_factor,
+            check_interval=check_interval,
+        )
+
+    def wait_for_connect(self, *, timeout=60):
+        test_function = lambda: self.is_connected
+        self.wait_until(test_function, timeout=timeout, check_connected=False)
+
+    def wait_for_disconnect(self, *, timeout=60):
+        test_function = lambda: not self.is_connected
+        self.wait_until(test_function, timeout=timeout, check_connected=False)
+
+    def wait_for_reconnect(self, *, timeout=60):
+        def test_function():
+            return (
+                self.is_connected
+                and self.last_message.get("version")
+                and not self.supports_v2_p2p
+            )
+
+        self.wait_until(test_function, timeout=timeout, check_connected=False)
+
+    # Message receiving helper methods
+
+    def wait_for_tx(self, txid, *, timeout=60):
+        def test_function():
+            if not self.last_message.get("tx"):
+                return False
+            return self.last_message["tx"].tx.txid_hex == txid
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_block(self, blockhash, *, timeout=60):
+        def test_function():
+            return (
+                self.last_message.get("block")
+                and self.last_message["block"].block.hash_int == blockhash
+            )
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_header(self, blockhash, *, timeout=60):
+        def test_function():
+            last_headers = self.last_message.get("headers")
+            if not last_headers:
+                return False
+            return last_headers.headers[0].hash_int == int(blockhash, 16)
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_merkleblock(self, blockhash, *, timeout=60):
+        def test_function():
+            last_filtered_block = self.last_message.get("merkleblock")
+            if not last_filtered_block:
+                return False
+            return last_filtered_block.merkleblock.header.hash_int == int(blockhash, 16)
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_getdata(self, hash_list, *, timeout=60):
+        """Waits for a getdata message.
+
+        The object hashes in the inventory vector must match the provided hash_list."""
+
+        def test_function():
+            last_data = self.last_message.get("getdata")
+            if not last_data:
+                return False
+            return [x.hash for x in last_data.inv] == hash_list
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_getheaders(self, block_hash=None, *, timeout=60):
+        """Waits for a getheaders message containing a specific block hash.
+
+        If no block hash is provided, checks whether any getheaders message has been received by
+        the node.
+        """
+
+        def test_function():
+            last_getheaders = self.last_message.pop("getheaders", None)
+            if block_hash is None:
+                return last_getheaders
+            if last_getheaders is None:
+                return False
+            return block_hash == last_getheaders.locator.vHave[0]
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_inv(self, expected_inv, *, timeout=60):
+        """
+        Waits for an INV message and checks that the first inv object in the message was as expected
+        """
+        if len(expected_inv) > 1:
+            raise NotImplementedError(
+                "wait_for_inv() will only verify the first inv object"
+            )
+
+        def test_function():
+            return (
+                self.last_message.get("inv")
+                and self.last_message["inv"].inv[0].type == expected_inv[0].type
+                and self.last_message["inv"].inv[0].hash == expected_inv[0].hash
+            )
+
+        self.wait_until(test_function, timeout=timeout)
+
+    def wait_for_verack(self, *, timeout=60):
+        def test_function():
+            return "verack" in self.last_message
+
+        self.wait_until(test_function, timeout=timeout)
+
+    # Message sending helper functions
+
+    def send_version(self):
+        if self.on_connection_send_msg:
+            self.send_without_ping(self.on_connection_send_msg)
+            self.on_connection_send_msg = None  # Never used again
+
+    def send_and_ping(self, message, *, timeout=60):
+        self.send_without_ping(message)
+        self.sync_with_ping(timeout=timeout)
+
+    def sync_with_ping(self, *, timeout=60):
+        """Ensure ProcessMessages and SendMessages is called on this connection"""
+        # Sending two pings back-to-back, requires that the node calls
+        # `ProcessMessage` twice, and thus ensures `SendMessages` must have
+        # been called at least once
+        self.send_without_ping(msg_ping(nonce=0))
+        self.send_without_ping(msg_ping(nonce=self.ping_counter))
+
+        def test_function():
+            return (
+                self.last_message.get("pong")
+                and self.last_message["pong"].nonce == self.ping_counter
+            )
+
+        self.wait_until(test_function, timeout=timeout)
+        self.ping_counter += 1
+
+
+# One lock for synchronizing all data access between the network event loop (see
+# NetworkThread below) and the thread running the test logic.  For simplicity,
+# P2PConnection acquires this lock whenever delivering a message to a P2PInterface.
+# This lock should be acquired in the thread running the test logic to synchronize
+# access to any data shared with the P2PInterface or P2PConnection.
+p2p_lock = threading.Lock()
+
+
+class NetworkThread(threading.Thread):
+    network_event_loop = None
+
+    def __init__(self):
+        super().__init__(name="NetworkThread")
+        # There is only one event loop and no more than one thread must be created
+        assert not self.network_event_loop
+
+        NetworkThread.listeners = {}
+        NetworkThread.protos = {}
+        if platform.system() == "Windows":
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        NetworkThread.network_event_loop = asyncio.new_event_loop()
+
+    def run(self):
+        """Start the network thread."""
+        self.network_event_loop.run_forever()
+
+    def close(self, *, timeout):
+        """Close the connections and network event loop."""
+        self.network_event_loop.call_soon_threadsafe(self.network_event_loop.stop)
+        wait_until_helper_internal(
+            lambda: not self.network_event_loop.is_running(), timeout=timeout
+        )
+        self.network_event_loop.close()
+        self.join(timeout)
+        # Safe to remove event loop.
+        NetworkThread.network_event_loop = None
+
+    @classmethod
+    def listen(
+        cls, p2p, callback, port=None, addr=None, idx=None
+    ):  # pylint: disable=unused-argument
+        """Ensure a listening server is running on the given port, and run the
+        protocol specified by `p2p` on the next connection to it. Once ready
+        for connections, call `callback`."""
+
+        if port is None:
+            port = Utility.get_random_port()
+        if addr is None:
+            addr = "127.0.0.1"
+
+        def exception_handler(loop, context):
+            if not p2p.reconnect:
+                loop.default_exception_handler(context)
+
+        cls.network_event_loop.set_exception_handler(exception_handler)
+        coroutine = cls.create_listen_server(addr, port, callback, p2p)
+        cls.network_event_loop.call_soon_threadsafe(
+            cls.network_event_loop.create_task, coroutine
+        )
+
+    @classmethod
+    async def create_listen_server(cls, addr, port, callback, proto):
+        def peer_protocol():
+            """Returns a function that does the protocol handling for a new
+            connection. To allow different connections to have different
+            behaviors, the protocol function is first put in the cls.protos
+            dict. When the connection is made, the function removes the
+            protocol function from that dict, and returns it so the event loop
+            can start executing it."""
+            response = cls.protos.get((addr, port))
+            # remove protocol function from dict only when reconnection doesn't need to
+            # happen/already happened
+            if not proto.reconnect:
+                cls.protos[(addr, port)] = None
+            return response
+
+        if port == 0 or (addr, port) not in cls.listeners:
+            # When creating a listener on a given (addr, port) we only need to
+            # do it once. If we want different behaviors for different
+            # connections, we can accomplish this by providing different
+            # `proto` functions
+
+            if port == 0:
+                # Manually create the socket in order to set the range to be
+                # used for the port before the bind() call.
+                if ipaddress.ip_address(addr).version == 4:
+                    address_family = socket.AF_INET
+                else:
+                    address_family = socket.AF_INET6
+                s = socket.socket(address_family)
+                set_ephemeral_port_range(s)
+                s.bind((addr, 0))
+                s.listen()
+                listener = await cls.network_event_loop.create_server(
+                    peer_protocol, sock=s
+                )
+                port = listener.sockets[0].getsockname()[1]
+            else:
+                listener = await cls.network_event_loop.create_server(
+                    peer_protocol, addr, port
+                )
+
+            logger.debug("Listening server on %s:%d should be started", addr, port)
+            cls.listeners[(addr, port)] = listener
+
+        cls.protos[(addr, port)] = proto
+        callback(addr, port)
+
+
+class P2PDataStore(P2PInterface):
+    """A P2P data store class.
+
+    Keeps a block and transaction store and responds correctly to getdata and getheaders requests.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # store of blocks. key is block hash, value is a CBlock object
+        self.block_store = {}
+        self.last_block_hash = ""
+        # store of txs. key is txid, value is a CTransaction object
+        self.tx_store = {}
+        self.getdata_requests = []
+
+    def on_getdata(self, message):
+        """Check for the tx/block in our stores and if found, reply with MSG_TX or MSG_BLOCK."""
+        for inv in message.inv:
+            self.getdata_requests.append(inv.hash)
+            invtype = inv.type & MSG_TYPE_MASK
+            if (
+                invtype == MSG_TX or invtype == MSG_WTX
+            ) and inv.hash in self.tx_store.keys():
+                self.send_without_ping(msg_tx(self.tx_store[inv.hash]))
+            elif invtype == MSG_BLOCK and inv.hash in self.block_store.keys():
+                self.send_without_ping(msg_block(self.block_store[inv.hash]))
+            else:
+                logger.debug("getdata message type %s received.", hex(inv.type))
+
+    def on_getheaders(self, message):
+        """
+        Search back through our block store for the locator, and reply with a headers message if
+        found.
+        """
+
+        locator, hash_stop = message.locator, message.hashstop
+
+        # Assume that the most recent block added is the tip
+        if not self.block_store:
+            return
+
+        headers_list = [self.block_store[self.last_block_hash]]
+        while headers_list[-1].hash_int not in locator.vHave:
+            # Walk back through the block store, adding headers to headers_list
+            # as we go.
+            prev_block_hash = headers_list[-1].hashPrevBlock
+            if prev_block_hash in self.block_store:
+                prev_block_header = CBlockHeader(self.block_store[prev_block_hash])
+                headers_list.append(prev_block_header)
+                if prev_block_header.hash_int == hash_stop:
+                    # if this is the hashstop header, stop here
+                    break
+            else:
+                logger.debug(
+                    "block hash %s not found in block store", hex(prev_block_hash)
+                )
+                break
+
+        # Truncate the list if there are too many headers
+        headers_list = headers_list[: -MAX_HEADERS_RESULTS - 1 : -1]
+        response = msg_headers(headers_list)
+
+        if response is not None:
+            self.send_without_ping(response)
+
+    def send_blocks_and_test(
+        self,
+        blocks,
+        node,
+        *,
+        success=True,
+        force_send=False,
+        reject_reason=None,
+        expect_disconnect=False,
+        timeout=60,
+        is_decoy=False,
+    ):
+        """Send blocks to test node and test whether the tip advances.
+
+        - add all blocks to our block_store
+        - send a headers message for the final block
+        - the on_getheaders handler will ensure that any getheaders are responded to
+        - if force_send is False: wait for getdata for each of the blocks. The on_getdata handler
+          will ensure that any getdata messages are responded to. Otherwise send the full block
+          unsolicited
+        - if success is True: assert that the node's tip is the last block in blocks at the end of
+          the operation.
+        - if success is False: assert that the node's tip isn't the last block in blocks at the end
+          of the operation
+        - if reject_reason is set: assert that the correct reject message is logged"""
+
+        with p2p_lock:
+            for block in blocks:
+                self.block_store[block.hash_int] = block
+                self.last_block_hash = block.hash_int
+
+        reject_reason = [reject_reason] if reject_reason else []
+        with node.assert_debug_log(expected_msgs=reject_reason):
+            if (
+                is_decoy
+            ):  # since decoy messages are ignored by the recipient - no need to wait for response
+                force_send = True
+            if force_send:
+                for b in blocks:
+                    self.send_without_ping(msg_block(block=b), is_decoy)
+            else:
+                self.send_without_ping(
+                    msg_headers([CBlockHeader(block) for block in blocks])
+                )
+                self.wait_until(
+                    lambda: blocks[-1].hash_int in self.getdata_requests,
+                    timeout=timeout,
+                    check_connected=success,
+                )
+
+            if expect_disconnect:
+                self.wait_for_disconnect(timeout=timeout)
+            else:
+                self.sync_with_ping(timeout=timeout)
+
+            if success:
+                self.wait_until(
+                    lambda: node.getbestblockhash() == blocks[-1].hash_hex,
+                    timeout=timeout,
+                )
+            else:
+                assert node.getbestblockhash() != blocks[-1].hash_hex
+
+    def send_txs_and_test(self, txs, node, *, success=True, reject_reason=None):
+        """Send txs to test node and test whether they're accepted to the mempool.
+
+        - add all txs to our tx_store
+        - send tx messages for all txs
+        - if success is True/False: assert that the txs are/are not accepted to the mempool
+        - if reject_reason is set: assert that the correct reject message is logged."""
+
+        with p2p_lock:
+            for tx in txs:
+                self.tx_store[tx.txid_int] = tx
+
+        reject_reason = [reject_reason] if reject_reason else []
+        with node.assert_debug_log(expected_msgs=reject_reason):
+            for tx in txs:
+                self.send_without_ping(msg_tx(tx))
+
+            self.sync_with_ping()
+
+            raw_mempool = node.getrawmempool()
+            if success:
+                # Check that all txs are now in the mempool
+                for tx in txs:
+                    assert tx.txid_hex in raw_mempool, "{} not found in mempool".format(
+                        tx.txid_hex
+                    )
+            else:
+                # Check that none of the txs are now in the mempool
+                for tx in txs:
+                    assert (
+                        tx.txid_hex not in raw_mempool
+                    ), "{} tx found in mempool".format(tx.txid_hex)
+
+
+class P2PTxInvStore(P2PInterface):
+    """A P2PInterface which stores a count of how many times each txid has been announced."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.tx_invs_received = defaultdict(int)
+
+    def on_inv(self, message):
+        super().on_inv(message)  # Send getdata in response.
+        # Store how many times invs have been received for each tx.
+        for i in message.inv:
+            if (i.type == MSG_TX) or (i.type == MSG_WTX):
+                # save txid
+                self.tx_invs_received[i.hash] += 1
+
+    def get_invs(self):
+        with p2p_lock:
+            return list(self.tx_invs_received.keys())
+
+    def wait_for_broadcast(self, txns, *, timeout=60):
+        """Waits for the txns (list of txids) to complete initial broadcast.
+        The mempool should mark unbroadcast=False for these transactions.
+        """
+        # Wait until invs have been received (and getdatas sent) for each txid.
+        self.wait_until(
+            lambda: set(self.tx_invs_received.keys())
+            == set([int(tx, 16) for tx in txns]),
+            timeout=timeout,
+        )
+        # Flush messages and wait for the getdatas to be processed
+        self.sync_with_ping()

--- a/tests/test_framework/p2p.py
+++ b/tests/test_framework/p2p.py
@@ -79,6 +79,7 @@ from test_framework.messages import (
     msg_wtxidrelay,
     NODE_NETWORK,
     NODE_WITNESS,
+    NODE_NETWORK_LIMITED,
     MAGIC_BYTES,
     sha256,
 )
@@ -103,7 +104,7 @@ MIN_P2P_VERSION_SUPPORTED = 60001
 # Version 70016 supports wtxid relay
 P2P_VERSION = 70016
 # The services that this test framework offers in its `version` message
-P2P_SERVICES = NODE_NETWORK | NODE_WITNESS
+P2P_SERVICES = NODE_NETWORK | NODE_WITNESS | NODE_NETWORK_LIMITED
 # The P2P user agent string that this test framework sends in its `version` message
 P2P_SUBVERSION = "/python-p2p-tester:0.0.3/"
 # Value for relay that this test framework sends in its `version` message

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -39,7 +39,7 @@ class BaseRPC(ABC):
     Subclasses should use `perform_request` to implement RPC calls.
     """
 
-    TIMEOUT: int = 15  # seconds
+    TIMEOUT: int = 30  # seconds
 
     def __init__(self, config: ConfigRPC, log):
         self._config = config

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -393,7 +393,7 @@ class BaseRPC(ABC):
         """
         return self.perform_request("ping")
 
-    def disconnectnode(self, node_address: str, node_id: Optional[int] = None):
+    def disconnectnode(self, node_address: str = "", node_id: Optional[int] = None):
         """
         Disconnect from a peer by `node_address` or `node_id`
         """

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -4,6 +4,7 @@
 
 import os
 import time
+import inspect
 import random
 import socket
 import subprocess
@@ -88,6 +89,38 @@ class Utility:
         )
 
         return (pk_path, cert_path)
+
+
+def wait_until_helper_internal(
+    predicate, *, timeout=60, lock=None, timeout_factor=1.0, check_interval=0.05
+):
+    """Sleep until the predicate resolves to be True.
+
+    Warning: Note that this method is not recommended to be used in tests as it is
+    not aware of the context of the test framework. Using the `wait_until()` members
+    from `BitcoinTestFramework` or `P2PInterface` class ensures the timeout is
+    properly scaled. Furthermore, `wait_until()` from `P2PInterface` class in
+    `p2p.py` has a preset lock.
+    """
+    timeout = timeout * timeout_factor
+    time_end = time.time() + timeout
+
+    while time.time() < time_end:
+        if lock:
+            with lock:
+                if predicate():
+                    return
+        else:
+            if predicate():
+                return
+        time.sleep(check_interval)
+
+    # Print the cause of the timeout
+    predicate_source = "''''\n" + inspect.getsource(predicate) + "'''"
+    print(f"wait_until() failed. Predicate: {predicate_source}")
+    raise AssertionError(
+        f"Predicate {predicate_source} not true after {timeout} seconds"
+    )
 
 
 def wait_until(predicate, timeout=30, interval=0.5, error_msg="Condition not met"):

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -3,46 +3,15 @@
 """Utility helpers used by the test framework (paths, ports, TLS helpers)."""
 
 import os
+import time
 import random
 import socket
 import subprocess
-import time
 
 from test_framework.crypto.pkcs8 import (
     create_pkcs8_private_key,
     create_pkcs8_self_signed_certificate,
 )
-
-
-# pylint: disable=too-many-arguments,too-many-positional-arguments
-def wait_for_chain_sync(
-    florestad,
-    bitcoind,
-    utreexod,
-    target_blocks: int,
-    timeout: float,
-    wait_for_ibd_exit: bool = False,
-):
-    """Poll the three nodes until they all report `target_blocks`.
-
-    When `wait_for_ibd_exit` is set, also wait until florestad reports
-    `initialblockdownload == False`. Polls every 0.5 s; returns silently on
-    success and silently on timeout (caller asserts the post-condition).
-    """
-    end = time.time() + timeout
-    while time.time() < end:
-        blocks_synced = (
-            florestad.rpc.get_block_count()
-            == bitcoind.rpc.get_block_count()
-            == utreexod.rpc.get_block_count()
-            == target_blocks
-        )
-        if blocks_synced and (
-            not wait_for_ibd_exit
-            or not florestad.rpc.get_blockchain_info()["initialblockdownload"]
-        ):
-            return
-        time.sleep(0.5)
 
 
 class Utility:
@@ -119,3 +88,16 @@ class Utility:
         )
 
         return (pk_path, cert_path)
+
+
+def wait_until(predicate, timeout=30, interval=0.5, error_msg="Condition not met"):
+    """
+    Wait until a predicate returns True or timeout is reached.
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        if predicate():
+            return True
+        time.sleep(interval)
+
+    raise TimeoutError(f"{error_msg} after {timeout} seconds")

--- a/tests/test_framework/v2_p2p.py
+++ b/tests/test_framework/v2_p2p.py
@@ -282,12 +282,16 @@ class EncryptedP2PState:
         Returns:
         bytes - encrypted packet contents
         """
-        assert len(contents) <= 2**24 - 1
+        length_field_len = LENGTH_FIELD_LEN
+        if len(contents) > 2**24 - 1:
+            print("Warning: Oversized packet detected")
+            length_field_len = 4
+
         header = (ignore << IGNORE_BIT_POS).to_bytes(HEADER_LEN, "little")
         plaintext = header + contents
         aead_ciphertext = self.peer["send_P"].encrypt(aad, plaintext)
         enc_plaintext_len = self.peer["send_L"].crypt(
-            len(contents).to_bytes(LENGTH_FIELD_LEN, "little")
+            len(contents).to_bytes(length_field_len, "little")
         )
         return enc_plaintext_len + aead_ciphertext
 

--- a/tests/test_framework/v2_p2p.py
+++ b/tests/test_framework/v2_p2p.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+# pylint: skip-file
+# This file was copied from the Bitcoin Core project and does not follow Pylint rules.
+# It is excluded from Pylint checks to maintain compatibility with the original code.
+
+# Copyright (c) 2022-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Class for v2 P2P protocol (see BIP 324)"""
+
+import random
+
+from .crypto.bip324_cipher import FSChaCha20Poly1305
+from .crypto.chacha20 import FSChaCha20
+from .crypto.ellswift import ellswift_create, ellswift_ecdh_xonly
+from .crypto.hkdf import hkdf_sha256
+from .key import tagged_hash
+from .messages import MAGIC_BYTES
+
+CHACHA20POLY1305_EXPANSION = 16
+HEADER_LEN = 1
+IGNORE_BIT_POS = 7
+LENGTH_FIELD_LEN = 3
+MAX_GARBAGE_LEN = 4095
+
+SHORTID = {
+    1: b"addr",
+    2: b"block",
+    3: b"blocktxn",
+    4: b"cmpctblock",
+    5: b"feefilter",
+    6: b"filteradd",
+    7: b"filterclear",
+    8: b"filterload",
+    9: b"getblocks",
+    10: b"getblocktxn",
+    11: b"getdata",
+    12: b"getheaders",
+    13: b"headers",
+    14: b"inv",
+    15: b"mempool",
+    16: b"merkleblock",
+    17: b"notfound",
+    18: b"ping",
+    19: b"pong",
+    20: b"sendcmpct",
+    21: b"tx",
+    22: b"getcfilters",
+    23: b"cfilter",
+    24: b"getcfheaders",
+    25: b"cfheaders",
+    26: b"getcfcheckpt",
+    27: b"cfcheckpt",
+    28: b"addrv2",
+}
+
+# Dictionary which contains short message type ID for the P2P message
+MSGTYPE_TO_SHORTID = {msgtype: shortid for shortid, msgtype in SHORTID.items()}
+
+
+class EncryptedP2PState:
+    """A class for managing the state when v2 P2P protocol is used. Performs initial v2 handshake and encrypts/decrypts
+    P2P messages. P2PConnection uses an object of this class.
+
+
+    Args:
+        initiating (bool): defines whether the P2PConnection is an initiator or responder.
+            - initiating = True for inbound connections in the test framework   [TestNode <------- P2PConnection]
+            - initiating = False for outbound connections in the test framework [TestNode -------> P2PConnection]
+
+        net (string): chain used (regtest, signet etc..)
+
+    Methods:
+        perform an advanced form of diffie-hellman handshake to instantiate the encrypted transport. before exchanging
+        any P2P messages, 2 nodes perform this handshake in order to determine a shared secret that is unique to both
+        of them and use it to derive keys to encrypt/decrypt P2P messages.
+            - initial v2 handshakes is performed by: (see BIP324 section #overall-handshake-pseudocode)
+                1. initiator using initiate_v2_handshake(), complete_handshake() and authenticate_handshake()
+                2. responder using respond_v2_handshake(), complete_handshake() and authenticate_handshake()
+            - initialize_v2_transport() sets various BIP324 derived keys and ciphers.
+
+        encrypt/decrypt v2 P2P messages using v2_enc_packet() and v2_receive_packet().
+    """
+
+    def __init__(self, *, initiating, net):
+        self.initiating = initiating  # True if initiator
+        self.net = net
+        self.peer = {}  # object with various BIP324 derived keys and ciphers
+        self.privkey_ours = None
+        self.ellswift_ours = None
+        self.sent_garbage = b""
+        self.received_garbage = b""
+        self.received_prefix = b""  # received ellswift bytes till the first mismatch from 16 bytes v1_prefix
+        self.tried_v2_handshake = False  # True when the initial handshake is over
+        # stores length of packet contents to detect whether first 3 bytes (which contains length of packet contents)
+        # has been decrypted. set to -1 if decryption hasn't been done yet.
+        self.contents_len = -1
+        self.found_garbage_terminator = False
+        self.transport_version = b""
+
+    @staticmethod
+    def v2_ecdh(priv, ellswift_theirs, ellswift_ours, initiating):
+        """Compute BIP324 shared secret.
+
+        Returns:
+        bytes - BIP324 shared secret
+        """
+        ecdh_point_x32 = ellswift_ecdh_xonly(ellswift_theirs, priv)
+        if initiating:
+            # Initiating, place our public key encoding first.
+            return tagged_hash(
+                "bip324_ellswift_xonly_ecdh",
+                ellswift_ours + ellswift_theirs + ecdh_point_x32,
+            )
+        else:
+            # Responding, place their public key encoding first.
+            return tagged_hash(
+                "bip324_ellswift_xonly_ecdh",
+                ellswift_theirs + ellswift_ours + ecdh_point_x32,
+            )
+
+    def generate_keypair_and_garbage(self, garbage_len=None):
+        """Generates ellswift keypair and 4095 bytes garbage at max"""
+        self.privkey_ours, self.ellswift_ours = ellswift_create()
+        if garbage_len is None:
+            garbage_len = random.randrange(MAX_GARBAGE_LEN + 1)
+        self.sent_garbage = random.randbytes(garbage_len)
+        return self.ellswift_ours + self.sent_garbage
+
+    def initiate_v2_handshake(self):
+        """Initiator begins the v2 handshake by sending its ellswift bytes and garbage
+
+        Returns:
+        bytes - bytes to be sent to the peer when starting the v2 handshake as an initiator
+        """
+        return self.generate_keypair_and_garbage()
+
+    def respond_v2_handshake(self, response):
+        """Responder begins the v2 handshake by sending its ellswift bytes and garbage. However, the responder
+        sends this after having received at least one byte that mismatches 16-byte v1_prefix.
+
+        Returns:
+        1. int - length of bytes that were consumed so that recvbuf can be updated
+        2. bytes - bytes to be sent to the peer when starting the v2 handshake as a responder.
+                 - returns b"" if more bytes need to be received before we can respond and start the v2 handshake.
+                 - returns -1 to downgrade the connection to v1 P2P.
+        """
+        v1_prefix = MAGIC_BYTES[self.net] + b"version\x00\x00\x00\x00\x00"
+        while len(self.received_prefix) < 16:
+            byte = response.read(1)
+            # return b"" if we need to receive more bytes
+            if not byte:
+                return len(self.received_prefix), b""
+            self.received_prefix += byte
+            if self.received_prefix[-1] != v1_prefix[len(self.received_prefix) - 1]:
+                return len(self.received_prefix), self.generate_keypair_and_garbage()
+        # return -1 to decide v1 only after all 16 bytes processed
+        return len(self.received_prefix), -1
+
+    def complete_handshake(self, response):
+        """Instantiates the encrypted transport and
+        sends garbage terminator + optional decoy packets + transport version packet.
+        Done by both initiator and responder.
+
+        Returns:
+        1. int - length of bytes that were consumed. returns 0 if all 64 bytes from ellswift haven't been received yet.
+        2. bytes - bytes to be sent to the peer when completing the v2 handshake
+        """
+        ellswift_theirs = self.received_prefix + response.read(
+            64 - len(self.received_prefix)
+        )
+        # return b"" if we need to receive more bytes
+        if len(ellswift_theirs) != 64:
+            return 0, b""
+        ecdh_secret = self.v2_ecdh(
+            self.privkey_ours, ellswift_theirs, self.ellswift_ours, self.initiating
+        )
+        self.initialize_v2_transport(ecdh_secret)
+        # Send garbage terminator
+        msg_to_send = self.peer["send_garbage_terminator"]
+        # Optionally send decoy packets after garbage terminator.
+        aad = self.sent_garbage
+        for decoy_content_len in [
+            random.randint(1, 100) for _ in range(random.randint(0, 10))
+        ]:
+            msg_to_send += self.v2_enc_packet(
+                decoy_content_len * b"\x00", aad=aad, ignore=True
+            )
+            aad = b""
+        # Send version packet.
+        msg_to_send += self.v2_enc_packet(self.transport_version, aad=aad)
+        return 64 - len(self.received_prefix), msg_to_send
+
+    def authenticate_handshake(self, response):
+        """Ensures that the received optional decoy packets and transport version packet are authenticated.
+        Marks the v2 handshake as complete. Done by both initiator and responder.
+
+        Returns:
+        1. int - length of bytes that were processed so that recvbuf can be updated
+        2. bool - True if the authentication was successful/more bytes need to be received and False otherwise
+        """
+        processed_length = 0
+
+        # Detect garbage terminator in the received bytes
+        if not self.found_garbage_terminator:
+            received_garbage = response[:16]
+            response = response[16:]
+            processed_length = len(received_garbage)
+            for _ in range(MAX_GARBAGE_LEN + 1):
+                if received_garbage[-16:] == self.peer["recv_garbage_terminator"]:
+                    # Receive, decode, and ignore version packet.
+                    # This includes skipping decoys and authenticating the received garbage.
+                    self.found_garbage_terminator = True
+                    self.received_garbage = received_garbage[:-16]
+                    break
+                else:
+                    # don't update recvbuf since more bytes need to be received
+                    if len(response) == 0:
+                        return 0, True
+                    received_garbage += response[:1]
+                    processed_length += 1
+                    response = response[1:]
+            else:
+                # disconnect since garbage terminator was not seen after 4 KiB of garbage.
+                return processed_length, False
+
+        # Process optional decoy packets and transport version packet
+        while not self.tried_v2_handshake:
+            length, contents = self.v2_receive_packet(
+                response, aad=self.received_garbage
+            )
+            if length == -1:
+                return processed_length, False
+            elif length == 0:
+                return processed_length, True
+            processed_length += length
+            self.received_garbage = b""
+            # decoy packets have contents = None. v2 handshake is complete only when version packet
+            # (can be empty with contents = b"") with contents != None is received.
+            if contents is not None:
+                assert (
+                    contents == b""
+                )  # currently TestNode sends an empty version packet
+                self.tried_v2_handshake = True
+                return processed_length, True
+            response = response[length:]
+
+    def initialize_v2_transport(self, ecdh_secret):
+        """Sets the peer object with various BIP324 derived keys and ciphers."""
+        peer = {}
+        salt = b"bitcoin_v2_shared_secret" + MAGIC_BYTES[self.net]
+        for name in (
+            "initiator_L",
+            "initiator_P",
+            "responder_L",
+            "responder_P",
+            "garbage_terminators",
+            "session_id",
+        ):
+            peer[name] = hkdf_sha256(
+                salt=salt, ikm=ecdh_secret, info=name.encode("utf-8"), length=32
+            )
+        if self.initiating:
+            self.peer["send_L"] = FSChaCha20(peer["initiator_L"])
+            self.peer["send_P"] = FSChaCha20Poly1305(peer["initiator_P"])
+            self.peer["send_garbage_terminator"] = peer["garbage_terminators"][:16]
+            self.peer["recv_L"] = FSChaCha20(peer["responder_L"])
+            self.peer["recv_P"] = FSChaCha20Poly1305(peer["responder_P"])
+            self.peer["recv_garbage_terminator"] = peer["garbage_terminators"][16:]
+        else:
+            self.peer["send_L"] = FSChaCha20(peer["responder_L"])
+            self.peer["send_P"] = FSChaCha20Poly1305(peer["responder_P"])
+            self.peer["send_garbage_terminator"] = peer["garbage_terminators"][16:]
+            self.peer["recv_L"] = FSChaCha20(peer["initiator_L"])
+            self.peer["recv_P"] = FSChaCha20Poly1305(peer["initiator_P"])
+            self.peer["recv_garbage_terminator"] = peer["garbage_terminators"][:16]
+        self.peer["session_id"] = peer["session_id"]
+
+    def v2_enc_packet(self, contents, aad=b"", ignore=False):
+        """Encrypt a BIP324 packet.
+
+        Returns:
+        bytes - encrypted packet contents
+        """
+        assert len(contents) <= 2**24 - 1
+        header = (ignore << IGNORE_BIT_POS).to_bytes(HEADER_LEN, "little")
+        plaintext = header + contents
+        aead_ciphertext = self.peer["send_P"].encrypt(aad, plaintext)
+        enc_plaintext_len = self.peer["send_L"].crypt(
+            len(contents).to_bytes(LENGTH_FIELD_LEN, "little")
+        )
+        return enc_plaintext_len + aead_ciphertext
+
+    def v2_receive_packet(self, response, aad=b""):
+        """Decrypt a BIP324 packet
+
+        Returns:
+        1. int - number of bytes consumed (or -1 if error)
+        2. bytes - contents of decrypted non-decoy packet if any (or None otherwise)
+        """
+        if self.contents_len == -1:
+            if len(response) < LENGTH_FIELD_LEN:
+                return 0, None
+            enc_contents_len = response[:LENGTH_FIELD_LEN]
+            self.contents_len = int.from_bytes(
+                self.peer["recv_L"].crypt(enc_contents_len), "little"
+            )
+        response = response[LENGTH_FIELD_LEN:]
+        if len(response) < HEADER_LEN + self.contents_len + CHACHA20POLY1305_EXPANSION:
+            return 0, None
+        aead_ciphertext = response[
+            : HEADER_LEN + self.contents_len + CHACHA20POLY1305_EXPANSION
+        ]
+        plaintext = self.peer["recv_P"].decrypt(aad, aead_ciphertext)
+        if plaintext is None:
+            return -1, None  # disconnect
+        header = plaintext[:HEADER_LEN]
+        length = (
+            LENGTH_FIELD_LEN
+            + HEADER_LEN
+            + self.contents_len
+            + CHACHA20POLY1305_EXPANSION
+        )
+        self.contents_len = -1
+        return length, (
+            None if (header[0] & (1 << IGNORE_BIT_POS)) else plaintext[HEADER_LEN:]
+        )


### PR DESCRIPTION
### Description and Notes

This PR introduces the `p2p` test suite to the integration tests for the Floresta project. The main enhancements include:

- **Integration of Bitcoin Core's P2P Testing Framework**: Added files that provide a P2P interface for communication between nodes. This allows testing scenarios such as sending unexpected messages and ensuring proper handling.
- **Address Relay Tests**: Added the `p2p_addr_relay.py` test to verify the behavior of Floresta regarding the handling of `addr`, `addrv2`, `sendaddr2`, and `getaddr` messages. This includes the following fixes:
  - Corrected a bug where Floresta was accepting `sendaddrv2` messages after the P2P handshake.
  - Updated the behavior of Floresta to send `addr` messages (instead of `addrv2`) to peers that do not signal support for `addrv2`.
- **Resilience Tests**: Added tests for scenarios involving:
  - Oversized messages exceeding the node's permissible limits (`p2p_oversized_msg.py`).
  - Spam of unwanted or unexpected messages to stress test Floresta's resilience (`p2p_spam_msg.py`).

These resilience tests ensure robustness and address potential vulnerabilities. Note that the oversized/spam message tests depend on the changes in **PR #880** to function correctly.

### How to verify the changes you have done?

To verify the changes, execute the functional tests as follows:

1. `./tests/run.sh -t p2p -k p2p_addr_relay.py`: Run the P2P Address Relay test.
2. `./tests/run.sh -t p2p -k p2p_oversized_msg.py`: Run the P2P Oversized Message test.
3. `./tests/run.sh -t p2p -k p2p_spam_msg.py`: Run the P2P Spam Message test.

Ensure that all tests pass successfully and validate the scenarios introduced in this PR. Note that `p2p_oversized_msg.py` and `p2p_spam_msg.py` require **PR #880** to run properly.