### PR TITLE
feat(rpc): add username/password authentication for JSON-RPC server and clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,7 @@ name = "floresta-node"
 version = "0.9.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "bitcoin",
  "corepc-types",
  "dns-lookup",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ readme = "README.md"
 # For exact versions when needed, use "=1.9.1"
 [workspace.dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
+base64 = "0.22"
 bitcoin = { version = "0.32", default-features = false }
 clap = { version = "4.5", default-features = false, features = ["derive", "std"] }
 corepc-types = "0.11"

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -10,6 +10,7 @@ use bitcoin::Txid;
 use clap::Parser;
 use clap::Subcommand;
 use floresta_rpc::jsonrpc_client::Client;
+use floresta_rpc::jsonrpc_client::JsonRPCConfig;
 use floresta_rpc::rpc::FlorestaRPC;
 use floresta_rpc::rpc_types::AddNodeCommand;
 use floresta_rpc::rpc_types::RescanConfidence;
@@ -20,7 +21,11 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Create a new JSON-RPC client using the host from the CLI arguments
-    let client = Client::new(get_host(&cli));
+    let client = Client::new_with_config(JsonRPCConfig {
+        url: get_host(&cli),
+        user: cli.rpc_user.clone(),
+        pass: cli.rpc_password.clone(),
+    });
 
     // Perform the requested RPC call and get the result
     let res = do_request(&cli, client)?;

--- a/bin/florestad/src/cli.rs
+++ b/bin/florestad/src/cli.rs
@@ -2,7 +2,6 @@
 
 use bitcoin::BlockHash;
 use bitcoin::Network;
-#[cfg(unix)]
 use clap::CommandFactory;
 use clap::Parser;
 use floresta_node::AssumeValidArg;
@@ -103,6 +102,14 @@ pub struct Cli {
     /// The address where our json-rpc server should listen to, in the format `<address>[:<port>]`
     pub rpc_address: Option<String>,
 
+    #[arg(long, value_name = "USERNAME")]
+    /// The username required to authenticate JSON-RPC requests.
+    pub rpc_user: Option<String>,
+
+    #[arg(long, value_name = "PASSWORD")]
+    /// The password required to authenticate JSON-RPC requests.
+    pub rpc_password: Option<String>,
+
     #[arg(long, value_name = "HEIGHT")]
     /// Download block filters starting at this height. Negative numbers are relative to the current tip.
     pub filters_start_height: Option<i32>,
@@ -199,6 +206,15 @@ impl Cli {
                 .error(
                     clap::error::ErrorKind::MissingRequiredArgument,
                     "--pid-file requires that --daemon be set",
+                )
+                .exit();
+        }
+
+        if self.rpc_user.is_some() != self.rpc_password.is_some() {
+            Cli::command()
+                .error(
+                    clap::error::ErrorKind::MissingRequiredArgument,
+                    "--rpc-user and --rpc-password must be set together",
                 )
                 .exit();
         }

--- a/bin/florestad/src/main.rs
+++ b/bin/florestad/src/main.rs
@@ -86,6 +86,10 @@ fn main() {
         zmq_address: params.zmq_address,
         #[cfg(feature = "json-rpc")]
         json_rpc_address: params.rpc_address,
+        #[cfg(feature = "json-rpc")]
+        rpc_user: params.rpc_user,
+        #[cfg(feature = "json-rpc")]
+        rpc_password: params.rpc_password,
         generate_cert: params.generate_cert,
         wallet_descriptor: params.wallet_descriptor,
         filters_start_height: params.filters_start_height,

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Floresta Developers <contact@getfloresta.org>"]
 
 [dependencies]
 axum = { workspace = true, optional = true }
+base64 = { workspace = true }
 bitcoin = { workspace = true }
 corepc-types = { workspace = true }
 dns-lookup = { workspace = true }

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -95,6 +95,9 @@ pub enum FlorestadError {
     /// Failed to create a chain provider.
     CouldNotCreateChainProvider(String),
 
+    /// Invalid JSON-RPC auth configuration.
+    InvalidRpcAuthConfig,
+
     /// Failed to create an Electrum server.
     CouldNotCreateElectrumServer(Box<dyn error::Error>),
 
@@ -194,6 +197,12 @@ impl Display for FlorestadError {
 
             FlorestadError::CouldNotCreateChainProvider(err) => {
                 write!(f, "Could not create chain provider: {err}")
+            }
+            FlorestadError::InvalidRpcAuthConfig => {
+                write!(
+                    f,
+                    "invalid RPC auth config: set both --rpc-user and --rpc-password or neither"
+                )
             }
             FlorestadError::CouldNotCreateElectrumServer(err) => {
                 write!(f, "Could not create Electrum server: {err}")

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -163,6 +163,14 @@ pub struct Config {
     /// The address our json-rpc should listen to
     pub json_rpc_address: Option<String>,
 
+    #[cfg(feature = "json-rpc")]
+    /// The username required to access JSON-RPC.
+    pub rpc_user: Option<String>,
+
+    #[cfg(feature = "json-rpc")]
+    /// The password required to access JSON-RPC.
+    pub rpc_password: Option<String>,
+
     /// Whether we should write logs to `stdout`.
     pub log_to_stdout: bool,
 
@@ -238,6 +246,10 @@ impl Config {
             connect: None,
             #[cfg(feature = "json-rpc")]
             json_rpc_address: None,
+            #[cfg(feature = "json-rpc")]
+            rpc_user: None,
+            #[cfg(feature = "json-rpc")]
+            rpc_password: None,
             log_to_stdout: false,
             log_to_file: false,
             assume_utreexo: false,
@@ -360,6 +372,12 @@ impl Florestad {
     pub async fn start(&self) -> Result<(), FlorestadError> {
         let data_dir = &self.config.data_dir;
 
+        #[cfg(feature = "json-rpc")]
+        match (&self.config.rpc_user, &self.config.rpc_password) {
+            (Some(_), Some(_)) | (None, None) => {}
+            _ => return Err(FlorestadError::InvalidRpcAuthConfig),
+        }
+
         // Check that the directory exists and is writable
         Florestad::validate_data_dir(data_dir)?;
 
@@ -478,6 +496,8 @@ impl Florestad {
                     .as_ref()
                     .map(|x| Self::resolve_hostname(x, 8332))
                     .transpose()?,
+                self.config.rpc_user.clone(),
+                self.config.rpc_password.clone(),
                 format!("{data_dir}/debug.log"),
             ));
 

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -9,12 +9,17 @@ use std::time::Instant;
 use axum::body::Body;
 use axum::body::Bytes;
 use axum::extract::State;
+use axum::http::header::AUTHORIZATION;
+use axum::http::header::WWW_AUTHENTICATE;
+use axum::http::HeaderMap;
 use axum::http::Method;
 use axum::http::Response;
 use axum::http::StatusCode;
 use axum::routing::post;
 use axum::Json;
 use axum::Router;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::hashes::hex::FromHex;
@@ -83,6 +88,8 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
     pub(super) log_path: String,
     pub(super) start_time: Instant,
+    pub(super) rpc_user: Option<String>,
+    pub(super) rpc_password: Option<String>,
 }
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
@@ -513,8 +520,31 @@ fn get_json_rpc_error_code(err: &JsonRpcError) -> i32 {
 
 async fn json_rpc_request(
     State(state): State<Arc<RpcImpl<impl RpcChain>>>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> Response<Body> {
+    if let Err(()) = check_rpc_auth(
+        &headers,
+        state.rpc_user.as_deref(),
+        state.rpc_password.as_deref(),
+    ) {
+        let error = RpcError {
+            code: -32600,
+            message: "Unauthorized".to_string(),
+            data: None,
+        };
+        let body = json!({
+            "error": error,
+            "id": Value::Null,
+        });
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("Content-Type", "application/json")
+            .header(WWW_AUTHENTICATE, "Basic realm=\"Floresta RPC\"")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+    }
+
     let req: RpcRequest = match serde_json::from_slice(&body) {
         Ok(req) => req,
         Err(e) => {
@@ -575,6 +605,34 @@ async fn json_rpc_request(
                 .header("Content-Type", "application/json")
                 .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
                 .unwrap()
+        }
+    }
+}
+
+fn check_rpc_auth(
+    headers: &HeaderMap,
+    user: Option<&str>,
+    password: Option<&str>,
+) -> std::result::Result<(), ()> {
+    match (user, password) {
+        (None, None) => Ok(()),
+        (Some(_), None) | (None, Some(_)) => Err(()),
+        (Some(user), Some(password)) => {
+            let auth_header = headers
+                .get(AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .ok_or(())?;
+
+            let basic = auth_header.strip_prefix("Basic ").ok_or(())?;
+            let auth_bytes = BASE64_STANDARD.decode(basic).map_err(|_| ())?;
+            let auth = String::from_utf8(auth_bytes).map_err(|_| ())?;
+            let (given_user, given_pass) = auth.split_once(':').ok_or(())?;
+
+            if given_user == user && given_pass == password {
+                Ok(())
+            } else {
+                Err(())
+            }
         }
     }
 }
@@ -748,6 +806,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         network: Network,
         block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         address: Option<SocketAddr>,
+        rpc_user: Option<String>,
+        rpc_password: Option<String>,
         log_path: String,
     ) {
         let address = address.unwrap_or_else(|| {
@@ -789,6 +849,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 inflight: Arc::new(RwLock::new(HashMap::new())),
                 log_path,
                 start_time: Instant::now(),
+                rpc_user,
+                rpc_password,
             }));
 
         axum::serve(listener, router)

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -42,6 +42,7 @@ mod tests {
     use rcgen::CertifiedKey;
 
     use crate::jsonrpc_client::Client;
+    use crate::jsonrpc_client::JsonRPCConfig;
     use crate::rpc::FlorestaRPC;
     use crate::rpc_types::GetBlockRes;
 
@@ -101,13 +102,19 @@ mod tests {
             .args(["-n", "regtest"])
             .args(["--data-dir", &dirname])
             .args(["--rpc-address", &format!("127.0.0.1:{port}")])
+            .args(["--rpc-user", "test"])
+            .args(["--rpc-password", "test"])
             .args(["--electrum-address", "127.0.0.1:0"])
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .unwrap_or_else(|e| panic!("Couldn't launch florestad at {florestad_path}: {e}"));
 
-        let client = Client::new(format!("http://127.0.0.1:{port}"));
+        let client = Client::new_with_config(JsonRPCConfig {
+            url: format!("http://127.0.0.1:{port}"),
+            user: Some("test".to_string()),
+            pass: Some("test".to_string()),
+        });
 
         let mut retries = 10;
         loop {
@@ -251,5 +258,18 @@ mod tests {
             Txid::from_str("1fb5734a07ce65c509311ebc03f136904f8b39a130ca3adff93200fc7ecde6fe")
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_unauthorized() {
+        let (_proc, _client) = start_florestad();
+        let port = get_available_port();
+        let unauthorized = Client::new_with_config(JsonRPCConfig {
+            url: format!("http://127.0.0.1:{port}"),
+            user: Some("wrong".to_string()),
+            pass: Some("credentials".to_string()),
+        });
+
+        assert!(unauthorized.get_block_count().is_err())
     }
 }

--- a/doc/run.md
+++ b/doc/run.md
@@ -90,6 +90,20 @@ and you can get the cli parameters by running
 floresta-cli help <command>
 ```
 
+## JSON-RPC Authentication
+
+You can require username/password authentication for JSON-RPC requests:
+
+```bash
+florestad --rpc-user alice --rpc-password secret
+```
+
+When authentication is enabled, RPC clients must use matching credentials:
+
+```bash
+floresta-cli --rpc-user alice --rpc-password secret getblockchaininfo
+```
+
 ## Wallet
 
 Floresta comes with a watch-only wallet that you can use to track your transactions. You just need to provide the wallet

--- a/tests/floresta-cli/rpc-auth.py
+++ b/tests/floresta-cli/rpc-auth.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+Test JSON-RPC username/password authentication on florestad.
+"""
+
+from requests.exceptions import HTTPError
+from test_framework import FlorestaTestFramework
+from test_framework.daemon import ConfigP2P
+from test_framework.electrum import ConfigElectrum
+from test_framework.node import NodeType
+from test_framework.rpc import ConfigRPC
+
+
+class RpcAuthTest(FlorestaTestFramework):
+    """
+    Ensure RPC requests are rejected without credentials and accepted with credentials.
+    """
+
+    def set_test_params(self):
+        rpc_config = ConfigRPC(
+            host="127.0.0.1",
+            port=18442,
+            user="alice",
+            password="secret",
+        )
+        self.florestad = self.add_node(
+            variant=NodeType.FLORESTAD,
+            rpc_config=rpc_config,
+            p2p_config=ConfigP2P(host="127.0.0.1", port=0),
+            extra_args=[],
+            electrum_config=ConfigElectrum(host="127.0.0.1", port=0, tls=None),
+            tls=False,
+        )
+
+    def run_test(self):
+        self.run_node(self.florestad)
+
+        authenticated = self.florestad.rpc.get_blockchain_info()
+        self.assertEqual(authenticated["chain"], "regtest")
+
+        host = self.florestad.rpc.config.host
+        port = self.florestad.rpc.config.port
+        self.florestad.rpc.set_config(ConfigRPC(host=host, port=port))
+
+        with self.assertRaises(HTTPError):
+            self.florestad.rpc.get_blockchain_info()
+
+
+if __name__ == "__main__":
+    RpcAuthTest().main()

--- a/tests/test_framework/daemon/floresta.py
+++ b/tests/test_framework/daemon/floresta.py
@@ -39,9 +39,19 @@ class FlorestaDaemon(BaseDaemon):
         Return the RPC configuration flags for the node.
         """
         address = f"{config.host}:{config.port}"
-        return [
+        rpc_settings = [
             f"--rpc-address={address}",
         ]
+
+        if config.user is not None and config.password is not None:
+            rpc_settings.extend(
+                [
+                    f"--rpc-user={config.user}",
+                    f"--rpc-password={config.password}",
+                ]
+            )
+
+        return rpc_settings
 
     def get_cmd_p2p(self, config: ConfigP2P) -> List[str]:
         """

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -70,6 +70,7 @@ BASE_TEST_SUITE = [
     ("floresta-cli", "getpeerinfo"),
     ("floresta-cli", "getconnectioncount"),
     ("floresta-cli", "getblockchaininfo"),
+    ("floresta-cli", "rpc-auth"),
     ("floresta-cli", "getblockheader"),
     ("example", "bitcoin"),
     ("example", "utreexod"),


### PR DESCRIPTION
### Description and Notes

This pr implements username/password authentication for json-rpc.

### How to verify the changes you have done?

start `florestad` like `florestad --rpc-user alice --rpc-password some-super-secret-text`. then try using `floresta-cli` with and without `--rpc-user` and `--rpc-password`. 

does some work towards closing #651 .