### PR TITLE
Feat : RPC logs at trace level

### DIFF
--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -43,6 +43,7 @@ use tower_http::cors::CorsLayer;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
+use tracing::trace;
 
 use super::res::JsonRpcError;
 use super::res::RawTxJson;
@@ -522,6 +523,9 @@ async fn json_rpc_request(
                 "error": error,
                 "id": Value::Null,
             });
+
+            trace!("rpc parse error: {body}");
+
             return Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .header("Content-Type", "application/json")
@@ -544,6 +548,8 @@ async fn json_rpc_request(
                 "id": id,
             });
 
+            trace!("RPC response {id}: {body}");
+
             axum::http::Response::builder()
                 .status(axum::http::StatusCode::OK)
                 .header("Content-Type", "application/json")
@@ -564,6 +570,8 @@ async fn json_rpc_request(
                 "error": error,
                 "id": id,
             });
+
+            trace!("RPC error {id}: {body}");
 
             axum::http::Response::builder()
                 .status(axum::http::StatusCode::from_u16(http_error_code).unwrap())


### PR DESCRIPTION
### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->
This pr should close issue #652

This pr added trace lvl logs for rpc request and response in `json_rpc_request` fn in `crates/floresta-node/src/json_rpc/server.rs` at these 3 points in pink(all outputs)

<img width="200" height="561" alt="Image" src="https://github.com/user-attachments/assets/cf87879e-0495-4883-acfd-5498460ea105" />

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

Run
`RUST_LOG=floresta_node::json_rpc=trace cargo run --bin florestad -- --network regtest`
for trace lvl log

Try running
  - for success `floresta-cli --network regtest getbestblockhash`
  (curl because floresta-cli won't send invalid json rpc)
  - error path invlaid json `curl -s -X POST http://127.0.0.1:18442 -d 'jsonbrody'`
  - error path `curl -s -X POST http://127.0.0.1:18442 -d '{"method":"jsonbrody","params":[],"id":1}'`

you'll see logs :

<a href="https://asciinema.org/a/5ZGdnhnKfCeQF0yG" target="_blank"><img src="https://asciinema.org/a/5ZGdnhnKfCeQF0yG.svg" /></a>

which were not visible before or with debug log set`RUST_LOG=floresta_node::json_rpc=debug`

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
