### PR TITLE
fix(chain,compact-filters): replace Debug delegation in Display impls with per-variant messages

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -27,7 +27,7 @@ use crate::extensions::ChainWorkOverflow;
 use crate::proof_util::UtreexoLeafError;
 use crate::pruned_utreexo::chain_state_builder::BlockchainBuilderError;
 
-pub trait DatabaseError: Debug + Send + Sync + 'static {}
+pub trait DatabaseError: Debug + Display + Send + Sync + 'static {}
 
 #[derive(Debug)]
 /// Errors that can happen whilst interacting with the local blockchain.
@@ -91,7 +91,7 @@ impl Display for BlockchainError {
                 "Failed to reconstruct a scriptpubkey from Compact Leaf Data: {e}"
             ),
             Self::Database(e) => {
-                write!(f, "Error whilst interacting with the the ChainState: {e:?}")
+                write!(f, "Error whilst interacting with the the ChainState: {e}")
             }
             Self::ChainNotInitialized => write!(f, "The ChainState is not initialized"),
             Self::InvalidTip(e) => write!(f, "The ChainState's tip is invalid: {e}"),


### PR DESCRIPTION
### Description

`BlockchainError` and `IterableFilterStoreError` both implement `Display` by delegating to `Debug`:

```rust
// floresta-chain: BlockchainError
impl Display for BlockchainError {
    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
        write!(f, "{self:?}")
    }
}

// floresta-compact-filters: IterableFilterStoreError
impl Display for IterableFilterStoreError {
    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
        Debug::fmt(self, f)
    }
}
```

This produces machine-oriented output that is unsuitable for user-facing error messages and cannot be composed with `thiserror`'s `#[error(transparent)]` in a meaningful way.

### Changes

Replaced both with explicit `match` arms producing human-readable messages for each variant. Inner types that already implement `Display` are formatted with `{}`, while `StumpError` and `Box<dyn DatabaseError>` (which only implement `Debug`) continue to use `{:?}`.

This is complementary to PR #879, which adds `Display` impls to error types that have *none*. This PR improves types that already *have* a `Display` impl but delegate it to `Debug`.

### Files changed

- `crates/floresta-chain/src/pruned_utreexo/error.rs` — `BlockchainError` (15 variants)
- `crates/floresta-compact-filters/src/lib.rs` — `IterableFilterStoreError` (4 variants)

Contributes to #667.