### PR TITLE
ci: Check signed commit

### DIFF
--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -1,0 +1,30 @@
+name: Signed Commits
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  signatures:
+    name: Assert all commits are signed
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check commit signatures
+        run: |
+          TOTAL=$(git log --pretty='tformat:%H' origin/master..HEAD | wc -l | tr -d ' ')
+          UNSIGNED=$(git log --pretty='tformat:%H %G?' origin/master..HEAD | grep " N$" | wc -l | tr -d ' ')
+          if [ "$UNSIGNED" -gt 0 ]; then
+            echo "Unsigned commits in this branch [$UNSIGNED/$TOTAL]"
+            exit 1
+          else
+            echo "All commits in this branch are signed [$TOTAL/$TOTAL]"
+          fi


### PR DESCRIPTION
### Description and Notes
Issue: #900.
Adds a new `signed-commits.yml` workflow that checks if the commits in a branch are signed.
The check runs on every push and pull request, and only inspects commits introduced on top of origin/master. Fails if any unsigned commit is found.
<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?
Check out https://github.com/shinigami-777/Floresta/actions/runs/23922916930/job/69773281458. 