### PR TITLE
feat(wire): implement BanMan and make it single source of truth for bans

### DIFF
--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -26,6 +26,9 @@ mod p2p_wire;
 pub use p2p_wire::UtreexoNodeConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::address_man;
+#[cfg(not(target_arch = "wasm32"))]
+pub use p2p_wire::ban_man;
+#[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::bitcoin_socket_addr;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::block_proof;

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::bitcoin_socket_addr::InvalidAddressError;
 use crate::onion::OnionV3Addr;
+use crate::p2p_wire::ban_man::BanMan;
 
 /// How long we'll wait before trying to connect to a peer that failed
 const RETRY_TIME: u64 = 10 * 60; // 10 minutes
@@ -70,9 +71,6 @@ pub enum AddressState {
 
     /// We tried this peer before, and had success at least once, so we know what to expect
     Tried(u64),
-
-    /// This peer misbehaved and we banned them
-    Banned(u64),
 
     /// We are connected to this peer right now
     Connected,
@@ -584,7 +582,6 @@ impl AddressMan {
             };
 
             match addr.state {
-                AddressState::Banned(_) => continue,
                 AddressState::Tried(_) | AddressState::Connected => bucket.tried += 1,
                 AddressState::NeverTried | AddressState::Failed(_) => bucket.new += 1,
             }
@@ -773,10 +770,8 @@ impl AddressMan {
             let peer = self.addresses.keys().nth(idx)?;
             let address = self.addresses.get(peer)?.to_owned();
 
-            // don't try to connect to a peer that is banned or already connected
-            if matches!(address.state, AddressState::Banned(_))
-                | matches!(address.state, AddressState::Connected)
-            {
+            // don't try to connect to a peer that is already connected
+            if matches!(address.state, AddressState::Connected) {
                 return None;
             }
 
@@ -810,8 +805,6 @@ impl AddressMan {
 
                     self.good_addresses.retain(|&x| x != id);
                 }
-
-                AddressState::Banned(_) => {}
             }
         }
 
@@ -900,16 +893,40 @@ impl AddressMan {
     /// This function moves addresses between buckets, like if the ban time of a peer expired,
     /// or if we tried to connect to a peer and it failed in the past, but now it might be online
     /// again.
-    pub fn rearrange_buckets(&mut self) {
+    pub fn rearrange_buckets(&mut self, ban_man: &BanMan) {
         let now = Self::time_since_unix();
+        let banned_ips = ban_man.banned_ips();
+
+        // Trap banned IPs inside the Failed state and purge them from good_addresses
+        // By keeping them in self.addresses, we remember them and won't blindly re-connect to them.
+        self.good_addresses.retain(|idx| {
+            self.addresses.get(idx).is_some_and(|address| {
+                address
+                    .get_net_address()
+                    .is_none_or(|ip| !banned_ips.contains(&ip))
+            })
+        });
+
+        for peers in self.good_peers_by_service.values_mut() {
+            peers.retain(|idx| {
+                self.addresses.get(idx).is_some_and(|address| {
+                    address
+                        .get_net_address()
+                        .is_none_or(|ip| !banned_ips.contains(&ip))
+                })
+            });
+        }
 
         for address in self.addresses.values_mut() {
+            if address
+                .get_net_address()
+                .is_some_and(|ip| banned_ips.contains(&ip))
+            {
+                address.state = AddressState::Failed(now);
+                continue;
+            }
+
             match address.state {
-                AddressState::Banned(ban_time) => {
-                    if ban_time < now {
-                        address.state = AddressState::NeverTried;
-                    }
-                }
                 AddressState::Tried(tried_time) => {
                     if tried_time + ASSUME_STALE < now {
                         address.state = AddressState::NeverTried;
@@ -987,9 +1004,6 @@ impl AddressMan {
         }
 
         match state {
-            AddressState::Banned(_) => {
-                self.good_addresses.retain(|&x| x != idx);
-            }
             AddressState::Tried(_) => {
                 if !self.good_addresses.contains(&idx) {
                     self.good_addresses.push(idx);
@@ -1030,6 +1044,25 @@ impl AddressMan {
         }
 
         self
+    }
+
+    /// Drops all addresses matching `ip` from the "good" pools so they won't
+    /// be selected for connection, while keeping the entries in the address
+    /// book so they become eligible again once the ban expires.
+    pub fn unmark_good_by_ip(&mut self, ip: IpAddr) {
+        let ids: Vec<usize> = self
+            .addresses
+            .iter()
+            .filter(|(_, addr)| addr.get_net_address() == Some(ip))
+            .map(|(id, _)| *id)
+            .collect();
+
+        for id in &ids {
+            self.good_addresses.retain(|&x| x != *id);
+            for peers in self.good_peers_by_service.values_mut() {
+                peers.retain(|&x| x != *id);
+            }
+        }
     }
 
     /// Adds a peer to the list of peers known to have some service
@@ -1337,6 +1370,7 @@ mod test {
     use std::fs::File;
     use std::io::Read;
     use std::io::{self};
+    use std::time::Duration;
 
     use bitcoin::Network;
     use bitcoin::p2p::ServiceFlags;
@@ -1353,6 +1387,7 @@ mod test {
     use crate::address_man::DiskLocalAddress;
     use crate::address_man::ReachableNetworks;
     use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+    use crate::p2p_wire::ban_man::BanMan;
 
     fn load_addresses_from_json(file_path: impl AsRef<Path>) -> io::Result<Vec<LocalAddress>> {
         let mut contents = String::new();
@@ -1540,7 +1575,9 @@ mod test {
             None, // No proxy
         ));
 
-        address_man.rearrange_buckets();
+        let ban_man = BanMan::new();
+
+        address_man.rearrange_buckets(&ban_man);
     }
 
     #[test]
@@ -1604,6 +1641,7 @@ mod test {
     fn test_rearrange_buckets() {
         let mut address_man = AddressMan::new(None, &[]);
         let addresses = get_addresses_and_random_times();
+        let banman = BanMan::new();
         address_man.addresses.extend(
             addresses
                 .iter()
@@ -1612,7 +1650,7 @@ mod test {
         );
 
         assert_eq!(address_man.addresses.len(), addresses.len());
-        address_man.rearrange_buckets();
+        address_man.rearrange_buckets(&banman);
 
         assert!(address_man.addresses.iter().all(|(_, addr)| {
             matches!(
@@ -1620,6 +1658,68 @@ mod test {
                 AddressState::NeverTried | AddressState::Tried(_)
             )
         }));
+    }
+
+    #[test]
+    fn test_rearrange_buckets_quarantines_banned_ips() {
+        let mut address_man = AddressMan::new(None, &[]);
+        let mut ban_man = BanMan::new();
+        let addresses = get_addresses_and_random_times();
+
+        address_man.addresses.extend(
+            addresses
+                .iter()
+                .map(|addr| (addr.id, addr.clone()))
+                .collect::<std::collections::HashMap<usize, LocalAddress>>(),
+        );
+
+        let total = address_man.addresses.len();
+        assert!(total > 0);
+
+        // Ban the first address
+        let first_addr = addresses[0].get_net_address().unwrap();
+        ban_man.add_ban(first_addr, Some(Duration::from_secs(3600)));
+
+        // Run rearrange_buckets — should quarantine the banned address into Failed
+        address_man.rearrange_buckets(&ban_man);
+
+        assert_eq!(address_man.addresses.len(), total); // Should NOT be deleted!
+
+        let quarantined = address_man
+            .addresses
+            .values()
+            .find(|addr| addr.get_net_address() == Some(first_addr))
+            .unwrap();
+
+        assert!(matches!(quarantined.state, AddressState::Failed(_)));
+    }
+
+    #[test]
+    fn test_unmark_good_by_ip_preserves_address_entries() {
+        let mut address_man = AddressMan::new(None, &[]);
+        let addresses = get_addresses_and_random_times();
+        address_man.addresses.extend(
+            addresses
+                .iter()
+                .map(|addr| (addr.id, addr.clone()))
+                .collect::<HashMap<usize, LocalAddress>>(),
+        );
+        let total = address_man.addresses.len();
+        let first_id = addresses[0].id;
+        let first_ip = addresses[0].get_net_address().unwrap();
+        address_man.good_addresses.push(first_id);
+
+        address_man.unmark_good_by_ip(first_ip);
+
+        assert_eq!(
+            address_man.addresses.len(),
+            total,
+            "address entry must not be deleted",
+        );
+        assert!(
+            !address_man.good_addresses.contains(&first_id),
+            "must be unmarked as good",
+        );
     }
 
     #[test]
@@ -1783,14 +1883,14 @@ mod test {
         );
 
         for addr in addresses {
-            address_man.update_set_state(addr.id, AddressState::Banned(0));
+            address_man.update_set_state(addr.id, AddressState::Failed(0));
         }
 
         assert!(
             address_man
                 .addresses
                 .values()
-                .all(|addr| matches!(addr.state, AddressState::Banned(_)))
+                .all(|addr| matches!(addr.state, AddressState::Failed(_)))
         );
     }
 

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::bitcoin_socket_addr::InvalidAddressError;
 use crate::onion::OnionV3Addr;
+use crate::p2p_wire::ban_man::BanMan;
 
 /// How long we'll wait before trying to connect to a peer that failed
 const RETRY_TIME: u64 = 10 * 60; // 10 minutes
@@ -70,9 +71,6 @@ pub enum AddressState {
 
     /// We tried this peer before, and had success at least once, so we know what to expect
     Tried(u64),
-
-    /// This peer misbehaved and we banned them
-    Banned(u64),
 
     /// We are connected to this peer right now
     Connected,
@@ -580,7 +578,6 @@ impl AddressMan {
             };
 
             match addr.state {
-                AddressState::Banned(_) => continue,
                 AddressState::Tried(_) | AddressState::Connected => bucket.tried += 1,
                 AddressState::NeverTried | AddressState::Failed(_) => bucket.new += 1,
             }
@@ -769,10 +766,8 @@ impl AddressMan {
             let peer = self.addresses.keys().nth(idx)?;
             let address = self.addresses.get(peer)?.to_owned();
 
-            // don't try to connect to a peer that is banned or already connected
-            if matches!(address.state, AddressState::Banned(_))
-                | matches!(address.state, AddressState::Connected)
-            {
+            // don't try to connect to a peer that is already connected
+            if matches!(address.state, AddressState::Connected) {
                 return None;
             }
 
@@ -806,8 +801,6 @@ impl AddressMan {
 
                     self.good_addresses.retain(|&x| x != id);
                 }
-
-                AddressState::Banned(_) => {}
             }
         }
 
@@ -896,16 +889,40 @@ impl AddressMan {
     /// This function moves addresses between buckets, like if the ban time of a peer expired,
     /// or if we tried to connect to a peer and it failed in the past, but now it might be online
     /// again.
-    pub fn rearrange_buckets(&mut self) {
+    pub fn rearrange_buckets(&mut self, ban_man: &mut BanMan) {
         let now = Self::time_since_unix();
+        let banned_ips = ban_man.banned_ips();
+
+        // Trap banned IPs inside the Failed state and purge them from good_addresses
+        // By keeping them in self.addresses, we remember them and won't blindly re-connect to them.
+        self.good_addresses.retain(|idx| {
+            self.addresses.get(idx).is_some_and(|address| {
+                address
+                    .get_net_address()
+                    .is_none_or(|ip| !banned_ips.contains(&ip))
+            })
+        });
+
+        for peers in self.good_peers_by_service.values_mut() {
+            peers.retain(|idx| {
+                self.addresses.get(idx).is_some_and(|address| {
+                    address
+                        .get_net_address()
+                        .is_none_or(|ip| !banned_ips.contains(&ip))
+                })
+            });
+        }
 
         for address in self.addresses.values_mut() {
+            if address
+                .get_net_address()
+                .is_some_and(|ip| banned_ips.contains(&ip))
+            {
+                address.state = AddressState::Failed(now);
+                continue;
+            }
+
             match address.state {
-                AddressState::Banned(ban_time) => {
-                    if ban_time < now {
-                        address.state = AddressState::NeverTried;
-                    }
-                }
                 AddressState::Tried(tried_time) => {
                     if tried_time + ASSUME_STALE < now {
                         address.state = AddressState::NeverTried;
@@ -983,9 +1000,6 @@ impl AddressMan {
         }
 
         match state {
-            AddressState::Banned(_) => {
-                self.good_addresses.retain(|&x| x != idx);
-            }
             AddressState::Tried(_) => {
                 if !self.good_addresses.contains(&idx) {
                     self.good_addresses.push(idx);
@@ -1026,6 +1040,25 @@ impl AddressMan {
         }
 
         self
+    }
+
+    /// Drops all addresses matching `ip` from the "good" pools so they won't
+    /// be selected for connection, while keeping the entries in the address
+    /// book so they become eligible again once the ban expires.
+    pub fn unmark_good_by_ip(&mut self, ip: IpAddr) {
+        let ids: Vec<usize> = self
+            .addresses
+            .iter()
+            .filter(|(_, addr)| addr.get_net_address() == Some(ip))
+            .map(|(id, _)| *id)
+            .collect();
+
+        for id in &ids {
+            self.good_addresses.retain(|&x| x != *id);
+            for peers in self.good_peers_by_service.values_mut() {
+                peers.retain(|&x| x != *id);
+            }
+        }
     }
 
     /// Adds a peer to the list of peers known to have some service
@@ -1132,6 +1165,42 @@ impl AddressMan {
     }
 }
 
+/// On-disk representation of [AddressState].
+///
+/// Kept separate so the persisted format can carry variants the in-memory state no
+/// longer has. `Banned` is deserialize-only, for `peers.json` files written before bans
+/// moved to [BanMan]; it is migrated to `NeverTried` on load.
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
+pub enum DiskAddressState {
+    NeverTried,
+    Tried(u64),
+    Connected,
+    Failed(u64),
+    Banned(u64),
+}
+
+impl From<AddressState> for DiskAddressState {
+    fn from(state: AddressState) -> Self {
+        match state {
+            AddressState::NeverTried => Self::NeverTried,
+            AddressState::Tried(time) => Self::Tried(time),
+            AddressState::Connected => Self::Connected,
+            AddressState::Failed(time) => Self::Failed(time),
+        }
+    }
+}
+
+impl From<DiskAddressState> for AddressState {
+    fn from(state: DiskAddressState) -> Self {
+        match state {
+            DiskAddressState::NeverTried | DiskAddressState::Banned(_) => Self::NeverTried,
+            DiskAddressState::Tried(time) => Self::Tried(time),
+            DiskAddressState::Connected => Self::Connected,
+            DiskAddressState::Failed(time) => Self::Failed(time),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiskLocalAddress {
     /// An actual address
@@ -1139,7 +1208,7 @@ pub struct DiskLocalAddress {
     /// Last time we successfully connected to this peer, only relevant is state == State::Tried
     last_connected: u64,
     /// Our local state for this peer, as defined in AddressState
-    state: AddressState,
+    state: DiskAddressState,
     /// Network services announced by this peer
     services: u64,
     /// Network port this peers listens to
@@ -1169,9 +1238,9 @@ impl From<LocalAddress> for DiskLocalAddress {
             address,
             last_connected: value.last_connected,
             state: if value.state == AddressState::Connected {
-                AddressState::Tried(time)
+                DiskAddressState::Tried(time)
             } else {
-                value.state
+                value.state.into()
             },
             services: value.services.to_u64(),
             port: value.get_port(),
@@ -1196,7 +1265,7 @@ impl From<DiskLocalAddress> for LocalAddress {
         Self {
             address: sock_addr,
             last_connected: value.last_connected,
-            state: value.state,
+            state: value.state.into(),
             services,
             id: value
                 .id
@@ -1333,6 +1402,7 @@ mod test {
     use std::fs::File;
     use std::io::Read;
     use std::io::{self};
+    use std::time::Duration;
 
     use bitcoin::Network;
     use bitcoin::p2p::ServiceFlags;
@@ -1349,6 +1419,7 @@ mod test {
     use crate::address_man::DiskLocalAddress;
     use crate::address_man::ReachableNetworks;
     use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+    use crate::p2p_wire::ban_man::BanMan;
 
     fn load_addresses_from_json(file_path: impl AsRef<Path>) -> io::Result<Vec<LocalAddress>> {
         let mut contents = String::new();
@@ -1361,7 +1432,7 @@ mod test {
 
         for seed in seeds {
             let state = match seed.state {
-                AddressState::Tried(time) => AddressState::Tried(time),
+                DiskAddressState::Tried(time) => AddressState::Tried(time),
                 _ => continue,
             };
 
@@ -1376,6 +1447,17 @@ mod test {
         }
 
         Ok(addresses)
+    }
+
+    #[test]
+    fn test_legacy_banned_state_migrates_to_never_tried() {
+        // peers.json written before BanMan existed may still carry the removed Banned variant
+        let legacy = r#"[{"address":{"V4":"10.0.0.1"},"last_connected":0,"state":{"Banned":86400},"services":0,"port":8333,"id":1}]"#;
+
+        let peers: Vec<DiskLocalAddress> = serde_json::from_str(legacy).unwrap();
+        let local: LocalAddress = peers[0].clone().into();
+
+        assert_eq!(local.state, AddressState::NeverTried);
     }
 
     #[test]
@@ -1536,7 +1618,9 @@ mod test {
             None, // No proxy
         ));
 
-        address_man.rearrange_buckets();
+        let mut ban_man = BanMan::new();
+
+        address_man.rearrange_buckets(&mut ban_man);
     }
 
     #[test]
@@ -1600,6 +1684,7 @@ mod test {
     fn test_rearrange_buckets() {
         let mut address_man = AddressMan::new(None, &[]);
         let addresses = get_addresses_and_random_times();
+        let mut banman = BanMan::new();
         address_man.addresses.extend(
             addresses
                 .iter()
@@ -1608,7 +1693,7 @@ mod test {
         );
 
         assert_eq!(address_man.addresses.len(), addresses.len());
-        address_man.rearrange_buckets();
+        address_man.rearrange_buckets(&mut banman);
 
         assert!(address_man.addresses.iter().all(|(_, addr)| {
             matches!(
@@ -1616,6 +1701,68 @@ mod test {
                 AddressState::NeverTried | AddressState::Tried(_)
             )
         }));
+    }
+
+    #[test]
+    fn test_rearrange_buckets_quarantines_banned_ips() {
+        let mut address_man = AddressMan::new(None, &[]);
+        let mut ban_man = BanMan::new();
+        let addresses = get_addresses_and_random_times();
+
+        address_man.addresses.extend(
+            addresses
+                .iter()
+                .map(|addr| (addr.id, addr.clone()))
+                .collect::<std::collections::HashMap<usize, LocalAddress>>(),
+        );
+
+        let total = address_man.addresses.len();
+        assert!(total > 0);
+
+        // Ban the first address
+        let first_addr = addresses[0].get_net_address().unwrap();
+        ban_man.add_ban(first_addr, Some(Duration::from_secs(3600)));
+
+        // Run rearrange_buckets — should quarantine the banned address into Failed
+        address_man.rearrange_buckets(&mut ban_man);
+
+        assert_eq!(address_man.addresses.len(), total); // Should NOT be deleted!
+
+        let quarantined = address_man
+            .addresses
+            .values()
+            .find(|addr| addr.get_net_address() == Some(first_addr))
+            .unwrap();
+
+        assert!(matches!(quarantined.state, AddressState::Failed(_)));
+    }
+
+    #[test]
+    fn test_unmark_good_by_ip_preserves_address_entries() {
+        let mut address_man = AddressMan::new(None, &[]);
+        let addresses = get_addresses_and_random_times();
+        address_man.addresses.extend(
+            addresses
+                .iter()
+                .map(|addr| (addr.id, addr.clone()))
+                .collect::<HashMap<usize, LocalAddress>>(),
+        );
+        let total = address_man.addresses.len();
+        let first_id = addresses[0].id;
+        let first_ip = addresses[0].get_net_address().unwrap();
+        address_man.good_addresses.push(first_id);
+
+        address_man.unmark_good_by_ip(first_ip);
+
+        assert_eq!(
+            address_man.addresses.len(),
+            total,
+            "address entry must not be deleted",
+        );
+        assert!(
+            !address_man.good_addresses.contains(&first_id),
+            "must be unmarked as good",
+        );
     }
 
     #[test]
@@ -1779,14 +1926,14 @@ mod test {
         );
 
         for addr in addresses {
-            address_man.update_set_state(addr.id, AddressState::Banned(0));
+            address_man.update_set_state(addr.id, AddressState::Failed(0));
         }
 
         assert!(
             address_man
                 .addresses
                 .values()
-                .all(|addr| matches!(addr.state, AddressState::Banned(_)))
+                .all(|addr| matches!(addr.state, AddressState::Failed(_)))
         );
     }
 

--- a/crates/floresta-wire/src/p2p_wire/ban_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/ban_man.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Centralized ban management for misbehaving peers.
+//!
+//! Tracks banned IP addresses with per-entry expiry, and persists them to
+//! `bans.json` under the node's data directory so bans survive restarts.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::net::IpAddr;
+use std::path::Path;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+/// Default ban duration in seconds
+const DEFAULT_BAN_DURATION: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
+
+/// Absolute Unix timestamp in seconds.
+type BanExpiry = u64;
+
+#[derive(Debug, Default)]
+/// Centralized manager for tracking banned IP addresses.
+pub struct BanMan {
+    banned: HashMap<IpAddr, BanExpiry>,
+}
+
+impl BanMan {
+    /// Creates a new empty [`BanMan`].
+    pub fn new() -> Self {
+        Self {
+            banned: HashMap::new(),
+        }
+    }
+
+    /// Bans an IP address for `duration` from now
+    ///
+    /// If `duration` is None, the default ban time (24 hours) will be used instead.
+    pub fn add_ban(&mut self, ip: IpAddr, duration: Option<Duration>) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let ban_duration = duration.unwrap_or(DEFAULT_BAN_DURATION);
+
+        let ban_until = now + ban_duration.as_secs();
+        self.banned.insert(ip, ban_until);
+    }
+
+    /// Returns true if the IP is banned
+    ///
+    /// Expired bans are removed automatically
+    pub fn is_banned(&mut self, ip: IpAddr) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        if let Some(ban_until) = self.banned.get(&ip) {
+            if *ban_until > now {
+                return true;
+            }
+            // Ban expired, clean it up
+            self.banned.remove(&ip);
+        }
+
+        false
+    }
+
+    /// Returns the set of currently banned IPs.
+    ///
+    /// Only includes IPs whose ban has not yet expired.
+    pub fn banned_ips(&self) -> Vec<IpAddr> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        self.banned
+            .iter()
+            .filter(|(_, ban_until)| **ban_until > now)
+            .map(|(ip, _)| *ip)
+            .collect()
+    }
+
+    /// Dumps the banned ips to a file on dir `datadir/bans.json` in json format
+    ///
+    /// The file is created if it doesn't exist, and overwritten if it does.
+    pub fn dump_bans(&self, datadir: impl AsRef<Path>) -> io::Result<()> {
+        if let Ok(bans) = serde_json::to_string(&self.banned) {
+            fs::write(datadir.as_ref().join("bans.json"), bans)?;
+        }
+        Ok(())
+    }
+
+    /// Loads the banned ips from `datadir/bans.json`.
+    ///
+    /// A missing file is treated as an empty ban list (first run). An
+    /// unreadable or malformed file returns an error so the operator
+    /// notices instead of silently starting with no bans.
+    pub fn load_bans(&mut self, datadir: impl AsRef<Path>) -> io::Result<()> {
+        let path = datadir.as_ref().join("bans.json");
+        match fs::read_to_string(&path) {
+            Ok(persisted_bans) => {
+                self.banned = serde_json::from_str(&persisted_bans)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Ok(())
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::time::Duration;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    use super::BanMan;
+    use super::DEFAULT_BAN_DURATION;
+
+    fn test_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))
+    }
+
+    #[test]
+    fn test_banned_ip_is_detected() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(3600)));
+        assert!(ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_unbanned_ip_is_not_detected() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        assert!(!ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_expired_ban_is_cleaned_up() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        // Insert a ban that already expired (ban_until is in the past)
+        ban_man.banned.insert(ip, 0);
+
+        assert!(!ban_man.is_banned(ip));
+        // Verify it was removed from the map
+        assert!(!ban_man.banned.contains_key(&ip));
+    }
+
+    #[test]
+    fn test_default_duration_when_none() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, None);
+
+        // Should be banned for 24 hours from now
+        let ban_until = ban_man.banned.get(&ip).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let expected = now + DEFAULT_BAN_DURATION.as_secs();
+        // Allow 1 second tolerance for test execution time
+        assert!(*ban_until >= expected - 1 && *ban_until <= expected + 1);
+    }
+
+    #[test]
+    fn test_multiple_ips_banned_independently() {
+        let mut ban_man = BanMan::new();
+        let ip1 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        ban_man.add_ban(ip1, Some(Duration::from_secs(3600)));
+
+        assert!(ban_man.is_banned(ip1));
+        assert!(!ban_man.is_banned(ip2));
+    }
+
+    #[test]
+    fn test_reban_updates_expiry() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(100)));
+        let first_ban = *ban_man.banned.get(&ip).unwrap();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(9999)));
+        let second_ban = *ban_man.banned.get(&ip).unwrap();
+
+        assert!(second_ban > first_ban);
+    }
+
+    #[test]
+    fn test_ban_man_persistence() {
+        let datadir = format!(
+            "{}/floresta_ban_test_{}",
+            std::env::temp_dir().display(),
+            rand::random::<u32>()
+        );
+        std::fs::create_dir_all(&datadir).unwrap();
+
+        let mut original_ban_man = BanMan::new();
+        let ip = test_ip();
+        original_ban_man.add_ban(ip, Some(Duration::from_secs(3600)));
+        assert!(original_ban_man.is_banned(ip));
+
+        original_ban_man
+            .dump_bans(&datadir)
+            .expect("Failed to dump bans to disk");
+
+        let mut loaded_ban_man = BanMan::new();
+
+        loaded_ban_man
+            .load_bans(&datadir)
+            .expect("Failed to load bans from disk");
+
+        assert!(loaded_ban_man.is_banned(ip));
+
+        std::fs::remove_dir_all(&datadir).unwrap();
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/ban_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/ban_man.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Centralized ban management for misbehaving peers.
+//!
+//! Tracks banned IP addresses with per-entry expiry, and persists them to
+//! `bans.json` under the node's data directory so bans survive restarts.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::net::IpAddr;
+use std::path::Path;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+/// Default ban duration in seconds
+const DEFAULT_BAN_DURATION: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
+
+/// Absolute Unix timestamp in seconds.
+type BanExpiry = u64;
+
+/// Current Unix time in seconds, or 0 if the clock is before the epoch.
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[derive(Debug, Default)]
+/// Centralized manager for tracking banned IP addresses.
+pub struct BanMan {
+    banned: HashMap<IpAddr, BanExpiry>,
+    /// Whether `banned` changed since the last successful dump to disk.
+    dirty: bool,
+}
+
+impl BanMan {
+    /// Creates a new empty [`BanMan`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bans an IP address for `duration` from now.
+    ///
+    /// If `duration` is None, the default ban time (24 hours) will be used instead.
+    /// An existing ban is only ever extended; a shorter re-ban is a no-op.
+    pub fn add_ban(&mut self, ip: IpAddr, duration: Option<Duration>) {
+        let ban_duration = duration.unwrap_or(DEFAULT_BAN_DURATION);
+        let ban_until = now_secs().saturating_add(ban_duration.as_secs());
+
+        if self
+            .banned
+            .get(&ip)
+            .is_some_and(|&current| current >= ban_until)
+        {
+            return;
+        }
+
+        self.banned.insert(ip, ban_until);
+        self.dirty = true;
+    }
+
+    /// Returns true if the IP has an unexpired ban.
+    pub fn is_banned(&self, ip: IpAddr) -> bool {
+        self.banned
+            .get(&ip)
+            .is_some_and(|&ban_until| ban_until > now_secs())
+    }
+
+    /// Returns the set of currently banned IPs, sweeping expired bans first.
+    pub fn banned_ips(&mut self) -> Vec<IpAddr> {
+        self.sweep_expired();
+        self.banned.keys().copied().collect()
+    }
+
+    /// Removes every expired ban.
+    fn sweep_expired(&mut self) {
+        let now = now_secs();
+        let before = self.banned.len();
+
+        self.banned.retain(|_, ban_until| *ban_until > now);
+
+        if self.banned.len() != before {
+            self.dirty = true;
+        }
+    }
+
+    /// Dumps the banned ips to `datadir/bans.json`, sweeping expired bans first.
+    ///
+    /// Skipped when nothing changed since the last dump. The file is created if it
+    /// doesn't exist, and overwritten if it does.
+    pub fn dump_bans(&mut self, datadir: impl AsRef<Path>) -> io::Result<()> {
+        self.sweep_expired();
+        if !self.dirty {
+            return Ok(());
+        }
+
+        let bans = serde_json::to_string(&self.banned)?;
+        fs::write(datadir.as_ref().join("bans.json"), bans)?;
+        self.dirty = false;
+
+        Ok(())
+    }
+
+    /// Loads the banned ips from `datadir/bans.json`, sweeping expired bans.
+    ///
+    /// A missing file is treated as an empty ban list (first run). An
+    /// unreadable or malformed file returns an error so the operator
+    /// notices instead of silently starting with no bans.
+    pub fn load_bans(&mut self, datadir: impl AsRef<Path>) -> io::Result<()> {
+        let path = datadir.as_ref().join("bans.json");
+        match fs::read_to_string(&path) {
+            Ok(persisted_bans) => {
+                self.banned = serde_json::from_str(&persisted_bans)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                self.sweep_expired();
+                Ok(())
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::time::Duration;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    use super::BanMan;
+    use super::DEFAULT_BAN_DURATION;
+
+    fn test_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))
+    }
+
+    #[test]
+    fn test_banned_ip_is_detected() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(3600)));
+        assert!(ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_unbanned_ip_is_not_detected() {
+        let ban_man = BanMan::new();
+        let ip = test_ip();
+
+        assert!(!ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_expired_ban_is_not_detected() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        // Insert a ban that already expired (ban_until is in the past)
+        ban_man.banned.insert(ip, 0);
+
+        assert!(!ban_man.is_banned(ip));
+        // is_banned is read-only; only a sweep removes the entry
+        assert!(ban_man.banned.contains_key(&ip));
+    }
+
+    #[test]
+    fn test_sweep_removes_only_expired_bans() {
+        let mut ban_man = BanMan::new();
+        let expired = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let active = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+        ban_man.banned.insert(expired, 0);
+        ban_man.add_ban(active, Some(Duration::from_secs(3600)));
+
+        assert_eq!(ban_man.banned_ips(), vec![active]);
+        assert!(!ban_man.banned.contains_key(&expired));
+    }
+
+    #[test]
+    fn test_shorter_reban_is_noop() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(9999)));
+        let first_ban = *ban_man.banned.get(&ip).unwrap();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(100)));
+        let second_ban = *ban_man.banned.get(&ip).unwrap();
+
+        assert_eq!(first_ban, second_ban);
+    }
+
+    /// Creates a fresh temp datadir and returns it with the `bans.json` path inside it.
+    fn temp_datadir(tag: &str) -> (String, String) {
+        let datadir = format!(
+            "{}/floresta_ban_{tag}_{}",
+            std::env::temp_dir().display(),
+            rand::random::<u32>()
+        );
+        std::fs::create_dir_all(&datadir).unwrap();
+        let path = format!("{datadir}/bans.json");
+        (datadir, path)
+    }
+
+    #[test]
+    fn test_dump_only_when_dirty() {
+        let (datadir, path) = temp_datadir("dirty");
+
+        let mut ban_man = BanMan::new();
+        ban_man.dump_bans(&datadir).unwrap();
+        // Nothing changed since creation, so nothing is written
+        assert!(!std::path::Path::new(&path).exists());
+
+        ban_man.add_ban(test_ip(), Some(Duration::from_secs(3600)));
+        assert!(ban_man.dirty);
+        ban_man.dump_bans(&datadir).unwrap();
+        assert!(!ban_man.dirty);
+        assert!(std::path::Path::new(&path).exists());
+
+        std::fs::remove_dir_all(&datadir).unwrap();
+    }
+
+    #[test]
+    fn test_dump_sweeps_expired_entries() {
+        let (datadir, path) = temp_datadir("sweep");
+        let expired = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        let mut ban_man = BanMan::new();
+        ban_man.add_ban(test_ip(), Some(Duration::from_secs(3600)));
+        ban_man.banned.insert(expired, 0);
+        ban_man.dump_bans(&datadir).unwrap();
+
+        let persisted = std::fs::read_to_string(&path).unwrap();
+        assert!(persisted.contains("192.168.1.1"));
+        assert!(!persisted.contains("10.0.0.1"));
+        assert!(!ban_man.banned.contains_key(&expired));
+
+        std::fs::remove_dir_all(&datadir).unwrap();
+    }
+
+    #[test]
+    fn test_load_malformed_bans_file_errors() {
+        let (datadir, path) = temp_datadir("malformed");
+        std::fs::write(&path, "not json").unwrap();
+
+        let mut ban_man = BanMan::new();
+        let err = ban_man.load_bans(&datadir).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(ban_man.banned.is_empty());
+
+        std::fs::remove_dir_all(&datadir).unwrap();
+    }
+
+    #[test]
+    fn test_default_duration_when_none() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, None);
+
+        // Should be banned for 24 hours from now
+        let ban_until = ban_man.banned.get(&ip).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let expected = now + DEFAULT_BAN_DURATION.as_secs();
+        // Allow 1 second tolerance for test execution time
+        assert!(*ban_until >= expected - 1 && *ban_until <= expected + 1);
+    }
+
+    #[test]
+    fn test_huge_duration_saturates() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, Some(Duration::MAX));
+
+        assert_eq!(*ban_man.banned.get(&ip).unwrap(), u64::MAX);
+        assert!(ban_man.is_banned(ip));
+    }
+
+    #[test]
+    fn test_multiple_ips_banned_independently() {
+        let mut ban_man = BanMan::new();
+        let ip1 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        ban_man.add_ban(ip1, Some(Duration::from_secs(3600)));
+
+        assert!(ban_man.is_banned(ip1));
+        assert!(!ban_man.is_banned(ip2));
+    }
+
+    #[test]
+    fn test_reban_updates_expiry() {
+        let mut ban_man = BanMan::new();
+        let ip = test_ip();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(100)));
+        let first_ban = *ban_man.banned.get(&ip).unwrap();
+
+        ban_man.add_ban(ip, Some(Duration::from_secs(9999)));
+        let second_ban = *ban_man.banned.get(&ip).unwrap();
+
+        assert!(second_ban > first_ban);
+    }
+
+    #[test]
+    fn test_ban_man_persistence() {
+        let (datadir, _) = temp_datadir("persistence");
+
+        let mut original_ban_man = BanMan::new();
+        let ip = test_ip();
+        original_ban_man.add_ban(ip, Some(Duration::from_secs(3600)));
+        assert!(original_ban_man.is_banned(ip));
+
+        original_ban_man
+            .dump_bans(&datadir)
+            .expect("Failed to dump bans to disk");
+
+        let mut loaded_ban_man = BanMan::new();
+
+        loaded_ban_man
+            .load_bans(&datadir)
+            .expect("Failed to load bans from disk");
+
+        assert!(loaded_ban_man.is_banned(ip));
+
+        std::fs::remove_dir_all(&datadir).unwrap();
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -4,6 +4,7 @@ use core::fmt;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use std::io;
+use std::net::IpAddr;
 
 use floresta_chain::BlockchainError;
 use floresta_common::impl_error_from;
@@ -95,6 +96,9 @@ pub enum WireError {
 
     /// Couldn't find the leaf data for a block
     LeafDataNotFound,
+
+    /// Peer is banned
+    PeerBanned(IpAddr),
 }
 
 impl Display for WireError {
@@ -142,6 +146,7 @@ impl Display for WireError {
                 "We tried to work on a block that we don't have a proof for yet"
             ),
             Self::LeafDataNotFound => write!(f, "Couldn't find the leaf data for a block"),
+            Self::PeerBanned(ip) => write!(f, "Peer {ip} is banned"),
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -89,6 +89,7 @@ impl Default for UtreexoNodeConfig {
 }
 
 pub mod address_man;
+pub mod ban_man;
 pub mod bitcoin_socket_addr;
 pub mod block_proof;
 pub mod error;

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -72,7 +72,6 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
-use crate::address_man::AddressState;
 use crate::block_proof::Bitmap;
 use crate::node::InflightBlock;
 use crate::node::InflightRequests;
@@ -183,12 +182,6 @@ where
                 error!("Error while downloading headers from peer={peer} err={e}");
 
                 self.disconnect_and_ban(peer)?;
-
-                let peer = self.peers.get(&peer).unwrap();
-                self.common.address_man.update_set_state(
-                    peer.address.id,
-                    AddressState::Banned(ChainSelector::BAN_TIME),
-                );
             }
         }
 
@@ -715,10 +708,6 @@ where
     fn ban_peers_on_tip(&mut self, tip: BlockHash) -> Result<(), WireError> {
         for peer in self.common.peers.clone() {
             if self.context.tip_cache.get(&peer.0).copied().eq(&Some(tip)) {
-                self.address_man.update_set_state(
-                    peer.1.address.id,
-                    AddressState::Banned(ChainSelector::BAN_TIME),
-                );
                 self.disconnect_and_ban(peer.0)?;
             }
         }

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -73,7 +73,6 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
-use crate::address_man::AddressState;
 use crate::block_proof::Bitmap;
 use crate::node::InflightBlock;
 use crate::node::InflightRequests;
@@ -184,12 +183,6 @@ where
                 error!("Error while downloading headers from peer={peer} err={e}");
 
                 self.disconnect_and_ban(peer)?;
-
-                let peer = self.peers.get(&peer).unwrap();
-                self.common.address_man.update_set_state(
-                    peer.address.id,
-                    AddressState::Banned(ChainSelector::BAN_TIME),
-                );
             }
         }
 
@@ -716,10 +709,6 @@ where
     fn ban_peers_on_tip(&mut self, tip: BlockHash) -> Result<(), WireError> {
         for peer in self.common.peers.clone() {
             if self.context.tip_cache.get(&peer.0).copied().eq(&Some(tip)) {
-                self.address_man.update_set_state(
-                    peer.1.address.id,
-                    AddressState::Banned(ChainSelector::BAN_TIME),
-                );
                 self.disconnect_and_ban(peer.0)?;
             }
         }

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -474,6 +474,7 @@ where
 
     pub(crate) fn init_peers(&mut self) -> Result<(), WireError> {
         let anchors = self.common.address_man.start_addr_man(&self.common.datadir);
+        self.common.ban_man.load_bans(&self.common.datadir)?;
         let enough_addresses = self.common.address_man.enough_addresses();
 
         if !self.config.disable_dns_seeds && !enough_addresses {

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -114,6 +114,13 @@ where
             return Err(WireError::NoAddressesAvailable);
         };
 
+        let net_address = peer_address.get_net_address();
+        if let Some(ip) = net_address {
+            if self.ban_man.is_banned(ip) {
+                return Err(WireError::PeerBanned(ip));
+            }
+        }
+
         debug!("Attempting connection with address={peer_address:?} kind={conn_kind:?}",);
 
         let now = SystemTime::now()

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -115,6 +115,13 @@ where
             return Err(WireError::NoAddressesAvailable);
         };
 
+        let net_address = peer_address.get_net_address();
+        if let Some(ip) = net_address {
+            if self.ban_man.is_banned(ip) {
+                return Err(WireError::PeerBanned(ip));
+            }
+        }
+
         debug!("Attempting connection with address={peer_address:?} kind={conn_kind:?}",);
 
         let now = SystemTime::now()

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -464,6 +464,7 @@ where
 
     pub(crate) fn init_peers(&mut self) -> Result<(), WireError> {
         let anchors = self.common.address_man.start_addr_man(&self.common.datadir);
+        self.common.ban_man.load_bans(&self.common.datadir)?;
         let enough_addresses = self.common.address_man.enough_addresses();
 
         if !self.config.disable_dns_seeds && !enough_addresses {

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -48,6 +48,7 @@ use tracing::info;
 use super::UtreexoNodeConfig;
 use super::address_man::AddressMan;
 use super::address_man::LocalAddress;
+use super::ban_man::BanMan;
 use super::block_proof::Bitmap;
 use super::error::WireError;
 use super::node_context::NodeContext;
@@ -269,6 +270,7 @@ pub struct NodeCommon<Chain: ChainBackend> {
     pub(crate) peer_by_service: HashMap<ServiceFlags, Vec<u32>>,
     pub(crate) max_banscore: u32,
     pub(crate) address_man: AddressMan,
+    pub(crate) ban_man: BanMan,
     pub(crate) added_peers: Vec<AddedPeerInfo>,
 
     // 3. Internal Communication
@@ -387,6 +389,7 @@ where
                 node_rx,
                 node_tx,
                 address_man,
+                ban_man: BanMan::new(),
                 last_tip_update: Instant::now(),
                 last_connection: Instant::now(),
                 last_peer_db_dump: Instant::now(),

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -337,7 +337,6 @@ impl<T, Chain: ChainBackend> DerefMut for UtreexoNode<Chain, T> {
 pub enum PeerStatus {
     Awaiting,
     Ready,
-    Banned,
 }
 
 impl<T, Chain> UtreexoNode<Chain, T>

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -48,6 +48,7 @@ use tracing::info;
 use super::UtreexoNodeConfig;
 use super::address_man::AddressMan;
 use super::address_man::LocalAddress;
+use super::ban_man::BanMan;
 use super::block_proof::Bitmap;
 use super::error::WireError;
 use super::node_context::NodeContext;
@@ -272,6 +273,7 @@ pub struct NodeCommon<Chain: ChainBackend> {
     pub(crate) peer_by_service: HashMap<ServiceFlags, Vec<u32>>,
     pub(crate) max_banscore: u32,
     pub(crate) address_man: AddressMan,
+    pub(crate) ban_man: BanMan,
     pub(crate) added_peers: Vec<AddedPeerInfo>,
 
     // 3. Internal Communication
@@ -390,6 +392,7 @@ where
                 node_rx,
                 node_tx,
                 address_man,
+                ban_man: BanMan::new(),
                 last_tip_update: Instant::now(),
                 last_connection: Instant::now(),
                 last_peer_db_dump: Instant::now(),

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -340,7 +340,6 @@ impl<T, Chain: ChainBackend> DerefMut for UtreexoNode<Chain, T> {
 pub enum PeerStatus {
     Awaiting,
     Ready,
-    Banned,
 }
 
 impl<T, Chain> UtreexoNode<Chain, T>

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -30,7 +30,6 @@ use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::block_proof::Bitmap;
-use crate::node::running_ctx::RunningNode;
 use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
 use crate::node_handle::NodeResponse;
@@ -204,16 +203,6 @@ where
         Ok(())
     }
 
-    // === PEER LIFECYCLE ===
-
-    fn is_peer_good(peer: &LocalPeerView, needs: ServiceFlags) -> bool {
-        if peer.state == PeerStatus::Banned {
-            return false;
-        }
-
-        peer.services.has(needs)
-    }
-
     pub(crate) fn handle_peer_ready(
         &mut self,
         peer: u32,
@@ -283,15 +272,22 @@ where
             version.id, version.user_agent, version.blocks, version.services
         );
 
+        // Check ban status before taking a mutable borrow on peers
+        let peer_ip = self
+            .peers
+            .get(&peer)
+            .and_then(|p| p.address.get_net_address());
+        let is_banned = peer_ip.is_some_and(|ip| self.ban_man.is_banned(ip));
+
         if let Some(peer_data) = self.common.peers.get_mut(&peer) {
             peer_data.services = version.services;
             peer_data.user_agent.clone_from(&version.user_agent);
             peer_data.height = version.blocks;
             peer_data.transport_protocol = version.transport_protocol;
 
-            // If this peer doesn't have basic services, we disconnect it
+            // If this peer is banned or doesn't have basic services, we disconnect it
             if let ConnectionKind::Regular(needs) = version.kind {
-                if !Self::is_peer_good(peer_data, needs) {
+                if is_banned || !peer_data.services.has(needs) {
                     info!(
                         "Disconnecting peer {peer} for not having the required services. has={} needs={}",
                         peer_data.services, needs
@@ -492,10 +488,6 @@ where
                     self.address_man
                         .update_set_state(idx, AddressState::Failed(now));
                 }
-                PeerStatus::Banned => {
-                    self.address_man
-                        .update_set_state(idx, AddressState::Banned(RunningNode::BAN_TIME));
-                }
             }
         }
 
@@ -569,8 +561,14 @@ where
                 return Ok(());
             }
 
-            // `handle_disconnection` will mark the address as banned when `Peer` object return
-            peer.state = PeerStatus::Banned;
+            let peer_addr = &peer.address;
+            if let Some(ip) = peer_addr.get_net_address() {
+                self.ban_man.add_ban(ip, None);
+                if let Err(e) = self.ban_man.dump_bans(&self.datadir) {
+                    warn!("Failed to persist ban for {ip}: {e:?}");
+                }
+                self.address_man.unmark_good_by_ip(ip);
+            }
         }
 
         self.send_to_peer(peer, NodeRequest::Shutdown)?;
@@ -752,6 +750,8 @@ where
     }
 
     pub(crate) fn save_peers(&self) -> Result<(), WireError> {
+        self.ban_man.dump_bans(&self.datadir)?;
+
         self.address_man
             .dump_peers(&self.datadir)
             .map_err(WireError::Io)

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -31,7 +31,6 @@ use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::block_proof::Bitmap;
-use crate::node::running_ctx::RunningNode;
 use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
 use crate::node_handle::NodeResponse;
@@ -205,16 +204,6 @@ where
         Ok(())
     }
 
-    // === PEER LIFECYCLE ===
-
-    fn is_peer_good(peer: &LocalPeerView, needs: ServiceFlags) -> bool {
-        if peer.state == PeerStatus::Banned {
-            return false;
-        }
-
-        peer.services.has(needs)
-    }
-
     pub(crate) fn handle_peer_ready(
         &mut self,
         peer: u32,
@@ -284,6 +273,13 @@ where
             version.id, version.user_agent, version.blocks, version.services
         );
 
+        // Check ban status before taking a mutable borrow on peers
+        let peer_ip = self
+            .peers
+            .get(&peer)
+            .and_then(|p| p.address.get_net_address());
+        let is_banned = peer_ip.is_some_and(|ip| self.ban_man.is_banned(ip));
+
         if let Some(peer_data) = self.common.peers.get_mut(&peer) {
             peer_data.services = version.services;
             peer_data.user_agent.clone_from(&version.user_agent);
@@ -291,9 +287,9 @@ where
             peer_data.time_offset = version.time_offset;
             peer_data.transport_protocol = version.transport_protocol;
 
-            // If this peer doesn't have basic services, we disconnect it
+            // If this peer is banned or doesn't have basic services, we disconnect it
             if let ConnectionKind::Regular(needs) = version.kind {
-                if !Self::is_peer_good(peer_data, needs) {
+                if is_banned || !peer_data.services.has(needs) {
                     info!(
                         "Disconnecting peer {peer} for not having the required services. has={} needs={}",
                         peer_data.services, needs
@@ -494,10 +490,6 @@ where
                     self.address_man
                         .update_set_state(idx, AddressState::Failed(now));
                 }
-                PeerStatus::Banned => {
-                    self.address_man
-                        .update_set_state(idx, AddressState::Banned(RunningNode::BAN_TIME));
-                }
             }
         }
 
@@ -571,8 +563,14 @@ where
                 return Ok(());
             }
 
-            // `handle_disconnection` will mark the address as banned when `Peer` object return
-            peer.state = PeerStatus::Banned;
+            let peer_addr = &peer.address;
+            if let Some(ip) = peer_addr.get_net_address() {
+                self.ban_man.add_ban(ip, None);
+                if let Err(e) = self.common.ban_man.dump_bans(&self.common.datadir) {
+                    warn!("Failed to persist ban for {ip}: {e:?}");
+                }
+                self.address_man.unmark_good_by_ip(ip);
+            }
         }
 
         self.send_to_peer(peer, NodeRequest::Shutdown)?;
@@ -753,7 +751,9 @@ where
         Ok(())
     }
 
-    pub(crate) fn save_peers(&self) -> Result<(), WireError> {
+    pub(crate) fn save_peers(&mut self) -> Result<(), WireError> {
+        self.common.ban_man.dump_bans(&self.common.datadir)?;
+
         self.address_man
             .dump_peers(&self.datadir)
             .map_err(WireError::Io)

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -424,7 +424,7 @@ where
 
         // Rework our address database
         periodic_job!(
-            self.context.last_address_rearrange => self.address_man.rearrange_buckets(),
+            self.context.last_address_rearrange => self.common.address_man.rearrange_buckets(&self.common.ban_man),
             RunningNode::ADDRESS_REARRANGE_INTERVAL,
             no_log,
         );

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -434,7 +434,7 @@ where
 
         // Rework our address database
         periodic_job!(
-            self.context.last_address_rearrange => self.address_man.rearrange_buckets(),
+            self.context.last_address_rearrange => self.common.address_man.rearrange_buckets(&mut self.common.ban_man),
             RunningNode::ADDRESS_REARRANGE_INTERVAL,
             no_log,
         );

--- a/fuzz/fuzz_targets/addrman.rs
+++ b/fuzz/fuzz_targets/addrman.rs
@@ -8,6 +8,7 @@ use bitcoin::p2p::address::AddrV2Message;
 use floresta_wire::address_man::AddressMan;
 use floresta_wire::address_man::LocalAddress;
 use floresta_wire::address_man::ReachableNetworks;
+use floresta_wire::ban_man::BanMan;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -37,5 +38,5 @@ fuzz_target!(|data: &[u8]| {
     for flag in available_flags {
         address_man.get_address_to_connect(flag, false);
     }
-    address_man.rearrange_buckets();
+    address_man.rearrange_buckets(&BanMan::new());
 });

--- a/fuzz/fuzz_targets/addrman.rs
+++ b/fuzz/fuzz_targets/addrman.rs
@@ -8,6 +8,7 @@ use bitcoin::p2p::address::AddrV2Message;
 use floresta_wire::address_man::AddressMan;
 use floresta_wire::address_man::LocalAddress;
 use floresta_wire::address_man::ReachableNetworks;
+use floresta_wire::ban_man::BanMan;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -37,5 +38,5 @@ fuzz_target!(|data: &[u8]| {
     for flag in available_flags {
         address_man.get_address_to_connect(flag, false);
     }
-    address_man.rearrange_buckets();
+    address_man.rearrange_buckets(&mut BanMan::new());
 });


### PR DESCRIPTION
### Description and Notes

Introduces BanMan for centralized ban management and makes it the single source of truth for bans. Removes AddressState::Banned and replaces scattered ban logic across AddressMan and peer_man.

**Why**

Before this PR, "is this peer banned?" was answered in several different places, each keeping its own copy of the answer. They could disagree, and a ban could quietly expire on the next housekeeping pass. This PR moves all of that into one place, BanMan, modeled on how Bitcoin Core does it.

**What BanMan does**

- Banning a peer records how long the ban lasts. Banning the same peer again can only make the ban longer, never shorter.
- Checking whether a peer is banned is a simple lookup that never modifies anything.
- Expired bans are cleaned up in one sweep whenever the list is loaded from disk, saved to disk, or read in full. This keeps both memory and the saved file from filling up with dead entries.
- Bans are saved to `bans.json` right when a peer is banned, and again periodically, but only if something actually changed since the last save.
- If `bans.json` on disk is corrupted, the node reports an error instead of silently starting with no bans.

**How the rest of the node uses it**

- The address manager asks BanMan for the banned list during its periodic housekeeping and marks those addresses as failed, so they are never picked for a new connection. The address is kept, not deleted, so the node still remembers it once the ban expires.
- If a banned peer tries to connect between housekeeping passes, the connection is rejected immediately.

**Upgrading from an older version**

Address books (`peers.json`) written before this PR may still contain the old "banned" marker. Those entries are read fine and treated as never tried, so nobody loses their saved peers on upgrade.

This PR is a consolidation of #892 and #912.
PR #899 tries to introduce support for CIDR/Subnet into BanMan

### To verify changes

- `cargo test -p floresta-wire`

Closes #820.
