### PR TITLE
Fix/rpc getblockchaininfo core compliance

### DIFF
--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -345,6 +345,10 @@ mod tests {
     impl BlockchainInterface for MockBlockchainInterface {
         type Error = MockBlockchainError;
 
+        fn size_on_disk(&self) -> Result<u64, Self::Error> {
+            unimplemented!("MockBlockchainInterface has no on-disk presence")
+        }
+
         fn get_block_header(&self, hash: &BlockHash) -> Result<Header, Self::Error> {
             self.headers
                 .get(hash)

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1046,6 +1046,10 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         read_lock!(self).acc.to_owned()
     }
 
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        Ok(read_lock!(self).chainstore.size_on_disk()?)
+    }
+
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error> {
         let fork_point = self.find_fork_point(&self.get_block_header(&block)?)?;
         Ok(fork_point.block_hash())

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -72,6 +72,13 @@ pub trait ChainStore {
     /// If you're using a database that already checks for integrity by itself,
     /// this can safely be a no-op.
     fn check_integrity(&self) -> Result<(), Self::Error>;
+
+    /// Returns the total size on disk, in bytes, of the data this store persists.
+    ///
+    /// The returned value is the sum of the sizes of each backing file managed by
+    /// this store. Implementations should not include the size of any enclosing
+    /// directory or unrelated data.
+    fn size_on_disk(&self) -> Result<u64, Self::Error>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1131,6 +1131,16 @@ impl ChainStore for FlatChainStore {
         unsafe { self.do_flush() }
     }
 
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        let headers_size = self.headers.len() as u64;
+        let metadata_size = self.metadata.len() as u64;
+        let block_index_size = self.block_index.index_map.len() as u64;
+        let fork_headers_size = self.fork_headers.len() as u64;
+        let accumulator_size = self.accumulator_file.metadata()?.len();
+
+        Ok(headers_size + metadata_size + block_index_size + fork_headers_size + accumulator_size)
+    }
+
     fn save_roots_for_block(&mut self, roots: Vec<u8>, height: u32) -> Result<(), Self::Error> {
         let index = Index::new(height)?;
 
@@ -1689,6 +1699,23 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_size_on_disk() {
+        let store = get_test_chainstore(None).unwrap();
+
+        let size = store.size_on_disk().unwrap();
+
+        // Sum of the four mmap regions plus the accumulator file. At init the accumulator
+        // file is empty, so the total should equal the sum of the four mapped files.
+        let expected = (store.headers.len()
+            + store.metadata.len()
+            + store.block_index.index_map.len()
+            + store.fork_headers.len()) as u64;
+
+        assert_eq!(size, expected);
+        assert!(size > 0);
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1401,6 +1401,7 @@ mod tests {
     use super::FlatChainStore;
     use super::FlatChainStoreConfig;
     use super::FlatChainstoreError;
+    use super::HashedDiskHeader;
     use super::Index;
     use crate::AssumeValidArg;
     use crate::BestChain;
@@ -1701,21 +1702,79 @@ mod tests {
         }
     }
 
+    fn make_sized_store(
+        block_index_size: usize,
+        headers_file_size: usize,
+        fork_file_size: usize,
+    ) -> FlatChainStore {
+        let test_id = rand::random::<u64>();
+        let config = FlatChainStoreConfig {
+            block_index_size: Some(block_index_size),
+            headers_file_size: Some(headers_file_size),
+            fork_file_size: Some(fork_file_size),
+            cache_size: Some(10),
+            file_permission: Some(0o660),
+            path: format!("./tmp-db/{test_id}/").into(),
+        };
+        FlatChainStore::new(config).unwrap()
+    }
+
     #[test]
     fn test_size_on_disk() {
-        let store = get_test_chainstore(None).unwrap();
+        // Baseline matches the formula in `size_on_disk`.
+        let mut store = make_sized_store(32_768, 32_768, 16_384);
+        let baseline = (32_768 * size_of::<u32>()
+            + 32_768 * size_of::<HashedDiskHeader>()
+            + 16_384 * size_of::<HashedDiskHeader>()
+            + size_of::<Metadata>()) as u64;
+        assert_eq!(store.size_on_disk().unwrap(), baseline);
 
-        let size = store.size_on_disk().unwrap();
+        // Vary each preallocated field; check the per-field delta so any
+        // dropped or miscounted summand in `size_on_disk` fails here.
+        let bigger_index = make_sized_store(65_536, 32_768, 16_384);
+        assert_eq!(
+            bigger_index.size_on_disk().unwrap() - baseline,
+            (32_768 * size_of::<u32>()) as u64,
+        );
 
-        // Sum of the four mmap regions plus the accumulator file. At init the accumulator
-        // file is empty, so the total should equal the sum of the four mapped files.
-        let expected = (store.headers.len()
-            + store.metadata.len()
-            + store.block_index.index_map.len()
-            + store.fork_headers.len()) as u64;
+        let bigger_headers = make_sized_store(32_768, 65_536, 16_384);
+        assert_eq!(
+            bigger_headers.size_on_disk().unwrap() - baseline,
+            (32_768 * size_of::<HashedDiskHeader>()) as u64,
+        );
 
-        assert_eq!(size, expected);
-        assert!(size > 0);
+        let bigger_fork = make_sized_store(32_768, 32_768, 32_768);
+        assert_eq!(
+            bigger_fork.size_on_disk().unwrap() - baseline,
+            (16_384 * size_of::<HashedDiskHeader>()) as u64,
+        );
+
+        // Accumulator file is the only dynamic component; grows by payload.
+        let genesis = genesis_block(Network::Regtest);
+        store
+            .save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))
+            .unwrap();
+        store.update_block_index(0, genesis.block_hash()).unwrap();
+
+        let acc = vec![0xab; 64];
+        store.save_roots_for_block(acc.clone(), 0).unwrap();
+        assert_eq!(store.size_on_disk().unwrap(), baseline + acc.len() as u64);
+
+        // Cumulative append at height 1.
+        let mut next = genesis.header;
+        next.prev_blockhash = genesis.block_hash();
+        store
+            .save_header(&DiskBlockHeader::FullyValid(next, 1))
+            .unwrap();
+        store.update_block_index(1, next.block_hash()).unwrap();
+
+        let acc2 = vec![0xcd; 32];
+        let pre_second = store.size_on_disk().unwrap();
+        store.save_roots_for_block(acc2.clone(), 1).unwrap();
+        assert_eq!(
+            store.size_on_disk().unwrap(),
+            pre_second + acc2.len() as u64,
+        );
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -77,6 +77,7 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
+use std::fs;
 use std::fs::DirBuilder;
 use std::fs::File;
 use std::fs::OpenOptions;
@@ -101,6 +102,7 @@ use index_impl::Index;
 use lru::LruCache;
 use memmap2::MmapMut;
 use memmap2::MmapOptions;
+use tracing::debug;
 use tracing::info;
 use twox_hash::XxHash3_64;
 
@@ -621,6 +623,9 @@ pub struct FlatChainStore {
     /// The file containing the accumulators for each blocks
     accumulator_file: File,
 
+    /// Backing-file directory; needed by `size_on_disk` since `MmapMut` drops the file handle.
+    datadir: PathBuf,
+
     /// A LRU cache for the last n blocks we've touched
     cache: Mutex<LruCache<BlockHash, DiskBlockHeader>>,
 }
@@ -710,6 +715,7 @@ impl FlatChainStore {
             metadata,
             block_index: BlockIndex::new(index_map, index_size),
             fork_headers,
+            datadir: datadir.to_path_buf(),
             cache: LruCache::new(cache_size).into(),
         })
     }
@@ -781,6 +787,7 @@ impl FlatChainStore {
             metadata: metadata_file,
             block_index: BlockIndex::new(index_map, metadata.index_capacity),
             fork_headers,
+            datadir: datadir.clone(),
             cache: LruCache::new(cache_size).into(),
         })
     }
