### PR TITLE
feat(wire): add subnet/CIDR support to BanMan

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/ban_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/ban_man.rs
@@ -1,0 +1,148 @@
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+/// Default ban duration in seconds
+const DEFAULT_BAN_DURATION: u64 = 60 * 60 * 24;
+
+/// Centralized manager for tracking banned IP addresses.
+#[derive(Debug, Default)]
+pub struct BanMan {
+    banned: HashMap<IpAddr, u64>,
+}
+
+impl BanMan {
+    /// Creates a new empty Banman
+    pub fn new() -> Self {
+        Self {
+            banned: HashMap::new(),
+        }
+    }
+
+    /// Bans an IP address for `duration` seconds from now
+    ///
+    /// If `duration` is 0, the default ban time (24 hours) will be use
+    pub fn add_ban(&mut self, ip: IpAddr, duration: u64) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let ban_duration = if duration == 0 {
+            DEFAULT_BAN_DURATION
+        } else {
+            duration
+        };
+
+        let ban_until = now + ban_duration;
+        self.banned.insert(ip, ban_until);
+    }
+
+    /// Returns true if the IP is banned
+    ///
+    /// Expired bans are removed automatically
+    pub fn is_banned(&mut self, ip: IpAddr) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        if let Some(ban_until) = self.banned.get(&ip) {
+            if *ban_until > now {
+                return true;
+            }
+            // Ban expired, clean it up
+            self.banned.remove(&ip);
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    fn test_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))
+    }
+
+    #[test]
+    fn test_banned_ip_is_detected() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, 3600);
+        assert!(ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_unbanned_ip_is_not_detected() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        assert!(!ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_expired_ban_is_cleaned_up() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        // Insert a ban that already expired (ban_until is in the past)
+        ban_man.banned.insert(ip, 0);
+
+        assert!(!ban_man.is_banned(ip));
+        // Verify it was removed from the map
+        assert!(!ban_man.banned.contains_key(&ip));
+    }
+
+    #[test]
+    fn test_default_duration_when_zero() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, 0);
+
+        // Should be banned for 24 hours from now
+        let ban_until = ban_man.banned.get(&ip).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let expected = now + DEFAULT_BAN_DURATION;
+        // Allow 1 second tolerance for test execution time
+        assert!(*ban_until >= expected - 1 && *ban_until <= expected + 1);
+    }
+
+    #[test]
+    fn test_multiple_ips_banned_independently() {
+        let mut ban_man = BanMan::new();
+        let ip1 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        ban_man.add_ban(ip1, 3600);
+
+        assert!(ban_man.is_banned(ip1));
+        assert!(!ban_man.is_banned(ip2));
+    }
+
+    #[test]
+    fn test_reban_updates_expiry() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, 100);
+        let first_ban = *ban_man.banned.get(&ip).unwrap();
+
+        ban_man.add_ban(ip, 9999);
+        let second_ban = *ban_man.banned.get(&ip).unwrap();
+
+        assert!(second_ban > first_ban);
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/ban_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/ban_man.rs
@@ -6,10 +6,52 @@ use std::time::UNIX_EPOCH;
 /// Default ban duration in seconds
 const DEFAULT_BAN_DURATION: u64 = 60 * 60 * 24;
 
+/// Represents a subnet that can be banned.
+///
+/// A single IP ban is stored as /32 (IPv4) or /128 (IPv6).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BanSubnet {
+    /// The network address
+    pub addr: IpAddr,
+    /// The prefix length (e.g. 24 for a /24 subnet)
+    pub prefix: u8,
+}
+
 /// Centralized manager for tracking banned IP addresses.
 #[derive(Debug, Default)]
 pub struct BanMan {
-    banned: HashMap<IpAddr, u64>,
+    banned: HashMap<BanSubnet, u64>,
+}
+
+impl BanSubnet {
+    /// Creates a new BanSubnet from an IP address and prefix length
+    pub fn new(addr: IpAddr, prefix: u8) -> Self {
+        Self { addr, prefix }
+    }
+
+    /// Creates a single-host subnet (/32 for IPv4, /128 for IPv6)
+    pub fn from_ip(ip: IpAddr) -> Self {
+        let prefix = match ip {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        Self::new(ip, prefix)
+    }
+
+    /// Returns true if the given IP falls within this subnet.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        match (self.addr, ip) {
+            (IpAddr::V4(net), IpAddr::V4(candidate)) => {
+                let mask = u32::MAX.checked_shl(32 - self.prefix as u32).unwrap_or(0);
+                u32::from(net) & mask == u32::from(candidate) & mask
+            }
+            (IpAddr::V6(net), IpAddr::V6(candidate)) => {
+                let mask = u128::MAX.checked_shl(128 - self.prefix as u32).unwrap_or(0);
+                u128::from(net) & mask == u128::from(candidate) & mask
+            }
+            _ => false,
+        }
+    }
 }
 
 impl BanMan {
@@ -20,10 +62,10 @@ impl BanMan {
         }
     }
 
