### PR TITLE
Avoid panic during node shutdown

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -323,7 +323,10 @@ where
 
         if *self.kill_signal.read().await {
             self.shutdown();
-            stop_signal.send(()).unwrap();
+            match stop_signal.send(()) {
+                Ok(_) => {}
+                Err(e) => error!("Stop signal receiver already dropped: {e:?}"),
+            }
             return;
         }
 


### PR DESCRIPTION
### Description and Notes
Fixes issue #822 

This PR fixes a panic that occurs during node shutdown when sending a stop signal through a channel whose receiver has already been dropped.

To fix this , I have replace the unwrap with match block. I used the error! macro to handle the failure case safely and exits without causing any panic.

### How to verify the changes you have done?

1. Run `cargo run --package florestad` and let it begin block validation.
2. Interrupt the process using`CTRL+C` while it is processing blocks.
3. Observe that:
   - The node shuts down cleanly.
   - No panic occurs.
   - Any dropped receiver case is handled without crashing.