@@ -1132,13 +1139,26 @@ impl ChainStore for FlatChainStore {
     }
 
     fn size_on_disk(&self) -> Result<u64, Self::Error> {
-        let headers_size = self.headers.len() as u64;
-        let metadata_size = self.metadata.len() as u64;
-        let block_index_size = self.block_index.index_map.len() as u64;
-        let fork_headers_size = self.fork_headers.len() as u64;
-        let accumulator_size = self.accumulator_file.metadata()?.len();
+        let metadata = unsafe { self.get_metadata() }?;
+        let header_size = size_of::<HashedDiskHeader>() as u64;
 
-        Ok(headers_size + metadata_size + block_index_size + fork_headers_size + accumulator_size)
+        // Fixed-size record files: compute from bookkeeping.
+        let mut total = (u64::from(metadata.depth) + 1) * header_size
+            + u64::from(metadata.fork_count) * header_size;
+
+        // Variable-structure files: report apparent (preallocated) length.
+        for name in ["blocks_index.bin", "metadata.bin", "accumulators.bin"] {
+            let path = self.datadir.join(name);
+            match fs::metadata(&path) {
+                Ok(meta) => total += meta.len(),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    debug!("size_on_disk: {name} not found, skipping");
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        Ok(total)
     }
 
     fn save_roots_for_block(&mut self, roots: Vec<u8>, height: u32) -> Result<(), Self::Error> {
@@ -1721,59 +1741,32 @@ mod tests {
 
     #[test]
     fn test_size_on_disk() {
-        // Baseline matches the formula in `size_on_disk`.
-        let mut store = make_sized_store(32_768, 32_768, 16_384);
-        let baseline = (32_768 * size_of::<u32>()
-            + 32_768 * size_of::<HashedDiskHeader>()
-            + 16_384 * size_of::<HashedDiskHeader>()
-            + size_of::<Metadata>()) as u64;
-        assert_eq!(store.size_on_disk().unwrap(), baseline);
+        // Size is derived from `depth` and `fork_count` in metadata, plus the
+        // apparent length of the variable-structure files.
+        const BLOCK_INDEX_SIZE: usize = 32_768;
+        const HEADERS_FILE_SIZE: usize = 32_768;
+        const FORK_FILE_SIZE: usize = 16_384;
 
-        // Vary each preallocated field; check the per-field delta so any
-        // dropped or miscounted summand in `size_on_disk` fails here.
-        let bigger_index = make_sized_store(65_536, 32_768, 16_384);
-        assert_eq!(
-            bigger_index.size_on_disk().unwrap() - baseline,
-            (32_768 * size_of::<u32>()) as u64,
-        );
+        let mut store = make_sized_store(BLOCK_INDEX_SIZE, HEADERS_FILE_SIZE, FORK_FILE_SIZE);
+        let header_size = size_of::<HashedDiskHeader>() as u64;
+        let initial = store.size_on_disk().unwrap();
 
-        let bigger_headers = make_sized_store(32_768, 65_536, 16_384);
-        assert_eq!(
-            bigger_headers.size_on_disk().unwrap() - baseline,
-            (32_768 * size_of::<HashedDiskHeader>()) as u64,
-        );
-
-        let bigger_fork = make_sized_store(32_768, 32_768, 32_768);
-        assert_eq!(
-            bigger_fork.size_on_disk().unwrap() - baseline,
-            (16_384 * size_of::<HashedDiskHeader>()) as u64,
-        );
-
-        // Accumulator file is the only dynamic component; grows by payload.
+        // Bumping depth from 0 to 1 should add exactly one header record.
         let genesis = genesis_block(Network::Regtest);
         store
-            .save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))
+            .save_height(&BestChain {
+                best_block: genesis.block_hash(),
+                depth: 1,
+                validation_index: genesis.block_hash(),
+                alternative_tips: vec![],
+            })
             .unwrap();
-        store.update_block_index(0, genesis.block_hash()).unwrap();
 
-        let acc = vec![0xab; 64];
-        store.save_roots_for_block(acc.clone(), 0).unwrap();
-        assert_eq!(store.size_on_disk().unwrap(), baseline + acc.len() as u64);
-
-        // Cumulative append at height 1.
-        let mut next = genesis.header;
-        next.prev_blockhash = genesis.block_hash();
-        store
-            .save_header(&DiskBlockHeader::FullyValid(next, 1))
-            .unwrap();
-        store.update_block_index(1, next.block_hash()).unwrap();
-
-        let acc2 = vec![0xcd; 32];
-        let pre_second = store.size_on_disk().unwrap();
-        store.save_roots_for_block(acc2.clone(), 1).unwrap();
+        let after = store.size_on_disk().unwrap();
         assert_eq!(
-            store.size_on_disk().unwrap(),
-            pre_second + acc2.len() as u64,
+            after,
+            initial + header_size,
+            "size should grow by exactly one HashedDiskHeader when depth increments",
         );
     }
 

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -128,6 +128,9 @@ pub trait BlockchainInterface {
 
     /// Returns the amount of [`Work`] associated with a given chain tip
     fn get_work(&self, tip: BlockHash) -> Result<Work, Self::Error>;
+
+    /// Returns the total size on disk, in bytes, of the chain data persisted by this backend.
+    fn size_on_disk(&self) -> Result<u64, Self::Error>;
 }
 
 /// [UpdatableChainstate] is a contract that a is expected from a chainstate
@@ -360,6 +363,10 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
 
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error> {
         T::get_fork_point(self, block)
+    }
+
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        T::size_on_disk(self)
     }
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -337,6 +337,10 @@ impl BlockchainInterface for PartialChainState {
         self.inner().current_acc.clone()
     }
 
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        unimplemented!("partialChainState has no on-disk presence")
+    }
+
     fn get_height(&self) -> Result<u32, Self::Error> {
         Ok(self.inner().current_height)
     }

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -6,6 +6,7 @@ use bitcoin::Address;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::MerkleBlock;
+use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitcoin::Script;
 use bitcoin::ScriptBuf;
