### PR TITLE
Refactor(electrum): Remove unwraps and expects

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -457,7 +457,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             // end of experimental endpoints
             "blockchain.transaction.broadcast" => {
                 let tx = get_arg!(request, String, 0);
-                let hex: Vec<_> = Vec::from_hex(&tx).map_err(|_| Error::InvalidParams)?;
+                let hex = Vec::from_hex(&tx).map_err(|_| Error::InvalidParams)?;
                 let tx: Transaction = deserialize(&hex).map_err(|_| Error::InvalidParams)?;
 
                 let txid = tx.compute_txid();

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -728,8 +728,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             .is_ok_and(|h| h == height);
 
         if height_matches {
-            let serialized = serde_json::to_string(&result)
-                .expect("serde_json::Value is always serializable");
+            let serialized =
+                serde_json::to_string(&result).expect("serde_json::Value is always serializable");
             for client in self.clients.values() {
                 if client.write(serialized.as_bytes()).is_err() {
                     info!("Could not write to client {client:?}");

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -92,22 +92,28 @@ impl<S: AsyncStream> TcpActor<S> {
                 result = lines.next_line() => {
                     match result {
                         Ok(Some(line)) => {
-                            self.message_transmitter
-                                .send(Message::Message((self.client_id, line)))
-                                .expect("Main loop is broken");
+                            match self.message_transmitter.send(Message::Message((self.client_id, line))) {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    error!("main loop receiver dropped: {e:?}");
+                                    break;
+                                }
+                            }
                         }
                         Ok(None) => {
                             info!("Client closed connection: {}", self.client_id);
-                            self.message_transmitter
-                                .send(Message::Disconnect(self.client_id))
-                                .expect("Main loop is broken");
+                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                Ok(_) => {}
+                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            }
                             break;
                         }
                         Err(e) => {
                             error!("Error reading from client: {e:?}");
-                            self.message_transmitter
-                                .send(Message::Disconnect(self.client_id))
-                                .expect("Main loop is broken");
+                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                Ok(_) => {}
+                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            }
                             break;
                         }
                     }
@@ -336,15 +342,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             "blockchain.scripthash.get_mempool" => json_rpc_res!(request, []),
             "blockchain.scripthash.listunspent" => {
                 let hash = get_arg!(request, sha256::Hash, 0);
-                let utxos = self.address_cache.get_address_utxos(&hash);
-                if utxos.is_none() {
+                let Some(utxos) = self.address_cache.get_address_utxos(&hash) else {
                     return json_rpc_res!(request, []);
-                }
+                };
                 let mut final_utxos = Vec::new();
-                for (utxo, prevout) in utxos.unwrap().into_iter() {
-                    let height = self.address_cache.get_height(&prevout.txid).unwrap();
-
-                    let position = self.address_cache.get_position(&prevout.txid).unwrap();
+                for (utxo, prevout) in utxos.into_iter() {
+                    let height = self.address_cache.get_height(&prevout.txid).unwrap_or(0);
+                    let position = self.address_cache.get_position(&prevout.txid).unwrap_or(0);
 
                     final_utxos.push(json!({
                         "height": height,
@@ -514,7 +518,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let genesis_hash = self
                     .chain
                     .get_block_hash(0)
-                    .expect("Genesis block should be present");
+                    .expect("genesis block is always in the chain store");
                 let res = json!(
                     {
                         "genesis_hash": genesis_hash,
@@ -540,7 +544,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     }
 
     pub async fn rebroadcast_mempool_transactions(&self) {
-        let unconfirmed = self.address_cache.find_unconfirmed().unwrap();
+        let unconfirmed = match self.address_cache.find_unconfirmed() {
+            Ok(txs) => txs,
+            Err(e) => {
+                error!("Could not fetch unconfirmed transactions for rebroadcast: {e}");
+                return;
+            }
+        };
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -644,6 +654,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         let Ok(blocks) =
             cfilters.match_any(_addresses, start_height, stop_height, self.chain.clone())
         else {
+            info!("Could not match block filters");
             self.addresses_to_scan.extend(addresses); // push them back to get a retry
             return Ok(());
         };
@@ -654,16 +665,16 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         for block in blocks {
             let block = self.node_interface.get_block(block).await;
             let Ok(Some(block)) = block else {
+                info!("Could not get block from node");
                 self.addresses_to_scan.extend(addresses); // push them back to get a retry
                 return Ok(());
             };
 
-            let height = self
-                .chain
-                .get_block_height(&block.block_hash())
-                .ok()
-                .flatten()
-                .unwrap();
+            let Ok(Some(height)) = self.chain.get_block_height(&block.block_hash()) else {
+                info!("Could not get block height: {}", block.block_hash());
+                self.addresses_to_scan.extend(addresses); // push them back to get a retry
+                return Ok(());
+            };
 
             self.handle_block(block, height);
         }
@@ -708,12 +719,23 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             self.address_cache.bump_height(height);
         }
 
-        if self.chain.get_height().unwrap() == height {
-            for client in &mut self.clients.values() {
-                let res = client.write(serde_json::to_string(&result).unwrap().as_bytes());
-                if res.is_err() {
-                    info!("Could not write to client {client:?}");
+        match self.chain.get_height() {
+            Ok(chain_height) => {
+                if chain_height == height {
+                    for client in &mut self.clients.values() {
+                        let res = client.write(
+                            serde_json::to_string(&result)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        );
+                        if res.is_err() {
+                            info!("Could not write to client {client:?}");
+                        }
+                    }
                 }
+            }
+            Err(e) => {
+                error!("Could not get chain height: {e:?}");
             }
         }
 
@@ -732,17 +754,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             Message::Message((client, msg)) => {
                 trace!("Message: {msg}");
                 if let Ok(req) = serde_json::from_str::<Request>(msg.as_str()) {
-                    let client = self.clients.get(&client);
-                    if client.is_none() {
+                    let Some(client) = self.clients.get(&client).cloned() else {
                         error!("Client sent a message but is not listed as client");
                         return Ok(());
-                    }
-                    let client = client.unwrap().to_owned();
+                    };
                     let id = req.id.to_owned();
                     let res = self.handle_client_request(client.clone(), req).await;
 
                     if let Ok(res) = res {
-                        client.write(serde_json::to_string(&res).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&res)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     } else {
                         let res = json!({
                             "jsonrpc": "2.0",
@@ -753,17 +777,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                             },
                             "id": id
                         });
-                        client.write(serde_json::to_string(&res).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&res)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     }
                 } else if let Ok(requests) = serde_json::from_str::<Vec<Request>>(&msg) {
                     let mut results = Vec::new();
                     for req in requests {
-                        let client = self.clients.get(&client);
-                        if client.is_none() {
+                        let Some(client) = self.clients.get(&client).cloned() else {
                             error!("Client sent a message but is not listed as client");
                             return Ok(());
-                        }
-                        let client = client.unwrap().to_owned();
+                        };
                         let id = req.id.to_owned();
                         let res = self.handle_client_request(client.clone(), req).await;
 
@@ -783,7 +809,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         }
                     }
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(serde_json::to_string(&results).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&results)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     }
                 } else {
                     let res = json!({
@@ -796,7 +826,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         "id": null
                     });
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(serde_json::to_string(&res).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&res)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     }
                 }
             }
@@ -813,15 +847,22 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         for (_, out) in transactions {
             let hash = get_spk_hash(&out.script_pubkey);
             if let Some(client) = self.client_addresses.get(&hash) {
-                let history = self.address_cache.get_address_history(&hash);
+                let Some(history) = self.address_cache.get_address_history(&hash) else {
+                    info!("Could not get address history for {hash}");
+                    continue;
+                };
 
-                let status_hash = get_status(history.unwrap());
+                let status_hash = get_status(history);
                 let notify = json!({
                     "jsonrpc": "2.0",
                     "method": "blockchain.scripthash.subscribe",
                     "params": [hash, status_hash]
                 });
-                if let Err(err) = client.write(serde_json::to_string(&notify).unwrap().as_bytes()) {
+                if let Err(err) = client.write(
+                    serde_json::to_string(&notify)
+                        .expect("serde_json::Value is always serializable")
+                        .as_bytes(),
+                ) {
                     error!("{err}");
                 }
             }
@@ -848,10 +889,17 @@ pub async fn client_accept_loop(
                             tls_stream,
                             message_transmitter.clone(),
                         ));
-                        message_transmitter
+                        match message_transmitter
                             .send(Message::NewClient((client.client_id, client)))
-                            .expect("Main loop is broken");
-                        id_count += 1;
+                        {
+                            Ok(_) => {
+                                id_count += 1;
+                            }
+                            Err(e) => {
+                                error!("main loop receiver dropped: {e:?}");
+                                break;
+                            }
+                        }
                     }
                     Err(e) => {
                         error!("TLS accept error: {e:?}");
@@ -859,10 +907,15 @@ pub async fn client_accept_loop(
                 }
             } else {
                 let client = Arc::new(Client::new(id_count, stream, message_transmitter.clone()));
-                message_transmitter
-                    .send(Message::NewClient((client.client_id, client)))
-                    .expect("Main loop is broken");
-                id_count += 1;
+                match message_transmitter.send(Message::NewClient((client.client_id, client))) {
+                    Ok(_) => {
+                        id_count += 1;
+                    }
+                    Err(e) => {
+                        error!("main loop receiver dropped: {e:?}");
+                        break;
+                    }
+                }
             }
         }
     }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -42,6 +42,7 @@ use tracing::error;
 use tracing::info;
 use tracing::trace;
 
+use crate::error::Error;
 use crate::get_arg;
 use crate::json_rpc_res;
 use crate::request::Request;
@@ -92,27 +93,22 @@ impl<S: AsyncStream> TcpActor<S> {
                 result = lines.next_line() => {
                     match result {
                         Ok(Some(line)) => {
-                            match self.message_transmitter.send(Message::Message((self.client_id, line))) {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    error!("main loop receiver dropped: {e:?}");
-                                    break;
-                                }
+                            if let Err(e) = self.message_transmitter.send(Message::Message((self.client_id, line))) {
+                                error!("main loop receiver dropped: {e:?}");
+                                break;
                             }
                         }
                         Ok(None) => {
                             info!("Client closed connection: {}", self.client_id);
-                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
-                                Ok(_) => {}
-                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            if let Err(e) = self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                error!("main loop receiver dropped: {e:?}");
                             }
                             break;
                         }
                         Err(e) => {
                             error!("Error reading from client: {e:?}");
-                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
-                                Ok(_) => {}
-                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            if let Err(e) = self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                error!("main loop receiver dropped: {e:?}");
                             }
                             break;
                         }
@@ -256,7 +252,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         &mut self,
         client: Arc<Client>,
         request: Request,
-    ) -> Result<Value, super::error::Error> {
+    ) -> Result<Value, Error> {
         // Methods are in alphabetical order
         match request.method.as_str() {
             "blockchain.block.header" => {
@@ -264,11 +260,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let hash = self
                     .chain
                     .get_block_hash(height as u32)
-                    .map_err(|_| super::error::Error::InvalidParams)?;
+                    .map_err(|_| Error::InvalidParams)?;
                 let header = self
                     .chain
                     .get_block_header(&hash)
-                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                    .map_err(|e| Error::Blockchain(Box::new(e)))?;
                 let header = serialize_hex(&header);
                 json_rpc_res!(request, header)
             }
@@ -281,12 +277,12 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     let hash = self
                         .chain
                         .get_block_hash(height as u32)
-                        .map_err(|_| super::error::Error::InvalidParams)?;
+                        .map_err(|_| Error::InvalidParams)?;
 
                     let header = self
                         .chain
                         .get_block_header(&hash)
-                        .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                        .map_err(|e| Error::Blockchain(Box::new(e)))?;
                     let header = serialize_hex(&header);
                     headers.push_str(&header);
                 }
@@ -301,11 +297,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let (height, hash) = self
                     .chain
                     .get_best_block()
-                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                    .map_err(|e| Error::Blockchain(Box::new(e)))?;
                 let header = self
                     .chain
                     .get_block_header(&hash)
-                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                    .map_err(|e| Error::Blockchain(Box::new(e)))?;
                 let result = json!({
                     "height": height,
                     "hex": serialize_hex(&header)
@@ -461,10 +457,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             // end of experimental endpoints
             "blockchain.transaction.broadcast" => {
                 let tx = get_arg!(request, String, 0);
-                let hex: Vec<_> =
-                    Vec::from_hex(&tx).map_err(|_| super::error::Error::InvalidParams)?;
-                let tx: Transaction =
-                    deserialize(&hex).map_err(|_| super::error::Error::InvalidParams)?;
+                let hex: Vec<_> = Vec::from_hex(&tx).map_err(|_| Error::InvalidParams)?;
+                let tx: Transaction = deserialize(&hex).map_err(|_| Error::InvalidParams)?;
 
                 let txid = tx.compute_txid();
                 if let Err(e) = self
@@ -473,7 +467,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     .await?
                 {
                     error!("Could not broadcast transaction {txid} due to {e}");
-                    return Err(super::error::Error::Mempool(Box::new(e)));
+                    return Err(Error::Mempool(Box::new(e)));
                 };
 
                 let updated = self
@@ -493,15 +487,15 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     return json_rpc_res!(request, tx);
                 }
 
-                Err(super::error::Error::InvalidParams)
+                Err(Error::InvalidParams)
             }
             "blockchain.transaction.get_merkle" => {
                 let tx_id = get_arg!(request, Txid, 0);
                 let Some(proof) = self.address_cache.get_merkle_proof(&tx_id) else {
-                    return Err(super::error::Error::InvalidParams);
+                    return Err(Error::InvalidParams);
                 };
                 let Some(height) = self.address_cache.get_height(&tx_id) else {
-                    return Err(super::error::Error::InvalidParams);
+                    return Err(Error::InvalidParams);
                 };
                 let result = json!({
                     "merkle": proof.hashes,
@@ -543,15 +537,15 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 [format!("Floresta {}", env!("CARGO_PKG_VERSION")), "1.4"]
             ),
 
-            _ => Err(super::error::Error::InvalidParams),
+            _ => Err(Error::InvalidParams),
         }
     }
 
-    pub async fn rebroadcast_mempool_transactions(&self) -> Result<(), super::error::Error> {
+    pub async fn rebroadcast_mempool_transactions(&self) -> Result<(), Error> {
         let unconfirmed = self
             .address_cache
             .find_unconfirmed()
-            .map_err(|e| super::error::Error::WatchOnly(Box::new(e)))?;
+            .map_err(|e| Error::WatchOnly(Box::new(e)))?;
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -623,10 +617,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     /// Usually, we'll rely on compact block filters to speed things up. If
     /// we don't have compact block filters, we may rescan using the older,
     /// more bandwidth-intensive method of actually downloading blocks.
-    async fn rescan_for_addresses(
-        &mut self,
-        addresses: Vec<ScriptBuf>,
-    ) -> Result<(), super::error::Error> {
+    async fn rescan_for_addresses(&mut self, addresses: Vec<ScriptBuf>) -> Result<(), Error> {
         // If compact block filters are enabled, use them. Otherwise, fallback
         // to the "old-school" rescaning.
         if let Some(cfilters) = &self.block_filters {
@@ -646,7 +637,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         start_height: Option<u32>,
         stop_height: Option<u32>,
         addresses: Vec<ScriptBuf>,
-    ) -> Result<(), super::error::Error> {
+    ) -> Result<(), Error> {
         // By default, we look from 1..tip
         let mut _addresses = addresses
             .iter()
@@ -656,7 +647,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         let Ok(blocks) =
             cfilters.match_any(_addresses, start_height, stop_height, self.chain.clone())
         else {
-            error!("Could not match block filters");
+            error!("Could not find matching block filters");
             self.addresses_to_scan.extend(addresses); // push them back to get a retry
             return Ok(());
         };
@@ -877,17 +868,13 @@ pub async fn client_accept_loop(
                             tls_stream,
                             message_transmitter.clone(),
                         ));
-                        match message_transmitter
-                            .send(Message::NewClient((client.client_id, client)))
+                        if let Err(e) =
+                            message_transmitter.send(Message::NewClient((client.client_id, client)))
                         {
-                            Ok(_) => {
-                                id_count += 1;
-                            }
-                            Err(e) => {
-                                error!("main loop receiver dropped: {e:?}");
-                                break;
-                            }
+                            error!("main loop receiver dropped: {e:?}");
+                            break;
                         }
+                        id_count += 1;
                     }
                     Err(e) => {
                         error!("TLS accept error: {e:?}");
@@ -895,15 +882,13 @@ pub async fn client_accept_loop(
                 }
             } else {
                 let client = Arc::new(Client::new(id_count, stream, message_transmitter.clone()));
-                match message_transmitter.send(Message::NewClient((client.client_id, client))) {
-                    Ok(_) => {
-                        id_count += 1;
-                    }
-                    Err(e) => {
-                        error!("main loop receiver dropped: {e:?}");
-                        break;
-                    }
+                if let Err(e) =
+                    message_transmitter.send(Message::NewClient((client.client_id, client)))
+                {
+                    error!("main loop receiver dropped: {e:?}");
+                    break;
                 }
+                id_count += 1;
             }
         }
     }
@@ -963,13 +948,13 @@ macro_rules! json_rpc_res {
 }
 
 #[macro_export]
-/// Returns and parses a value from the request json or fails with [super::error::Error::InvalidParams].
+/// Returns and parses a value from the request json or fails with [Error::InvalidParams].
 macro_rules! get_arg {
     ($request:ident, $arg_type:ty, $idx:literal) => {
         if let Some(arg) = $request.params.get($idx) {
             serde_json::from_value::<$arg_type>(arg.clone())?
         } else {
-            return Err(super::error::Error::InvalidParams);
+            return Err(Error::InvalidParams);
         }
     };
 }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -347,8 +347,12 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 };
                 let mut final_utxos = Vec::new();
                 for (utxo, prevout) in utxos.into_iter() {
-                    let height = self.address_cache.get_height(&prevout.txid).unwrap_or(0);
-                    let position = self.address_cache.get_position(&prevout.txid).unwrap_or(0);
+                    let Some(height) = self.address_cache.get_height(&prevout.txid) else {
+                        return json_rpc_res!(request, []);
+                    };
+                    let Some(position) = self.address_cache.get_position(&prevout.txid) else {
+                        return json_rpc_res!(request, []);
+                    };
 
                     final_utxos.push(json!({
                         "height": height,
@@ -493,18 +497,18 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }
             "blockchain.transaction.get_merkle" => {
                 let tx_id = get_arg!(request, Txid, 0);
-                let proof = self.address_cache.get_merkle_proof(&tx_id);
-                let height = self.address_cache.get_height(&tx_id);
-                if let Some(proof) = proof {
-                    let result = json!({
-                        "merkle": proof.hashes,
-                        "block_height": height.unwrap_or(0),
-                        "pos": proof.pos
-                    });
-                    return json_rpc_res!(request, result);
-                }
-
-                Err(super::error::Error::InvalidParams)
+                let Some(proof) = self.address_cache.get_merkle_proof(&tx_id) else {
+                    return Err(super::error::Error::InvalidParams);
+                };
+                let Some(height) = self.address_cache.get_height(&tx_id) else {
+                    return Err(super::error::Error::InvalidParams);
+                };
+                let result = json!({
+                    "merkle": proof.hashes,
+                    "block_height": height,
+                    "pos": proof.pos
+                });
+                json_rpc_res!(request, result)
             }
             //blockchain.transaction.id_from_pos
             // TODO: Create an actual histogram
@@ -518,7 +522,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let genesis_hash = self
                     .chain
                     .get_block_hash(0)
-                    .expect("genesis block is always in the chain store");
+                    .expect("Genesis block is always in the chain store");
                 let res = json!(
                     {
                         "genesis_hash": genesis_hash,
@@ -543,14 +547,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         }
     }
 
-    pub async fn rebroadcast_mempool_transactions(&self) {
-        let unconfirmed = match self.address_cache.find_unconfirmed() {
-            Ok(txs) => txs,
-            Err(e) => {
-                error!("Could not fetch unconfirmed transactions for rebroadcast: {e}");
-                return;
-            }
-        };
+    pub async fn rebroadcast_mempool_transactions(&self) -> Result<(), super::error::Error> {
+        let unconfirmed = self
+            .address_cache
+            .find_unconfirmed()
+            .map_err(|e| super::error::Error::WatchOnly(Box::new(e)))?;
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -559,6 +560,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 debug!("Rebroadcasted transaction {txid}");
             }
         }
+        Ok(())
     }
 
     pub async fn main_loop(mut self) -> Result<(), crate::error::Error> {
@@ -594,7 +596,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 .unwrap_or(true);
 
             if should_rebroadcast {
-                self.rebroadcast_mempool_transactions().await;
+                self.rebroadcast_mempool_transactions().await?;
                 self.last_rebroadcast = Some(Instant::now());
             }
 
@@ -654,7 +656,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         let Ok(blocks) =
             cfilters.match_any(_addresses, start_height, stop_height, self.chain.clone())
         else {
-            info!("Could not match block filters");
+            error!("Could not match block filters");
             self.addresses_to_scan.extend(addresses); // push them back to get a retry
             return Ok(());
         };
@@ -665,13 +667,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         for block in blocks {
             let block = self.node_interface.get_block(block).await;
             let Ok(Some(block)) = block else {
-                info!("Could not get block from node");
+                error!("Could not get block from node");
                 self.addresses_to_scan.extend(addresses); // push them back to get a retry
                 return Ok(());
             };
 
             let Ok(Some(height)) = self.chain.get_block_height(&block.block_hash()) else {
-                info!("Could not get block height: {}", block.block_hash());
+                error!("Could not get block height: {}", block.block_hash());
                 self.addresses_to_scan.extend(addresses); // push them back to get a retry
                 return Ok(());
             };
@@ -719,23 +721,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             self.address_cache.bump_height(height);
         }
 
-        match self.chain.get_height() {
-            Ok(chain_height) => {
-                if chain_height == height {
-                    for client in &mut self.clients.values() {
-                        let res = client.write(
-                            serde_json::to_string(&result)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        );
-                        if res.is_err() {
-                            info!("Could not write to client {client:?}");
-                        }
-                    }
+        let height_matches = self
+            .chain
+            .get_height()
+            .inspect_err(|e| error!("Could not get chain height: {e:?}"))
+            .is_ok_and(|h| h == height);
+
+        if height_matches {
+            let serialized = serde_json::to_string(&result)
+                .expect("serde_json::Value is always serializable");
+            for client in self.clients.values() {
+                if client.write(serialized.as_bytes()).is_err() {
+                    info!("Could not write to client {client:?}");
                 }
-            }
-            Err(e) => {
-                error!("Could not get chain height: {e:?}");
             }
         }
 
@@ -762,11 +760,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     let res = self.handle_client_request(client.clone(), req).await;
 
                     if let Ok(res) = res {
-                        client.write(
-                            serde_json::to_string(&res)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let res = serde_json::to_string(&res)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(res.as_bytes())?;
                     } else {
                         let res = json!({
                             "jsonrpc": "2.0",
@@ -777,11 +773,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                             },
                             "id": id
                         });
-                        client.write(
-                            serde_json::to_string(&res)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let res = serde_json::to_string(&res)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(res.as_bytes())?;
                     }
                 } else if let Ok(requests) = serde_json::from_str::<Vec<Request>>(&msg) {
                     let mut results = Vec::new();
@@ -809,11 +803,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         }
                     }
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(
-                            serde_json::to_string(&results)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let results = serde_json::to_string(&results)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(results.as_bytes())?;
                     }
                 } else {
                     let res = json!({
@@ -826,11 +818,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         "id": null
                     });
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(
-                            serde_json::to_string(&res)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let res = serde_json::to_string(&res)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(res.as_bytes())?;
                     }
                 }
             }
@@ -858,11 +848,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     "method": "blockchain.scripthash.subscribe",
                     "params": [hash, status_hash]
                 });
-                if let Err(err) = client.write(
-                    serde_json::to_string(&notify)
-                        .expect("serde_json::Value is always serializable")
-                        .as_bytes(),
-                ) {
+                let notify = serde_json::to_string(&notify)
+                    .expect("serde_json::Value is always serializable");
+                if let Err(err) = client.write(notify.as_bytes()) {
                     error!("{err}");
                 }
             }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -352,8 +352,12 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 };
                 let mut final_utxos = Vec::new();
                 for (utxo, prevout) in utxos.into_iter() {
-                    let height = self.address_cache.get_height(&prevout.txid).unwrap_or(0);
-                    let position = self.address_cache.get_position(&prevout.txid).unwrap_or(0);
+                    let Some(height) = self.address_cache.get_height(&prevout.txid) else {
+                        return json_rpc_res!(request, []);
+                    };
+                    let Some(position) = self.address_cache.get_position(&prevout.txid) else {
+                        return json_rpc_res!(request, []);
+                    };
 
                     final_utxos.push(json!({
                         "height": height,
@@ -498,18 +502,18 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }
             "blockchain.transaction.get_merkle" => {
                 let tx_id = get_arg!(request, Txid, 0);
-                let proof = self.address_cache.get_merkle_proof(&tx_id);
-                let height = self.address_cache.get_height(&tx_id);
-                if let Some(proof) = proof {
-                    let result = json!({
-                        "merkle": proof.hashes,
-                        "block_height": height.unwrap_or(0),
-                        "pos": proof.pos
-                    });
-                    return json_rpc_res!(request, result);
-                }
-
-                Err(super::error::Error::InvalidParams)
+                let Some(proof) = self.address_cache.get_merkle_proof(&tx_id) else {
+                    return Err(super::error::Error::InvalidParams);
+                };
+                let Some(height) = self.address_cache.get_height(&tx_id) else {
+                    return Err(super::error::Error::InvalidParams);
+                };
+                let result = json!({
+                    "merkle": proof.hashes,
+                    "block_height": height,
+                    "pos": proof.pos
+                });
+                json_rpc_res!(request, result)
             }
             //blockchain.transaction.id_from_pos
             // TODO: Create an actual histogram
@@ -523,7 +527,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let genesis_hash = self
                     .chain
                     .get_block_hash(0)
-                    .expect("genesis block is always in the chain store");
+                    .expect("Genesis block is always in the chain store");
                 let res = json!(
                     {
                         "genesis_hash": genesis_hash,
@@ -548,14 +552,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         }
     }
 
-    pub async fn rebroadcast_mempool_transactions(&self) {
-        let unconfirmed = match self.address_cache.find_unconfirmed() {
-            Ok(txs) => txs,
-            Err(e) => {
-                error!("Could not fetch unconfirmed transactions for rebroadcast: {e}");
-                return;
-            }
-        };
+    pub async fn rebroadcast_mempool_transactions(&self) -> Result<(), super::error::Error> {
+        let unconfirmed = self
+            .address_cache
+            .find_unconfirmed()
+            .map_err(|e| super::error::Error::WatchOnly(Box::new(e)))?;
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -564,6 +565,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 debug!("Rebroadcasted transaction {txid}");
             }
         }
+        Ok(())
     }
 
     pub async fn main_loop(mut self) -> Result<(), crate::error::Error> {
@@ -599,7 +601,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 .unwrap_or(true);
 
             if should_rebroadcast {
-                self.rebroadcast_mempool_transactions().await;
+                self.rebroadcast_mempool_transactions().await?;
                 self.last_rebroadcast = Some(Instant::now());
             }
 
@@ -659,7 +661,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         let Ok(blocks) =
             cfilters.match_any(_addresses, start_height, stop_height, self.chain.clone())
         else {
-            info!("Could not match block filters");
+            error!("Could not match block filters");
             self.addresses_to_scan.extend(addresses); // push them back to get a retry
             return Ok(());
         };
@@ -670,13 +672,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         for block in blocks {
             let block = self.node_interface.get_block(block).await;
             let Ok(Some(block)) = block else {
-                info!("Could not get block from node");
+                error!("Could not get block from node");
                 self.addresses_to_scan.extend(addresses); // push them back to get a retry
                 return Ok(());
             };
 
             let Ok(Some(height)) = self.chain.get_block_height(&block.block_hash()) else {
-                info!("Could not get block height: {}", block.block_hash());
+                error!("Could not get block height: {}", block.block_hash());
                 self.addresses_to_scan.extend(addresses); // push them back to get a retry
                 return Ok(());
             };
@@ -724,23 +726,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             self.address_cache.bump_height(height);
         }
 
-        match self.chain.get_height() {
-            Ok(chain_height) => {
-                if chain_height == height {
-                    for client in &mut self.clients.values() {
-                        let res = client.write(
-                            serde_json::to_string(&result)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        );
-                        if res.is_err() {
-                            info!("Could not write to client {client:?}");
-                        }
-                    }
+        let height_matches = self
+            .chain
+            .get_height()
+            .inspect_err(|e| error!("Could not get chain height: {e:?}"))
+            .is_ok_and(|h| h == height);
+
+        if height_matches {
+            let serialized = serde_json::to_string(&result)
+                .expect("serde_json::Value is always serializable");
+            for client in self.clients.values() {
+                if client.write(serialized.as_bytes()).is_err() {
+                    info!("Could not write to client {client:?}");
                 }
-            }
-            Err(e) => {
-                error!("Could not get chain height: {e:?}");
             }
         }
 
@@ -767,11 +765,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     let res = self.handle_client_request(client.clone(), req).await;
 
                     if let Ok(res) = res {
-                        client.write(
-                            serde_json::to_string(&res)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let res = serde_json::to_string(&res)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(res.as_bytes())?;
                     } else {
                         let res = json!({
                             "jsonrpc": "2.0",
@@ -782,11 +778,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                             },
                             "id": id
                         });
-                        client.write(
-                            serde_json::to_string(&res)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let res = serde_json::to_string(&res)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(res.as_bytes())?;
                     }
                 } else if let Ok(requests) = serde_json::from_str::<Vec<Request>>(&msg) {
                     let mut results = Vec::new();
@@ -814,11 +808,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         }
                     }
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(
-                            serde_json::to_string(&results)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let results = serde_json::to_string(&results)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(results.as_bytes())?;
                     }
                 } else {
                     let res = json!({
@@ -831,11 +823,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         "id": null
                     });
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(
-                            serde_json::to_string(&res)
-                                .expect("serde_json::Value is always serializable")
-                                .as_bytes(),
-                        )?;
+                        let res = serde_json::to_string(&res)
+                            .expect("serde_json::Value is always serializable");
+                        client.write(res.as_bytes())?;
                     }
                 }
             }
@@ -863,11 +853,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     "method": "blockchain.scripthash.subscribe",
                     "params": [hash, status_hash]
                 });
-                if let Err(err) = client.write(
-                    serde_json::to_string(&notify)
-                        .expect("serde_json::Value is always serializable")
-                        .as_bytes(),
-                ) {
+                let notify = serde_json::to_string(&notify)
+                    .expect("serde_json::Value is always serializable");
+                if let Err(err) = client.write(notify.as_bytes()) {
                     error!("{err}");
                 }
             }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -462,7 +462,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             // end of experimental endpoints
             "blockchain.transaction.broadcast" => {
                 let tx = get_arg!(request, String, 0);
-                let hex: Vec<_> = Vec::from_hex(&tx).map_err(|_| Error::InvalidParams)?;
+                let hex = Vec::from_hex(&tx).map_err(|_| Error::InvalidParams)?;
                 let tx: Transaction = deserialize(&hex).map_err(|_| Error::InvalidParams)?;
 
                 let txid = tx.compute_txid();

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -733,8 +733,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             .is_ok_and(|h| h == height);
 
         if height_matches {
-            let serialized = serde_json::to_string(&result)
-                .expect("serde_json::Value is always serializable");
+            let serialized =
+                serde_json::to_string(&result).expect("serde_json::Value is always serializable");
             for client in self.clients.values() {
                 if client.write(serialized.as_bytes()).is_err() {
                     info!("Could not write to client {client:?}");

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -42,6 +42,7 @@ use tracing::error;
 use tracing::info;
 use tracing::trace;
 
+use crate::error::Error;
 use crate::get_arg;
 use crate::json_rpc_res;
 use crate::request::Request;
@@ -92,27 +93,22 @@ impl<S: AsyncStream> TcpActor<S> {
                 result = lines.next_line() => {
                     match result {
                         Ok(Some(line)) => {
-                            match self.message_transmitter.send(Message::Message((self.client_id, line))) {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    error!("main loop receiver dropped: {e:?}");
-                                    break;
-                                }
+                            if let Err(e) = self.message_transmitter.send(Message::Message((self.client_id, line))) {
+                                error!("main loop receiver dropped: {e:?}");
+                                break;
                             }
                         }
                         Ok(None) => {
                             info!("Client closed connection: {}", self.client_id);
-                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
-                                Ok(_) => {}
-                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            if let Err(e) = self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                error!("main loop receiver dropped: {e:?}");
                             }
                             break;
                         }
                         Err(e) => {
                             error!("Error reading from client: {e:?}");
-                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
-                                Ok(_) => {}
-                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            if let Err(e) = self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                error!("main loop receiver dropped: {e:?}");
                             }
                             break;
                         }
@@ -256,7 +252,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         &mut self,
         client: Arc<Client>,
         request: Request,
-    ) -> Result<Value, super::error::Error> {
+    ) -> Result<Value, Error> {
         // Methods are in alphabetical order
         match request.method.as_str() {
             "blockchain.block.header" => {
@@ -268,7 +264,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let header = self
                     .chain
                     .get_block_header(&hash)
-                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                    .map_err(|e| Error::Blockchain(Box::new(e)))?;
                 let header = serialize_hex(&header);
                 json_rpc_res!(request, header)
             }
@@ -306,11 +302,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let (height, hash) = self
                     .chain
                     .get_best_block()
-                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                    .map_err(|e| Error::Blockchain(Box::new(e)))?;
                 let header = self
                     .chain
                     .get_block_header(&hash)
-                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                    .map_err(|e| Error::Blockchain(Box::new(e)))?;
                 let result = json!({
                     "height": height,
                     "hex": serialize_hex(&header)
@@ -466,10 +462,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             // end of experimental endpoints
             "blockchain.transaction.broadcast" => {
                 let tx = get_arg!(request, String, 0);
-                let hex: Vec<_> =
-                    Vec::from_hex(&tx).map_err(|_| super::error::Error::InvalidParams)?;
-                let tx: Transaction =
-                    deserialize(&hex).map_err(|_| super::error::Error::InvalidParams)?;
+                let hex: Vec<_> = Vec::from_hex(&tx).map_err(|_| Error::InvalidParams)?;
+                let tx: Transaction = deserialize(&hex).map_err(|_| Error::InvalidParams)?;
 
                 let txid = tx.compute_txid();
                 if let Err(e) = self
@@ -478,7 +472,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     .await?
                 {
                     error!("Could not broadcast transaction {txid} due to {e}");
-                    return Err(super::error::Error::Mempool(Box::new(e)));
+                    return Err(Error::Mempool(Box::new(e)));
                 };
 
                 let updated = self
@@ -498,15 +492,15 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     return json_rpc_res!(request, tx);
                 }
 
-                Err(super::error::Error::InvalidParams)
+                Err(Error::InvalidParams)
             }
             "blockchain.transaction.get_merkle" => {
                 let tx_id = get_arg!(request, Txid, 0);
                 let Some(proof) = self.address_cache.get_merkle_proof(&tx_id) else {
-                    return Err(super::error::Error::InvalidParams);
+                    return Err(Error::InvalidParams);
                 };
                 let Some(height) = self.address_cache.get_height(&tx_id) else {
-                    return Err(super::error::Error::InvalidParams);
+                    return Err(Error::InvalidParams);
                 };
                 let result = json!({
                     "merkle": proof.hashes,
@@ -548,15 +542,15 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 [format!("Floresta {}", env!("CARGO_PKG_VERSION")), "1.4"]
             ),
 
-            _ => Err(super::error::Error::InvalidParams),
+            _ => Err(Error::InvalidParams),
         }
     }
 
-    pub async fn rebroadcast_mempool_transactions(&self) -> Result<(), super::error::Error> {
+    pub async fn rebroadcast_mempool_transactions(&self) -> Result<(), Error> {
         let unconfirmed = self
             .address_cache
             .find_unconfirmed()
-            .map_err(|e| super::error::Error::WatchOnly(Box::new(e)))?;
+            .map_err(|e| Error::WatchOnly(Box::new(e)))?;
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -628,10 +622,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     /// Usually, we'll rely on compact block filters to speed things up. If
     /// we don't have compact block filters, we may rescan using the older,
     /// more bandwidth-intensive method of actually downloading blocks.
-    async fn rescan_for_addresses(
-        &mut self,
-        addresses: Vec<ScriptBuf>,
-    ) -> Result<(), super::error::Error> {
+    async fn rescan_for_addresses(&mut self, addresses: Vec<ScriptBuf>) -> Result<(), Error> {
         // If compact block filters are enabled, use them. Otherwise, fallback
         // to the "old-school" rescaning.
         if let Some(cfilters) = &self.block_filters {
@@ -651,7 +642,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         start_height: Option<u32>,
         stop_height: Option<u32>,
         addresses: Vec<ScriptBuf>,
-    ) -> Result<(), super::error::Error> {
+    ) -> Result<(), Error> {
         // By default, we look from 1..tip
         let mut _addresses = addresses
             .iter()
@@ -661,7 +652,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         let Ok(blocks) =
             cfilters.match_any(_addresses, start_height, stop_height, self.chain.clone())
         else {
-            error!("Could not match block filters");
+            error!("Could not find matching block filters");
             self.addresses_to_scan.extend(addresses); // push them back to get a retry
             return Ok(());
         };
@@ -882,17 +873,13 @@ pub async fn client_accept_loop(
                             tls_stream,
                             message_transmitter.clone(),
                         ));
-                        match message_transmitter
-                            .send(Message::NewClient((client.client_id, client)))
+                        if let Err(e) =
+                            message_transmitter.send(Message::NewClient((client.client_id, client)))
                         {
-                            Ok(_) => {
-                                id_count += 1;
-                            }
-                            Err(e) => {
-                                error!("main loop receiver dropped: {e:?}");
-                                break;
-                            }
+                            error!("main loop receiver dropped: {e:?}");
+                            break;
                         }
+                        id_count += 1;
                     }
                     Err(e) => {
                         error!("TLS accept error: {e:?}");
@@ -900,15 +887,13 @@ pub async fn client_accept_loop(
                 }
             } else {
                 let client = Arc::new(Client::new(id_count, stream, message_transmitter.clone()));
-                match message_transmitter.send(Message::NewClient((client.client_id, client))) {
-                    Ok(_) => {
-                        id_count += 1;
-                    }
-                    Err(e) => {
-                        error!("main loop receiver dropped: {e:?}");
-                        break;
-                    }
+                if let Err(e) =
+                    message_transmitter.send(Message::NewClient((client.client_id, client)))
+                {
+                    error!("main loop receiver dropped: {e:?}");
+                    break;
                 }
+                id_count += 1;
             }
         }
     }
@@ -968,13 +953,13 @@ macro_rules! json_rpc_res {
 }
 
 #[macro_export]
-/// Returns and parses a value from the request json or fails with [super::error::Error::InvalidParams].
+/// Returns and parses a value from the request json or fails with [Error::InvalidParams].
 macro_rules! get_arg {
     ($request:ident, $arg_type:ty, $idx:literal) => {
         if let Some(arg) = $request.params.get($idx) {
             serde_json::from_value::<$arg_type>(arg.clone())?
         } else {
-            return Err(super::error::Error::InvalidParams);
+            return Err(Error::InvalidParams);
         }
     };
 }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -346,22 +346,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let Some(utxos) = self.address_cache.get_address_utxos(&hash) else {
                     return json_rpc_res!(request, []);
                 };
-                let mut final_utxos = Vec::new();
-                for (utxo, prevout) in utxos.into_iter() {
-                    let Some(height) = self.address_cache.get_height(&prevout.txid) else {
-                        return json_rpc_res!(request, []);
-                    };
-                    let Some(position) = self.address_cache.get_position(&prevout.txid) else {
-                        return json_rpc_res!(request, []);
-                    };
-
-                    final_utxos.push(json!({
-                        "height": height,
-                        "tx_pos": position,
-                        "tx_hash": prevout.txid,
-                        "value": utxo.value
-                    }));
-                }
+                let final_utxos = utxos
+                    .into_iter()
+                    .flat_map(|(utxo, prevout)| {
+                        let height = self.address_cache.get_height(&prevout.txid)?;
+                        let position = self.address_cache.get_position(&prevout.txid)?;
+                        Some(json!({
+                            "height": height,
+                            "tx_pos": position,
+                            "tx_hash": prevout.txid,
+                            "value": utxo.value
+                        }))
+                    })
+                    .collect::<Vec<_>>();
 
                 json_rpc_res!(request, final_utxos)
             }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -92,22 +92,28 @@ impl<S: AsyncStream> TcpActor<S> {
                 result = lines.next_line() => {
                     match result {
                         Ok(Some(line)) => {
-                            self.message_transmitter
-                                .send(Message::Message((self.client_id, line)))
-                                .expect("Main loop is broken");
+                            match self.message_transmitter.send(Message::Message((self.client_id, line))) {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    error!("main loop receiver dropped: {e:?}");
+                                    break;
+                                }
+                            }
                         }
                         Ok(None) => {
                             info!("Client closed connection: {}", self.client_id);
-                            self.message_transmitter
-                                .send(Message::Disconnect(self.client_id))
-                                .expect("Main loop is broken");
+                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                Ok(_) => {}
+                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            }
                             break;
                         }
                         Err(e) => {
                             error!("Error reading from client: {e:?}");
-                            self.message_transmitter
-                                .send(Message::Disconnect(self.client_id))
-                                .expect("Main loop is broken");
+                            match self.message_transmitter.send(Message::Disconnect(self.client_id)) {
+                                Ok(_) => {}
+                                Err(e) => error!("main loop receiver dropped: {e:?}"),
+                            }
                             break;
                         }
                     }
@@ -341,15 +347,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             "blockchain.scripthash.get_mempool" => json_rpc_res!(request, []),
             "blockchain.scripthash.listunspent" => {
                 let hash = get_arg!(request, sha256::Hash, 0);
-                let utxos = self.address_cache.get_address_utxos(&hash);
-                if utxos.is_none() {
+                let Some(utxos) = self.address_cache.get_address_utxos(&hash) else {
                     return json_rpc_res!(request, []);
-                }
+                };
                 let mut final_utxos = Vec::new();
-                for (utxo, prevout) in utxos.unwrap().into_iter() {
-                    let height = self.address_cache.get_height(&prevout.txid).unwrap();
-
-                    let position = self.address_cache.get_position(&prevout.txid).unwrap();
+                for (utxo, prevout) in utxos.into_iter() {
+                    let height = self.address_cache.get_height(&prevout.txid).unwrap_or(0);
+                    let position = self.address_cache.get_position(&prevout.txid).unwrap_or(0);
 
                     final_utxos.push(json!({
                         "height": height,
@@ -519,7 +523,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let genesis_hash = self
                     .chain
                     .get_block_hash(0)
-                    .expect("Genesis block should be present");
+                    .expect("genesis block is always in the chain store");
                 let res = json!(
                     {
                         "genesis_hash": genesis_hash,
@@ -545,7 +549,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     }
 
     pub async fn rebroadcast_mempool_transactions(&self) {
-        let unconfirmed = self.address_cache.find_unconfirmed().unwrap();
+        let unconfirmed = match self.address_cache.find_unconfirmed() {
+            Ok(txs) => txs,
+            Err(e) => {
+                error!("Could not fetch unconfirmed transactions for rebroadcast: {e}");
+                return;
+            }
+        };
         for tx in unconfirmed {
             let txid = tx.compute_txid();
             if let Ok(Err(e)) = self.node_interface.broadcast_transaction(tx.clone()).await {
@@ -649,6 +659,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         let Ok(blocks) =
             cfilters.match_any(_addresses, start_height, stop_height, self.chain.clone())
         else {
+            info!("Could not match block filters");
             self.addresses_to_scan.extend(addresses); // push them back to get a retry
             return Ok(());
         };
@@ -659,16 +670,16 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         for block in blocks {
             let block = self.node_interface.get_block(block).await;
             let Ok(Some(block)) = block else {
+                info!("Could not get block from node");
                 self.addresses_to_scan.extend(addresses); // push them back to get a retry
                 return Ok(());
             };
 
-            let height = self
-                .chain
-                .get_block_height(&block.block_hash())
-                .ok()
-                .flatten()
-                .unwrap();
+            let Ok(Some(height)) = self.chain.get_block_height(&block.block_hash()) else {
+                info!("Could not get block height: {}", block.block_hash());
+                self.addresses_to_scan.extend(addresses); // push them back to get a retry
+                return Ok(());
+            };
 
             self.handle_block(block, height);
         }
@@ -713,12 +724,23 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             self.address_cache.bump_height(height);
         }
 
-        if self.chain.get_height().unwrap() == height {
-            for client in &mut self.clients.values() {
-                let res = client.write(serde_json::to_string(&result).unwrap().as_bytes());
-                if res.is_err() {
-                    info!("Could not write to client {client:?}");
+        match self.chain.get_height() {
+            Ok(chain_height) => {
+                if chain_height == height {
+                    for client in &mut self.clients.values() {
+                        let res = client.write(
+                            serde_json::to_string(&result)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        );
+                        if res.is_err() {
+                            info!("Could not write to client {client:?}");
+                        }
+                    }
                 }
+            }
+            Err(e) => {
+                error!("Could not get chain height: {e:?}");
             }
         }
 
@@ -737,17 +759,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             Message::Message((client, msg)) => {
                 trace!("Message: {msg}");
                 if let Ok(req) = serde_json::from_str::<Request>(msg.as_str()) {
-                    let client = self.clients.get(&client);
-                    if client.is_none() {
+                    let Some(client) = self.clients.get(&client).cloned() else {
                         error!("Client sent a message but is not listed as client");
                         return Ok(());
-                    }
-                    let client = client.unwrap().to_owned();
+                    };
                     let id = req.id.to_owned();
                     let res = self.handle_client_request(client.clone(), req).await;
 
                     if let Ok(res) = res {
-                        client.write(serde_json::to_string(&res).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&res)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     } else {
                         let res = json!({
                             "jsonrpc": "2.0",
@@ -758,17 +782,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                             },
                             "id": id
                         });
-                        client.write(serde_json::to_string(&res).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&res)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     }
                 } else if let Ok(requests) = serde_json::from_str::<Vec<Request>>(&msg) {
                     let mut results = Vec::new();
                     for req in requests {
-                        let client = self.clients.get(&client);
-                        if client.is_none() {
+                        let Some(client) = self.clients.get(&client).cloned() else {
                             error!("Client sent a message but is not listed as client");
                             return Ok(());
-                        }
-                        let client = client.unwrap().to_owned();
+                        };
                         let id = req.id.to_owned();
                         let res = self.handle_client_request(client.clone(), req).await;
 
@@ -788,7 +814,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         }
                     }
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(serde_json::to_string(&results).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&results)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     }
                 } else {
                     let res = json!({
@@ -801,7 +831,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                         "id": null
                     });
                     if let Some(client) = self.clients.get(&client) {
-                        client.write(serde_json::to_string(&res).unwrap().as_bytes())?;
+                        client.write(
+                            serde_json::to_string(&res)
+                                .expect("serde_json::Value is always serializable")
+                                .as_bytes(),
+                        )?;
                     }
                 }
             }
@@ -818,15 +852,22 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         for (_, out) in transactions {
             let hash = get_spk_hash(&out.script_pubkey);
             if let Some(client) = self.client_addresses.get(&hash) {
-                let history = self.address_cache.get_address_history(&hash);
+                let Some(history) = self.address_cache.get_address_history(&hash) else {
+                    info!("Could not get address history for {hash}");
+                    continue;
+                };
 
-                let status_hash = get_status(history.unwrap());
+                let status_hash = get_status(history);
                 let notify = json!({
                     "jsonrpc": "2.0",
                     "method": "blockchain.scripthash.subscribe",
                     "params": [hash, status_hash]
                 });
-                if let Err(err) = client.write(serde_json::to_string(&notify).unwrap().as_bytes()) {
+                if let Err(err) = client.write(
+                    serde_json::to_string(&notify)
+                        .expect("serde_json::Value is always serializable")
+                        .as_bytes(),
+                ) {
                     error!("{err}");
                 }
             }
@@ -853,10 +894,17 @@ pub async fn client_accept_loop(
                             tls_stream,
                             message_transmitter.clone(),
                         ));
-                        message_transmitter
+                        match message_transmitter
                             .send(Message::NewClient((client.client_id, client)))
-                            .expect("Main loop is broken");
-                        id_count += 1;
+                        {
+                            Ok(_) => {
+                                id_count += 1;
+                            }
+                            Err(e) => {
+                                error!("main loop receiver dropped: {e:?}");
+                                break;
+                            }
+                        }
                     }
                     Err(e) => {
                         error!("TLS accept error: {e:?}");
@@ -864,10 +912,15 @@ pub async fn client_accept_loop(
                 }
             } else {
                 let client = Arc::new(Client::new(id_count, stream, message_transmitter.clone()));
-                message_transmitter
-                    .send(Message::NewClient((client.client_id, client)))
-                    .expect("Main loop is broken");
-                id_count += 1;
+                match message_transmitter.send(Message::NewClient((client.client_id, client))) {
+                    Ok(_) => {
+                        id_count += 1;
+                    }
+                    Err(e) => {
+                        error!("main loop receiver dropped: {e:?}");
+                        break;
+                    }
+                }
             }
         }
     }

--- a/crates/floresta-electrum/src/error.rs
+++ b/crates/floresta-electrum/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("Mempool accept error")]
     Mempool(Box<dyn core::error::Error + Send + 'static>),
 
+    #[error("Watch-only cache error")]
+    WatchOnly(Box<dyn core::error::Error + Send + 'static>),
+
     #[error("Node isn't working")]
     NodeInterface(#[from] oneshot::error::RecvError),
 }

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -7,6 +7,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/getfloresta/floresta-media/master/logo_png/Icon-Green(main).png"
 )]
 #![allow(clippy::manual_is_multiple_of)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -7,7 +7,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/getfloresta/floresta-media/master/logo_png/Icon-Green(main).png"
 )]
 #![allow(clippy::manual_is_multiple_of)]
-#![cfg_attr(not(test), deny(clippy::as_conversions))]
+#![cfg_attr(not(test), deny(clippy::as_conversions), deny(clippy::unwrap_used))]
 
 use serde::Deserialize;
 use serde::Serialize;


### PR DESCRIPTION

### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

This pr removes all .unwrap() and non-infallible .expect() calls in non-test code of `floresta-electrum`

contributes to issue #463

note to reviewers : added `self.addresses_to_scan.extend(addresses)` to avoid silent address drop in at get_block_height failure in `rescan_with_block_filters` fn 

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
