### PR TITLE
doc: Remove additional run argument

### DIFF
--- a/bin/florestad/docs/tutorial(EN).md
+++ b/bin/florestad/docs/tutorial(EN).md
@@ -55,7 +55,7 @@ or
 or
 
 ```bash
-cargo run --release -- -c config.toml --network signet run
+cargo run --release -- -c config.toml --network signet
 ```
 Where:
 

--- a/bin/florestad/docs/tutorial(PT-BR).md
+++ b/bin/florestad/docs/tutorial(PT-BR).md
@@ -58,7 +58,7 @@ ou
 ou
 
 ```bash
-cargo run --release -- -c config.toml --network signet run
+cargo run --release -- -c config.toml --network signet
 ```
 
 Onde:


### PR DESCRIPTION
The `run` appended at the end of this `cargo` command causes an execution failure.