@@ -21,6 +22,7 @@ use corepc_types::v29::GetTxOut;
 use corepc_types::v30::DeploymentInfo;
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
+use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
 use floresta_chain::buried_deployments_for;
 use floresta_chain::extensions::HeaderExt;
@@ -31,7 +33,6 @@ use serde_json::json;
 use tracing::debug;
 
 use super::res::GetBlockHeaderRes;
-use super::res::GetBlockchainInfoRes;
 use super::res::GetTxOutProof;
 use super::res::jsonrpc_interface::JsonRpcError;
 use super::server::RpcChain;
@@ -245,7 +246,10 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     }
 
     // getblockchaininfo
-    pub(super) fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes, JsonRpcError> {
+    //
+    // `headers` tracks the best-known header tip; `blocks` tracks the validated
+    // tip. They can diverge mid-IBD and coincide once sync completes.
+    pub(super) fn get_blockchain_info(&self) -> Result<GetBlockchainInfo, JsonRpcError> {
         let (height, hash) = self
             .chain
             .get_best_block()
@@ -254,49 +258,61 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .chain
             .get_validation_index()
             .map_err(|_| JsonRpcError::Chain)?;
-        let ibd = self.chain.is_in_ibd();
+        let initial_block_download = self.chain.is_in_ibd();
         let latest_header = self
             .chain
             .get_block_header(&hash)
             .map_err(|_| JsonRpcError::Chain)?;
-        let latest_work = latest_header
+        let chain_work = latest_header
             .calculate_chain_work(&self.chain)?
             .to_string_hex();
-        let latest_block_time = latest_header.time;
-        let leaf_count = self.chain.acc().leaves as u32;
-        let root_count = self.chain.acc().roots.len() as u32;
-        let root_hashes = self
-            .chain
-            .acc()
-            .roots
-            .into_iter()
-            .map(|r| r.to_string())
-            .collect();
 
-        let validated_blocks = self
-            .chain
-            .get_validation_index()
-            .map_err(|_| JsonRpcError::Chain)?;
-
-        let validated_percentage = if height != 0 {
-            validated_blocks as f32 / height as f32
+        let verification_progress = if height != 0 {
+            f64::from(validated) / f64::from(height)
         } else {
             0.0
         };
 
-        Ok(GetBlockchainInfoRes {
-            best_block: hash.to_string(),
-            height,
-            ibd,
-            validated,
-            latest_work,
-            latest_block_time,
-            leaf_count,
-            root_count,
-            root_hashes,
-            chain: self.network.to_string(),
-            difficulty: latest_header.difficulty(self.chain.get_params()) as u64,
-            progress: validated_percentage,
+        let blocks = i64::from(validated);
+        let headers = i64::from(height);
+        let best_block_hash = hash.to_string();
+        let bits = latest_header.get_bits_hex();
+        let target = latest_header.get_target_hex();
+        let difficulty = latest_header.get_difficulty();
+        let time = i64::from(latest_header.time);
+        let median_time = i64::from(latest_header.calculate_median_time_past(&self.chain)?);
+        let size_on_disk = self.chain.size_on_disk().map_err(|_| JsonRpcError::Chain)?;
+        let prune_height = Some(blocks + 1);
+
+        let chain = match self.network {
+            Network::Bitcoin => "main",
+            Network::Testnet => "test",
+            Network::Testnet4 => "testnet4",
+            Network::Signet => "signet",
+            Network::Regtest => "regtest",
+        }
+        .to_string();
+
+        Ok(GetBlockchainInfo {
+            chain,
+            blocks,
+            headers,
+            best_block_hash,
+            bits,
+            target,
+            difficulty,
+            time,
+            median_time,
+            verification_progress,
+            initial_block_download,
+            chain_work,
+            size_on_disk,
+            pruned: true,
+            prune_height,
+            automatic_pruning: Some(true),
+            prune_target_size: Some(0),
+            signet_challenge: None,
+            warnings: vec![],
         })
     }
 

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -506,21 +506,6 @@ pub mod jsonrpc_interface {
         }
     }
 }
-#[derive(Deserialize, Serialize)]
-pub struct GetBlockchainInfoRes {
-    pub best_block: String,
-    pub height: u32,
-    pub ibd: bool,
-    pub validated: u32,
-    pub latest_work: String,
-    pub latest_block_time: u32,
-    pub leaf_count: u32,
-    pub root_count: u32,
-    pub root_hashes: Vec<String>,
-    pub chain: String,
-    pub progress: f32,
-    pub difficulty: u64,
-}
 
 /// A confidence enum to auxiliate rescan timestamp values.
 ///

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -164,15 +164,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_roots() {
-        let (_proc, client) = start_florestad();
-
-        let roots = client.get_roots().expect("rpc not working");
-
-        assert!(roots.is_empty());
-    }
-
-    #[test]
     fn test_get_best_block_hash() {
         let (_proc, client) = start_florestad();
 

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -158,20 +158,18 @@ mod tests {
 
         let gbi = client.get_blockchain_info().expect("rpc not working");
 
-        assert_eq!(gbi.height, 0);
+        assert_eq!(gbi.blocks, 0);
         assert_eq!(gbi.chain, "regtest".to_owned());
-        assert!(gbi.ibd);
-        assert_eq!(gbi.leaf_count, 0);
-        assert_eq!(gbi.root_hashes, Vec::<String>::new());
+        assert!(gbi.initial_block_download);
     }
 
     #[test]
     fn test_get_roots() {
         let (_proc, client) = start_florestad();
 
-        let gbi = client.get_blockchain_info().expect("rpc not working");
+        let roots = client.get_roots().expect("rpc not working");
 
-        assert_eq!(gbi.root_hashes, Vec::<String>::new());
+        assert!(roots.is_empty());
     }
 
     #[test]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -7,6 +7,7 @@ use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
 use corepc_types::v30::GetAddrManInfo;
+use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
 use serde_json::Number;
 use serde_json::Value;
@@ -30,7 +31,7 @@ pub trait FlorestaRPC {
     /// This method returns a bunch of information about the chain we are on, including
     /// the current height, the best block hash, the difficulty, and whether we are
     /// currently in IBD (Initial Block Download) mode.
-    fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes>;
+    fn get_blockchain_info(&self) -> Result<GetBlockchainInfo>;
     /// Returns the hash of the best (tip) block in the most-work fully-validated chain.
     fn get_best_block_hash(&self) -> Result<BlockHash>;
     /// Returns the hash of the block at the given height
@@ -360,7 +361,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockheader", &params)
     }
 
-    fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes> {
+    fn get_blockchain_info(&self) -> Result<GetBlockchainInfo> {
         self.call("getblockchaininfo", &[])
     }
 

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -18,48 +18,6 @@ use serde::Serialize;
 /// by btc core.
 pub struct GetTxOutProof(pub Vec<u8>);
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GetBlockchainInfoRes {
-    /// The best block we know about
-    ///
-    /// This should be the hash of the latest block in the most PoW chain we know about. We may
-    /// or may not have fully-validated it yet
-    pub best_block: String,
-    /// The depth of the most-PoW chain we know about
-    pub height: u32,
-    /// Whether we are on Initial Block Download
-    pub ibd: bool,
-    /// How many blocks we have fully-validated so far? This number will be smaller than
-    /// height during IBD, and should be equal to height otherwise
-    pub validated: u32,
-    /// The work performed by the last block
-    ///
-    /// This is the estimated amount of hashes the miner of this block had to perform
-    /// before mining that block, on average
-    pub latest_work: String,
-    /// The UNIX timestamp for the latest block, as reported by the block's header
-    pub latest_block_time: u32,
-    /// How many leaves we have in the utreexo accumulator so far
-    ///
-    /// This should be equal to the number of UTXOs returned by core's `gettxoutsetinfo`
-    pub leaf_count: u32,
-    /// How many roots we have in the acc
-    pub root_count: u32,
-    /// The actual hex-encoded roots
-    pub root_hashes: Vec<String>,
-    /// A short string representing the chain we're in
-    pub chain: String,
-    /// The validation progress
-    ///
-    /// 0 means we didn't validate any block. 1 means we've validated all blocks. so validated == height.
-    pub progress: f32,
-    /// Current network "difficulty"
-    ///
-    /// On average, miners needs to make `difficulty` hashes before finding one that
-    /// solves a block's PoW
-    pub difficulty: u64,
-}
-
 /// The information returned by a get_raw_tx
 #[derive(Deserialize, Serialize)]
 pub struct RawTx {

--- a/doc/rpc/getblockchaininfo.md
+++ b/doc/rpc/getblockchaininfo.md
@@ -1,6 +1,6 @@
 # `getblockchaininfo`
 
-Returns general information about the current state of the blockchain, including block height, validation progress, network difficulty, and utreexo accumulator statistics.
+Returns general information about the current state of the blockchain, including block height, validation progress, and network difficulty.
 
 ## Usage
 
@@ -27,36 +27,57 @@ This command takes no arguments.
 
 Returns a JSON object with the following fields:
 
-- `best_block` - (string) The hash of the best (most-work) block we know about. This is the latest block in the most PoW chain, which may or may not be fully validated yet.
+- `bestblockhash` - (string) The hash of the best (most-work) block we know about. This is the latest block in the most PoW chain, which may or may not be fully validated yet.
 
-- `height` - (numeric) The depth of the most-work chain we know about, representing the total number of blocks.
+- `blocks` - (numeric) The height of the most-work fully-validated chain. During IBD, this number will be smaller than `headers`; after IBD completes, it should be equal to `headers`.
 
-- `ibd` - (boolean) Whether the node is currently in Initial Block Download (IBD) mode.
+- `initialblockdownload` - (boolean) Whether the node is currently in Initial Block Download (IBD) mode.
 
-- `validated` - (numeric) How many blocks have been fully validated so far. During IBD, this number will be smaller than `height`. After IBD completes, it should be equal to `height`.
+- `headers` - (numeric) The count of headers we have validated. During IBD, this number will be larger than `blocks`; after IBD completes, it should be equal to `blocks`.
 
-- `latest_work` - (string) The work performed by the last block. This is the estimated number of hashes the miner had to perform before mining that block, on average.
+- `chainwork` - (string) Total amount of work in the active chain, in hexadecimal.
 
-- `latest_block_time` - (numeric) The UNIX timestamp for the latest block, as reported by the block's header.
-
-- `leaf_count` - (numeric) The number of leaves in the utreexo accumulator. This represents the total number of transaction outputs (TXOs) that have ever been added to the accumulator.
-
-- `root_count` - (numeric) The number of roots in the utreexo accumulator.
-
-- `root_hashes` - (array of strings) The actual hex-encoded roots of the utreexo accumulator.
+- `time` - (numeric) The UNIX timestamp for the latest block, as reported by the block's header.
 
 - `chain` - (string) A short string representing the blockchain network (e.g., "bitcoin", "testnet", "signet").
 
-- `progress` - (numeric) The validation progress as a decimal between 0 and 1. A value of 0 means no blocks have been validated, while 1 means all blocks are validated (validated == height).
+- `verificationprogress` - (numeric) The validation progress as a decimal between 0 and 1. A value of 0 means no blocks have been validated, while 1 means all blocks are validated (headers == blocks).
 
 - `difficulty` - (numeric) The current network difficulty. On average, miners need to make `difficulty` hashes before finding one that solves a block's Proof-of-Work.
 
+- `mediantime` - (numeric) The median block time of the last 11 blocks, expressed in UNIX epoch time.
+
+- `bits` - (string) nBits: compact representation of the block difficulty target, in hexadecimal.
+
+- `target` - (string) The difficulty target, in hexadecimal.
+
+- `pruned` - (boolean) Whether the blocks are subject to pruning. Always `true` for Floresta since it does not store full blocks.
+
+- `pruneheight` - (numeric) Height of the last pruned block plus one. In Floresta, always equals `blocks + 1` since every validated block is immediately pruned.
+
+- `automatic_pruning` - (boolean) Whether automatic pruning is enabled. Always `true` for Floresta.
+
+- `prune_target_size` - (numeric) Target on-disk size used for pruning, in bytes. Always `0` in Floresta since blocks are not retained on disk.
+
+- `signet_challenge` - (string or null) The block challenge used on signet networks. Always `null` in Floresta; not yet exposed on signet.
+
+- `warnings` - (array of strings) Any network and blockchain warnings.
+
+- `size_on_disk` - (numeric) The total size, in bytes, of the chain-store files persisted by Floresta. See the note below on what this value represents.
+
+
 ### Error Enum `CommandError`
 
-* `JsonRpcError::ChainWorkOverflow` - Overflow occurred while calculating accumulated chain work 
-* `JsonRpcError::BlockNotFound` - The requested block hash was not found in the blockchain
-* `JsonRpcError::Chain` - If there's an error accessing blockchain data.
+- `JsonRpcError::ChainWorkOverflow` - Overflow occurred while calculating accumulated chain work
+- `JsonRpcError::BlockNotFound` - The requested block hash was not found in the blockchain
+- `JsonRpcError::Chain` - If there's an error accessing blockchain data.
 
 ## Notes
 
 - During IBD, some features may be limited.
+- `pruned`, `automatic_pruning`, and `prune_target_size` are hardcoded (`true`, `true`, `0`) because Floresta does not store raw blocks or undo files locally.
+- `pruneheight` always equals `blocks + 1` since pruning is immediate. Detect pruning via `pruned`; do not use `pruneheight` to decide which blocks to fetch.
+- `warnings` is hardcoded to `[]`. Floresta does not currently pipe network or node warnings here.
+- `signet_challenge` is hardcoded to `null`. Floresta does not currently expose the signet challenge script.
+- `blocks`, `headers`, `difficulty`, `mediantime`, `bits`, `target`, and `chainwork` are dynamically calculated and behave identically to Bitcoin Core.
+- `size_on_disk` is the sum, in bytes, of Floresta's chainstore files: the main-chain header records, the fork-header records, the block index, the metadata file, and the accumulator file.

--- a/tests/example/functional.py
+++ b/tests/example/functional.py
@@ -17,8 +17,7 @@ import pytest
 from test_framework.constants import (
     GENESIS_BLOCK_HEIGHT,
     GENESIS_BLOCK_HASH,
-    GENESIS_BLOCK_DIFFICULTY_INT,
-    GENESIS_BLOCK_LEAF_COUNT,
+    GENESIS_BLOCK_DIFFICULTY_FLOAT,
 )
 
 
@@ -31,7 +30,6 @@ def test_functional(florestad_node):
     """
     response = florestad_node.rpc.get_blockchain_info()
 
-    assert response["height"] == GENESIS_BLOCK_HEIGHT
-    assert response["best_block"] == GENESIS_BLOCK_HASH
-    assert response["difficulty"] == GENESIS_BLOCK_DIFFICULTY_INT
-    assert response["leaf_count"] == GENESIS_BLOCK_LEAF_COUNT
+    assert response["blocks"] == GENESIS_BLOCK_HEIGHT
+    assert response["bestblockhash"] == GENESIS_BLOCK_HASH
+    assert response["difficulty"] == pytest.approx(GENESIS_BLOCK_DIFFICULTY_FLOAT)

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -1,37 +1,79 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 """
-floresta_cli_getblockchainfo.py
+floresta_cli_getblockchaininfo.py
 
-This functional test cli utility to interact with a Floresta node with `getblockchaininfo`
+Functional test for `getblockchaininfo`. Mines blocks via utreexod, then
+compares florestad's response against bitcoind's field-by-field. Bitcoind is
+treated as the source of truth, so future Core API changes surface as test
+failures rather than silent drift.
 """
 
+import time
 import pytest
-from test_framework.constants import (
-    GENESIS_BLOCK_HASH,
-    GENESIS_BLOCK_DIFFICULTY_INT,
-    GENESIS_BLOCK_HEIGHT,
-)
+
+from test_framework.util import wait_for_chain_sync
+
+TIMEOUT_SECONDS = 30
+MINE_BLOCKS = 10
+EXTRA_BLOCKS = 5
+# Fields where florestad diverges from bitcoind:
+#   - `pruned` is always True (Utreexo discards full blocks)
+#   - `size_on_disk` reports mmap capacity, not blk*.dat size; checked below.
+FLORESTA_SPECIFIC_FIELDS = ("pruned", "size_on_disk")
+
+
+def _wait_for_size_growth(node, baseline):
+    end = time.time() + TIMEOUT_SECONDS
+    current = baseline
+    while time.time() < end:
+        current = node.rpc.get_blockchain_info()["size_on_disk"]
+        if current > baseline:
+            return current
+        time.sleep(0.5)
+    return current
 
 
 @pytest.mark.rpc
-def test_get_blockchain_info(florestad_node):
+def test_get_blockchain_info(florestad_bitcoind_utreexod_with_chain):
     """
-    Test `getblockchaininfo` with a fresh node and its first block
+    Compare florestad's getblockchaininfo response against bitcoind's after a
+    small chain extension. Iterates bitcoind's keys so any new field added in
+    a future Core release fails the test until florestad implements it.
     """
+    florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
 
-    response = florestad_node.rpc.get_blockchain_info()
-    assert response["best_block"] == GENESIS_BLOCK_HASH
-    assert response["difficulty"] == GENESIS_BLOCK_DIFFICULTY_INT
-    assert response["height"] == GENESIS_BLOCK_HEIGHT
-    assert response["ibd"] is True
-    assert response["latest_block_time"] == 1296688602
-    assert (
-        response["latest_work"]
-        == "0000000000000000000000000000000000000000000000000000000000000002"
+    wait_for_chain_sync(
+        florestad,
+        bitcoind,
+        utreexod,
+        MINE_BLOCKS,
+        TIMEOUT_SECONDS,
+        wait_for_ibd_exit=True,
     )
-    assert response["leaf_count"] == 0
-    assert response["progress"] == 0
-    assert response["root_count"] == 0
-    assert response["root_hashes"] == []
-    assert response["validated"] == 0
+
+    floresta_info = florestad.rpc.get_blockchain_info()
+    bitcoind_info = bitcoind.rpc.get_blockchain_info()
+
+    for key, bval in bitcoind_info.items():
+        if key in FLORESTA_SPECIFIC_FIELDS:
+            continue
+        fval = floresta_info[key]
+        if key == "difficulty":
+            # Allow float rounding noise.
+            assert round(fval, 3) == round(bval, 3)
+        else:
+            assert fval == bval, f"{key}: floresta={fval} bitcoind={bval}"
+
+    # size_on_disk: well-formed, grows after mining.
+    size_before = floresta_info["size_on_disk"]
+    assert isinstance(size_before, int)
+
+    utreexod.rpc.generate(EXTRA_BLOCKS)
+    # Poll for growth: get_block_count moves on header receipt, but acc roots
+    # are only written post-validation.
+    size_after = _wait_for_size_growth(florestad, size_before)
+    assert size_after > size_before, (
+        f"size_on_disk did not grow after mining {EXTRA_BLOCKS} blocks: "
+        f"before={size_before} after={size_after}"
+    )

--- a/tests/floresta-cli/getdeploymentinfo.py
+++ b/tests/floresta-cli/getdeploymentinfo.py
@@ -12,8 +12,9 @@ require the versionbits state machine; those keys are present in bitcoind's
 response but skipped on the floresta side.
 """
 
-import time
 import pytest
+
+from test_framework.util import wait_for_chain_sync
 
 TIMEOUT_SECONDS = 30
 MINE_BLOCKS = 10
@@ -35,16 +36,7 @@ def test_get_deployment_info(florestad_bitcoind_utreexod_with_chain):
     """
     florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
 
-    end = time.time() + TIMEOUT_SECONDS
-    while time.time() < end:
-        if (
-            florestad.rpc.get_block_count()
-            == bitcoind.rpc.get_block_count()
-            == utreexod.rpc.get_block_count()
-            == MINE_BLOCKS
-        ):
-            break
-        time.sleep(0.5)
+    wait_for_chain_sync(florestad, bitcoind, utreexod, MINE_BLOCKS, TIMEOUT_SECONDS)
 
     floresta_info = florestad.rpc.get_deployment_info()
     bitcoind_info = bitcoind.rpc.get_deployment_info()

--- a/tests/floresta-cli/gettxout.py
+++ b/tests/floresta-cli/gettxout.py
@@ -31,11 +31,11 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain):
     while time.time() < timeout:
         floresta_info = florestad.rpc.get_blockchain_info()
         if (
-            floresta_info["height"]
+            floresta_info["headers"]
             == utreexod.rpc.get_block_count()
             == bitcoind.rpc.get_block_count()
             == blocks
-            and not floresta_info["ibd"]
+            and not floresta_info["initialblockdownload"]
         ):
             break
 
@@ -47,7 +47,9 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain):
         except Exception as e:
             log.error(f"Error fetching block from peer: {e}")
 
-    assert floresta_info["height"] == blocks and not floresta_info["ibd"]
+    assert (
+        floresta_info["headers"] == blocks and not floresta_info["initialblockdownload"]
+    )
 
     log.info("Comparing gettxout results between Floresta and Bitcoind...")
     for height in range(2, blocks):

--- a/tests/florestad/reorg_chain.py
+++ b/tests/florestad/reorg_chain.py
@@ -66,8 +66,8 @@ class ChainReorgTest:
 
         florestad_info = self.florestad.rpc.get_blockchain_info()
         utreexod_info = self.utreexod.rpc.get_blockchain_info()
-        assert florestad_info["best_block"] == utreexod_info["bestblockhash"]
-        assert florestad_info["height"] == utreexod_info["blocks"]
+        assert florestad_info["bestblockhash"] == utreexod_info["bestblockhash"]
+        assert florestad_info["headers"] == utreexod_info["blocks"]
 
     def mine_blocks(self, blocks):
         """Request Utreexod to generate blocks and wait for Florestad to sync."""

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -6,11 +6,43 @@ import os
 import random
 import socket
 import subprocess
+import time
 
 from test_framework.crypto.pkcs8 import (
     create_pkcs8_private_key,
     create_pkcs8_self_signed_certificate,
 )
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def wait_for_chain_sync(
+    florestad,
+    bitcoind,
+    utreexod,
+    target_blocks: int,
+    timeout: float,
+    wait_for_ibd_exit: bool = False,
+):
+    """Poll the three nodes until they all report `target_blocks`.
+
+    When `wait_for_ibd_exit` is set, also wait until florestad reports
+    `initialblockdownload == False`. Polls every 0.5 s; returns silently on
+    success and silently on timeout (caller asserts the post-condition).
+    """
+    end = time.time() + timeout
+    while time.time() < end:
+        blocks_synced = (
+            florestad.rpc.get_block_count()
+            == bitcoind.rpc.get_block_count()
+            == utreexod.rpc.get_block_count()
+            == target_blocks
+        )
+        if blocks_synced and (
+            not wait_for_ibd_exit
+            or not florestad.rpc.get_blockchain_info()["initialblockdownload"]
+        ):
+            return
+        time.sleep(0.5)
 
 
 class Utility:


### PR DESCRIPTION
### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
This PR brings the getblockchaininfo rpc closer to Bitcoin Core v30 compliance by adding the missing fields: mediantime, bits, target, pruned, pruneheight, automatic_pruning, prune_target_size, signet_challenge, warnings, and size_on_disk. The blocks and headers fields were also corrected to match Core's semantics (blocks = fully validated tip, headers = best known tip).


### How to test
Run the integration tests for getblockchaininfo
`FLORESTA_TEMP_DIR=/tmp/floresta-tests uv run python tests/floresta-cli/getblockchaininfo.py`