-    /// Bans an IP address for `duration` seconds from now
+    /// Bans an IP subnet for `duration` seconds from now
     ///
     /// If `duration` is 0, the default ban time (24 hours) will be use
-    pub fn add_ban(&mut self, ip: IpAddr, duration: u64) {
+    pub fn add_ban(&mut self, subnet: BanSubnet, duration: u64) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -36,7 +78,7 @@ impl BanMan {
         };
 
         let ban_until = now + ban_duration;
-        self.banned.insert(ip, ban_until);
+        self.banned.insert(subnet, ban_until);
     }
 
     /// Returns true if the IP is banned
@@ -48,15 +90,11 @@ impl BanMan {
             .map(|d| d.as_secs())
             .unwrap_or(0);
 
-        if let Some(ban_until) = self.banned.get(&ip) {
-            if *ban_until > now {
-                return true;
-            }
-            // Ban expired, clean it up
-            self.banned.remove(&ip);
-        }
+        // Remove expired bans first
+        self.banned.retain(|_, ban_until| *ban_until > now);
 
-        false
+        // Check if any subnet contains the IP
+        self.banned.keys().any(|subnet| subnet.contains(ip))
     }
 }
 
@@ -76,7 +114,7 @@ mod tests {
         let mut ban_man = BanMan::new();
         let ip = test_ip();
 
-        ban_man.add_ban(ip, 3600);
+        ban_man.add_ban(BanSubnet::from_ip(ip), 3600);
         assert!(ban_man.is_banned(ip));
     }
 
@@ -94,22 +132,23 @@ mod tests {
         let ip = test_ip();
 
         // Insert a ban that already expired (ban_until is in the past)
-        ban_man.banned.insert(ip, 0);
+        ban_man.banned.insert(BanSubnet::from_ip(ip), 0);
 
         assert!(!ban_man.is_banned(ip));
         // Verify it was removed from the map
-        assert!(!ban_man.banned.contains_key(&ip));
+        assert!(ban_man.banned.is_empty());
     }
 
     #[test]
     fn test_default_duration_when_zero() {
         let mut ban_man = BanMan::new();
         let ip = test_ip();
+        let subnet = BanSubnet::from_ip(ip);
 
-        ban_man.add_ban(ip, 0);
+        ban_man.add_ban(subnet.clone(), 0);
 
         // Should be banned for 24 hours from now
-        let ban_until = ban_man.banned.get(&ip).unwrap();
+        let ban_until = ban_man.banned.get(&subnet).unwrap();
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -126,7 +165,7 @@ mod tests {
         let ip1 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
         let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
 
-        ban_man.add_ban(ip1, 3600);
+        ban_man.add_ban(BanSubnet::from_ip(ip1), 3600);
 
         assert!(ban_man.is_banned(ip1));
         assert!(!ban_man.is_banned(ip2));
@@ -136,13 +175,26 @@ mod tests {
     fn test_reban_updates_expiry() {
         let mut ban_man = BanMan::new();
         let ip = test_ip();
+        let subnet = BanSubnet::from_ip(ip);
 
-        ban_man.add_ban(ip, 100);
-        let first_ban = *ban_man.banned.get(&ip).unwrap();
+        ban_man.add_ban(subnet.clone(), 100);
+        let first_ban = *ban_man.banned.get(&subnet).unwrap();
 
-        ban_man.add_ban(ip, 9999);
-        let second_ban = *ban_man.banned.get(&ip).unwrap();
+        ban_man.add_ban(subnet.clone(), 9999);
+        let second_ban = *ban_man.banned.get(&subnet).unwrap();
 
         assert!(second_ban > first_ban);
+    }
+
+    #[test]
+    fn test_subnet_ban_covers_all_ips_in_range() {
+        let mut ban_man = BanMan::new();
+        // Ban 192.168.1.0/24 — all of 192.168.1.*
+        let subnet = BanSubnet::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), 24);
+        ban_man.add_ban(subnet, 3600);
+
+        assert!(ban_man.is_banned(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(ban_man.is_banned(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255))));
+        assert!(!ban_man.is_banned(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1))));
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -88,6 +88,9 @@ pub enum WireError {
 
     /// Couldn't find the leaf data for a block
     LeafDataNotFound,
+
+    /// Peer is banned
+    PeerBanned(IpAddr),
 }
 
 impl std::fmt::Display for WireError {
@@ -132,6 +135,7 @@ impl std::fmt::Display for WireError {
                 "We tried to work on a block that we don't have a proof for yet"
             ),
             WireError::LeafDataNotFound => write!(f, "Couldn't find the leaf data for a block"),
+            WireError::PeerBanned(ip) => write!(f, "Peer {ip} is banned"),
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -86,6 +86,7 @@ impl Default for UtreexoNodeConfig {
 }
 
 pub mod address_man;
+pub mod ban_man;
 pub mod block_proof;
 pub mod error;
 pub mod node;

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -90,6 +90,11 @@ where
             return Err(WireError::NoAddressesAvailable);
         };
 
