### PR TITLE
[BUG] mempool_size should decreased  when txn is removed from mempool

### DIFF
--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -214,10 +214,13 @@ impl Mempool {
             .iter()
             .map(|tx| {
                 let short_txid = self.hasher.hash_one(tx.compute_txid());
-                self.transactions
+                if let Some(removed) = self
+                    .transactions
                     .remove(&short_txid)
-                    .map(|tx| tx.transaction);
-
+                    .map(|tx| tx.transaction)
+                {
+                    self.mempool_size -= removed.total_size();
+                }
                 tx.compute_txid()
             })
             .collect()
@@ -478,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mepool_accept() {
+    fn test_mempool_accept() {
         let mut mempool = Mempool::new(10_000_000);
 
         let transactions = build_transactions(42, false);
@@ -621,5 +624,36 @@ mod tests {
         assert!(block.check_merkle_root());
 
         check_block_transactions(block);
+    }
+
+    #[test]
+    fn test_consume_block_updates_mempool_size() {
+        let mut mempool = Mempool::new(10_000_000);
+
+        let transactions = build_transactions(15, false);
+        for tx in transactions {
+            mempool
+                .accept_to_mempool(tx)
+                .expect("failed to accept to mempool");
+        }
+
+        let size_before_consume = mempool.mempool_size;
+
+        let target = Target::MAX_ATTAINABLE_REGTEST;
+        let block = mempool.get_block_template(
+            block::Version::ONE,
+            BlockHash::all_zeros(),
+            0,
+            target.to_compact_lossy(),
+            4_000_000,
+        );
+
+        mempool.consume_block(&block);
+
+        assert_eq!(
+            mempool.mempool_size, 0,
+            "mempool_size was {} before consume_block and it is {} after but it should be 0",
+            size_before_consume, mempool.mempool_size
+        );
     }
 }


### PR DESCRIPTION
### Description and Notes

In the `consume_block` function the transactions were removed from the `mempool` but the `mempool_size` was never decremented. Over time this would cause the mempool to reject all new transactions with `MemoryUsageTooHigh` even when it's nearly empty.

Also there was a typo in `test_mepool_accept` test, I included in this PR rather than opening a new one for a typo.


### How to verify the changes you have done?

Added a small test to check it `test_consume_block_updates_mempool_size`

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
