### PR TITLE
Ci linting action

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -24,12 +24,6 @@ jobs:
       - name: Prepare environment
         run: uv sync --all-extras --dev
 
-      - name: Run black formatting
-        run: uv run black --check --verbose ./tests
-
-      - name: Run pylint linter
-        run: uv run pylint --verbose ./tests
-
       # Required for compiling the project, as it depends on the bitcoinkernel
       - name: Install Boost
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,66 @@
+name: Linting
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  typos:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run typos
+        uses: crate-ci/typos@v1
+
+  rust-lint:
+    name: Rust Lint
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Boost
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
+      - name: Run cargo fmt
+        run: cargo +nightly fmt --all --check
+
+      - name: Run cargo doc
+        run: |
+          RUSTDOCFLAGS="--cfg docsrs -D warnings" \
+          cargo +nightly doc --workspace --no-deps --lib --all-features --document-private-items
+
+      - name: Run cargo clippy
+        run: ./contrib/feature_matrix.sh clippy '-- -D warnings'
+        shell: bash # Ensure the script runs using bash on all platforms
+
+  python-lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Prepare environment
+        run: uv sync --all-extras --dev
+
+      - name: Run black formatting
+        run: uv run black --check --verbose ./tests
+
+      - name: Run pylint linter
+        run: uv run pylint --verbose ./tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,38 +8,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-hack
-
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-
-      - name: Install Boost
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libboost-all-dev
-
-      - name: Spell check
-        uses: crate-ci/typos@v1
-
-      - name: Run cargo fmt
-        run: cargo +nightly fmt --all --check
-
-      - name: Run cargo doc
-        run: |
-          RUSTDOCFLAGS="--cfg docsrs -D warnings" \
-          cargo +nightly doc --workspace --no-deps --lib --all-features --document-private-items
-
-      - name: Run cargo clippy
-        run: ./contrib/feature_matrix.sh clippy '-- -D warnings'
-        shell: bash # Ensure the script runs using bash on all platforms
-
   cross-testing:
     strategy:
       matrix:


### PR DESCRIPTION
### Description and Notes
Closes #677 
Currently, typos runs inside the Rust CI linting job in rust.yml, even though it's language agnostic and checks the entire project not just rust code. Similarly, Python linting is duplicated in functional.yml.

This PR creates a dedicated lint.yml workflow that separates language agnostic linting from rust specific check.

### How to verify the changes you have done?

the ci passes in my fork https://github.com/psg-19/Floresta/actions

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