+        let net_address = address.get_net_address();
+        if self.ban_man.is_banned(net_address) {
+            return Err(WireError::PeerBanned(net_address));
+        }
+
         debug!("attempting connection with address={address:?} kind={kind:?}",);
 
         let now = SystemTime::now()

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -42,6 +42,7 @@ use tracing::info;
 
 use super::address_man::AddressMan;
 use super::address_man::LocalAddress;
+use super::ban_man::BanMan;
 use super::block_proof::Bitmap;
 use super::error::WireError;
 use super::node_context::NodeContext;
@@ -257,6 +258,7 @@ pub struct NodeCommon<Chain: ChainBackend> {
     pub(crate) peer_by_service: HashMap<ServiceFlags, Vec<u32>>,
     pub(crate) max_banscore: u32,
     pub(crate) address_man: AddressMan,
+    pub(crate) ban_man: BanMan,
     pub(crate) added_peers: Vec<AddedPeerInfo>,
 
     // 3. Internal Communication
@@ -370,6 +372,7 @@ where
                 node_rx,
                 node_tx,
                 address_man,
+                ban_man: BanMan::new(),
                 last_tip_update: Instant::now(),
                 last_connection: Instant::now(),
                 last_peer_db_dump: Instant::now(),

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -505,11 +505,13 @@ where
         let is_missbehaving = peer.banscore >= self.common.max_banscore;
         // extra peers should be banned immediately
         let is_extra = peer.kind == ConnectionKind::Extra;
+        let peer_addr = peer.address;
 
         if is_missbehaving || is_extra {
             warn!("banning peer {peer_id} for misbehaving");
             peer.channel.send(NodeRequest::Shutdown)?;
             peer.state = PeerStatus::Banned;
+            self.common.ban_man.add_ban(peer_addr, 0);
             return Ok(());
         }
 
@@ -528,8 +530,10 @@ where
 
             let ban_state = AddressState::Banned(T::BAN_TIME);
             let addr_id = peer.address_id as usize;
+            let peer_addr = peer.address;
 
             self.address_man.update_set_state(addr_id, ban_state);
+            self.ban_man.add_ban(peer_addr, 0);
         }
 
         self.send_to_peer(peer, NodeRequest::Shutdown)?;

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -34,6 +34,7 @@ use crate::node_context::PeerId;
 use crate::node_interface::NodeResponse;
 use crate::node_interface::PeerInfo;
 use crate::node_interface::UserRequest;
+use crate::p2p_wire::ban_man::BanSubnet;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
@@ -511,7 +512,9 @@ where
             warn!("banning peer {peer_id} for misbehaving");
             peer.channel.send(NodeRequest::Shutdown)?;
             peer.state = PeerStatus::Banned;
-            self.common.ban_man.add_ban(peer_addr, 0);
+            self.common
+                .ban_man
+                .add_ban(BanSubnet::from_ip(peer_addr), 0);
             return Ok(());
         }
 
@@ -533,7 +536,7 @@ where
             let peer_addr = peer.address;
 
             self.address_man.update_set_state(addr_id, ban_state);
-            self.ban_man.add_ban(peer_addr, 0);
+            self.ban_man.add_ban(BanSubnet::from_ip(peer_addr), 0);
         }
 
         self.send_to_peer(peer, NodeRequest::Shutdown)?;


### PR DESCRIPTION
## Summary

Adds `BanSubnet` to support banning entire subnets (e.g. `192.168.1.0/24`) instead of only single IPs. Uses bitwise mask matching, same approach as Bitcoin Core's [`CSubNet::Match`](https://github.com/bitcoin/bitcoin/blob/master/src/netaddress.cpp).

- `BanSubnet` holds an `IpAddr` + prefix length, with `contains(ip)` for matching
- `BanMan` keyed by `BanSubnet` instead of `IpAddr`; `is_banned()` does linear scan over all entries
- Single-IP bans are just `/32` or `/128` subnets
- Integration points in `peer_man.rs` wrapped with `BanSubnet::from_ip()`

Follow-up to #892 as discussed — showing the direction for subnet banning.

## Test plan

- [x] Existing unit tests updated and passing
- [x] New: `test_subnet_ban_covers_all_ips_in_range` — bans /24, checks IPs inside and outside
- [x] Clippy and fmt clean