### PR TITLE
Chore: add linters and formatters para Dockerfile, justfile, TOMLs and sh scripts.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -24,12 +24,6 @@ jobs:
       - name: Prepare environment
         run: uv sync --all-extras --dev
 
-      - name: Run black formatting
-        run: uv run black --check --verbose ./tests
-
-      - name: Run pylint linter
-        run: uv run pylint --verbose ./tests
-
       # Required for compiling the project, as it depends on the bitcoinkernel
       - name: Install Boost
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,19 @@ jobs:
       - name: Check justfile formatting
         run: just --fmt --check --unstable
 
+  toml-lint:
+    name: TOML Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install taplo
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \
+            | gzip -d > /usr/local/bin/taplo
+          chmod +x /usr/local/bin/taplo
+      - name: Check TOML formatting
+        run: taplo fmt --check
+
   rust-lint:
     name: Rust Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Run shellcheck
         run: shellcheck contrib/clean_data.sh contrib/feature_matrix.sh contrib/dist/gen_manpages.sh contrib/install.sh tests/prepare.sh tests/run.sh
 
+  docker-lint:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
   rust-lint:
     name: Rust Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,19 @@ jobs:
       - name: Run typos
         uses: crate-ci/typos@v1
 
+  just-lint:
+    name: Justfile Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - name: Check justfile formatting
+        run: just --fmt --check --unstable
+
   rust-lint:
     name: Rust Lint
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-hack

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,21 @@ jobs:
       - name: Check TOML formatting
         run: taplo fmt --check
 
+  shell-lint:
+    name: Shell Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shfmt
+        run: |
+          curl -fsSL https://github.com/mvdan/sh/releases/download/v3.12.0/shfmt_v3.12.0_linux_amd64 \
+            -o /usr/local/bin/shfmt
+          chmod +x /usr/local/bin/shfmt
+      - name: Check shell formatting
+        run: shfmt -d contrib/clean_data.sh contrib/feature_matrix.sh contrib/dist/gen_manpages.sh contrib/install.sh tests/prepare.sh tests/run.sh
+      - name: Run shellcheck
+        run: shellcheck contrib/clean_data.sh contrib/feature_matrix.sh contrib/dist/gen_manpages.sh contrib/install.sh tests/prepare.sh tests/run.sh
+
   rust-lint:
     name: Rust Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,66 @@
+name: Linting
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  typos:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run typos
+        uses: crate-ci/typos@v1
+
+  rust-lint:
+    name: Rust Lint
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Boost
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
+      - name: Run cargo fmt
+        run: cargo +nightly fmt --all --check
+
+      - name: Run cargo doc
+        run: |
+          RUSTDOCFLAGS="--cfg docsrs -D warnings" \
+          cargo +nightly doc --workspace --no-deps --lib --all-features --document-private-items
+
+      - name: Run cargo clippy
+        run: ./contrib/feature_matrix.sh clippy '-- -D warnings'
+        shell: bash # Ensure the script runs using bash on all platforms
+
+  python-lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Prepare environment
+        run: uv sync --all-extras --dev
+
+      - name: Run black formatting
+        run: uv run black --check --verbose ./tests
+
+      - name: Run pylint linter
+        run: uv run pylint --verbose ./tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,38 +8,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-hack
-
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-
-      - name: Install Boost
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libboost-all-dev
-
-      - name: Spell check
-        uses: crate-ci/typos@v1
-
-      - name: Run cargo fmt
-        run: cargo +nightly fmt --all --check
-
-      - name: Run cargo doc
-        run: |
-          RUSTDOCFLAGS="--cfg docsrs -D warnings" \
-          cargo +nightly doc --workspace --no-deps --lib --all-features --document-private-items
-
-      - name: Run cargo clippy
-        run: ./contrib/feature_matrix.sh clippy '-- -D warnings'
-        shell: bash # Ensure the script runs using bash on all platforms
-
   cross-testing:
     strategy:
       matrix:

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3008 # Pin versions in apt-get install

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,7 @@
 # imports
-reorder_imports = true
-imports_granularity = "Item"
 group_imports = "StdExternalCrate"
+imports_granularity = "Item"
+reorder_imports = true
 
 # lines
 newline_style = "Unix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,70 +1,94 @@
 [workspace]
-resolver = "2"
 members = [
-    # Libraries
-    "crates/floresta",
-    "crates/floresta-node",
-    "crates/floresta-chain",
-    "crates/floresta-rpc",
-    "crates/floresta-common",
-    "crates/floresta-compact-filters",
-    "crates/floresta-electrum",
-    "crates/floresta-watch-only",
-    "crates/floresta-wire",
-    "crates/floresta-mempool",
+  # Libraries
+  "crates/floresta",
+  "crates/floresta-node",
+  "crates/floresta-chain",
+  "crates/floresta-rpc",
+  "crates/floresta-common",
+  "crates/floresta-compact-filters",
+  "crates/floresta-electrum",
+  "crates/floresta-watch-only",
+  "crates/floresta-wire",
+  "crates/floresta-mempool",
 
-    # Binaries
-    "bin/florestad",
-    "bin/floresta-cli",
+  # Binaries
+  "bin/florestad",
+  "bin/floresta-cli",
 
-    # Tests and monitoring
-    "metrics",
-    "fuzz",
+  # Tests and monitoring
+  "metrics",
+  "fuzz",
 ]
+resolver = "2"
 
 default-members = [
-    "crates/floresta",
-    "crates/floresta-node",
-    "crates/floresta-chain",
-    "crates/floresta-rpc",
-    "crates/floresta-common",
-    "crates/floresta-compact-filters",
-    "crates/floresta-electrum",
-    "crates/floresta-watch-only",
-    "crates/floresta-wire",
-    "crates/floresta-mempool",
-    "bin/florestad",
-    "bin/floresta-cli",
+  "crates/floresta",
+  "crates/floresta-node",
+  "crates/floresta-chain",
+  "crates/floresta-rpc",
+  "crates/floresta-common",
+  "crates/floresta-compact-filters",
+  "crates/floresta-electrum",
+  "crates/floresta-watch-only",
+  "crates/floresta-wire",
+  "crates/floresta-mempool",
+  "bin/florestad",
+  "bin/floresta-cli",
 ]
 
 [workspace.package]
-rust-version = "1.81.0" # MSRV declaration
 readme = "README.md"
+rust-version = "1.81.0" # MSRV declaration
 
 # Version Convention: Use major.minor only (e.g., "1.9" not "1.9.1")
 # We accept all compatible patch versions, so specifying patch level is misleading.
 # For exact versions when needed, use "=1.9.1"
 [workspace.dependencies]
-axum = { version = "0.8", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
+axum = { version = "0.8", default-features = false, features = [
+  "http1",
+  "json",
+  "tracing",
+  "tokio",
+] }
 bitcoin = { version = "0.32", default-features = false }
-clap = { version = "4.5", default-features = false, features = ["derive", "std"] }
-corepc-types = "0.11"
+clap = { version = "4.5", default-features = false, features = [
+  "derive",
+  "std",
+] }
 console-subscriber = { version = "0.5", default-features = false }
+corepc-types = "0.11"
 dns-lookup = "2.1"
 hex = "0.4"
 kv = "0.24"
 miniscript = { version = "12.3", default-features = false }
 rand = "0.8"
-rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs", "pem"] }
+rcgen = { version = "0.14", default-features = false, features = [
+  "aws_lc_rs",
+  "pem",
+] }
 rustreexo = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = { version = "0.10", default-features = false }
-spin = { version = "0.10", default-features = false, features = ["spin_mutex", "rwlock"] }
+spin = { version = "0.10", default-features = false, features = [
+  "spin_mutex",
+  "rwlock",
+] }
 tempfile = "3.23"
-tokio = { version = "1.48", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
+tokio = { version = "1.48", features = [
+  "net",
+  "time",
+  "rt-multi-thread",
+  "signal",
+  "macros",
+] }
 tokio-rustls = "0.26"
-toml = { version = "0.9", default-features = false, features = ["std", "parse", "serde"] }
+toml = { version = "0.9", default-features = false, features = [
+  "std",
+  "parse",
+  "serde",
+] }
 tracing = { version = "0.1", default-features = false }
 zstd = "0.13"
 
@@ -73,11 +97,11 @@ floresta-chain = { path = "crates/floresta-chain" }
 floresta-common = { path = "crates/floresta-common" }
 floresta-compact-filters = { path = "crates/floresta-compact-filters" }
 floresta-electrum = { path = "crates/floresta-electrum" }
+floresta-mempool = { path = "crates/floresta-mempool" }
 floresta-node = { path = "crates/floresta-node", default-features = false }
 floresta-rpc = { path = "crates/floresta-rpc" }
 floresta-watch-only = { path = "crates/floresta-watch-only" }
 floresta-wire = { path = "crates/floresta-wire" }
-floresta-mempool = { path = "crates/floresta-mempool" }
 metrics = { path = "metrics" }
 
 [workspace.lints.clippy]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:13.2-slim@sha256:18764e98673c3baf1a6f8d960b5b5a1ec69092049522abac4e2
 
 ARG BUILD_FEATURES=""
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
     curl \
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     libboost-all-dev \
     && rm -rf /var/lib/apt/lists/*
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup default 1.81.0

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "floresta-cli"
-version = "0.5.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 description = """
 A command line interface for Florestad.
 
 You can use this client to interact with a running Florestad node. Check out doc/rpc/ or run `floresta-cli --help` for more information
 on how to use the CLI.
 """
-repository = "https://github.com/getfloresta/Floresta"
-readme = "README.md"
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
-categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
+license = "MIT"
+name = "floresta-cli"
+readme = "README.md"
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/bin/florestad/Cargo.toml
+++ b/bin/florestad/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
-name = "florestad"
-version = "0.9.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 description = """
 The main binary for Floresta, a lightweight Bitcoin node implementation in Rust,
 utilizing Utreexo for efficient state management.
@@ -13,10 +10,13 @@ run this binary as a daemon on unix systems. There's a couple of features and co
 options to customize the node to your needs. Check out the README.md and the documentation
 for more information on how to use and configure Florestad.
 """
-repository = "https://github.com/getfloresta/Floresta"
-readme.workspace = true # Floresta/README.md
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
-categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
+license = "MIT"
+name = "florestad"
+readme.workspace = true # Floresta/README.md
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.9.0"
 
 [dependencies]
 bitcoin = { workspace = true }
@@ -26,7 +26,11 @@ dirs = { version = "4.0", default-features = false }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2", default-features = false }
-tracing-subscriber = { version = "0.3", features = ["chrono", "ansi", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = [
+  "chrono",
+  "ansi",
+  "env-filter",
+] }
 
 # Local dependencies
 floresta-node = { workspace = true }
@@ -38,12 +42,12 @@ libc = { version = "0.2" }
 toml = { workspace = true }
 
 [features]
-default = ["json-rpc"]
 compact-filters = ["floresta-node/compact-filters"]
-zmq-server = ["floresta-node/zmq-server"]
+default = ["json-rpc"]
 json-rpc = ["floresta-node/json-rpc", "compact-filters"]
 metrics = ["floresta-node/metrics"]
 tokio-console = ["dep:console-subscriber"]
+zmq-server = ["floresta-node/zmq-server"]
 
 [lints]
 workspace = true

--- a/contrib/dist/gen_manpages.sh
+++ b/contrib/dist/gen_manpages.sh
@@ -31,7 +31,8 @@ convert_single() {
     fi
 
     # Extract filename without extension
-    local basename=$(basename "$file" .md)
+    local basename
+    basename=$(basename "$file" .md)
 
     # Skip the template stub file
     if [[ "$basename" == "template" ]]; then

--- a/contrib/feature_matrix.sh
+++ b/contrib/feature_matrix.sh
@@ -40,10 +40,10 @@ for crate in $crates; do
 
     # The default feature, if not used to conditionally compile code, can be skipped as the combinations already
     # include that case (see https://github.com/taiki-e/cargo-hack/issues/155#issuecomment-2474330839)
-    if [ "$crate" = "floresta-compact-filters" ] || \
-       [ "$crate" = "floresta-electrum" ] || \
-       [ "$crate" = "fuzz" ] || \
-       [ "$crate" = "metrics" ]; then
+    if [ "$crate" = "floresta-compact-filters" ] ||
+        [ "$crate" = "floresta-electrum" ] ||
+        [ "$crate" = "fuzz" ] ||
+        [ "$crate" = "metrics" ]; then
         # These crates don't have a default feature
         skip_default=""
     else
@@ -62,5 +62,5 @@ for crate in $crates; do
         cargo hack test --release --feature-powerset $skip_default -v $cargo_arg
     fi
 
-    cd - > /dev/null || exit 1
+    cd - >/dev/null || exit 1
 done

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -106,8 +106,7 @@ check_interactive_mode() {
 }
 
 # Use getopt for long options
-OPTIONS=$(getopt -o x:d:a:n:t:p:C:z:v:f:usUNh --long xpub:,desc:,address:,network:,tag:,proxy:,connect:,zmq-address:,assume-valid:,filters:,assume-utreexo,tls,uninstall,non-interactive,help -n "$0" -- "$@")
-if [ $? -ne 0 ]; then
+if ! OPTIONS=$(getopt -o x:d:a:n:t:p:C:z:v:f:usUNh --long xpub:,desc:,address:,network:,tag:,proxy:,connect:,zmq-address:,assume-valid:,filters:,assume-utreexo,tls,uninstall,non-interactive,help -n "$0" -- "$@"); then
     show_usage
     exit 1
 fi
@@ -216,8 +215,15 @@ done
 #   - testnet
 #   - regtest
 validate_network() {
-    valid_networks=("bitcoin" "signet" "testnet3" "testnet4" "regtest")
-    if [[ ! " ${valid_networks[@]} " =~ " ${network} " ]]; then
+    local valid_networks=("bitcoin" "signet" "testnet3" "testnet4" "regtest")
+    local valid=false
+    for n in "${valid_networks[@]}"; do
+        if [ "$n" = "$network" ]; then
+            valid=true
+            break
+        fi
+    done
+    if [ "$valid" = false ]; then
         echo "❌ Invalid network '$network'. Valid options are: ${valid_networks[*]}"
         exit 1
     fi
@@ -264,19 +270,20 @@ install_rustup() {
         export PATH=/home/$me/.cargo/bin:$PATH
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --no-modify-path
 
-        chown $me:$me -R /home/$me/.cargo
+        chown "$me":"$me" -R /home/"$me"/.cargo
 
         # Load it on profile
-        echo "source /home/$me/.cargo/env" >>/home/$me/.profile
-        source /home/$me/.cargo/env
+        echo "source /home/$me/.cargo/env" >>/home/"$me"/.profile
+        # shellcheck disable=SC1090
+        source /home/"$me"/.cargo/env
     else
         echo "🦀 Rustup found in $haveRust. Skip download..."
     fi
 
-    isUpdated=$(/home/$me/.cargo/bin/rustup check | grep -B 1 "Up to date")
+    isUpdated=$(/home/"$me"/.cargo/bin/rustup check | grep -B 1 "Up to date")
     if [ -z "$isUpdated" ]; then
         echo "🦀 Updating rust..."
-        /home/$me/.cargo/bin/rustup update
+        /home/"$me"/.cargo/bin/rustup update
     else
         echo "🦀 Skip rust update..."
     fi
@@ -286,7 +293,7 @@ install_rustup() {
 #
 # Clean all downloaded or installed things
 clean_on_error() {
-    rm $1
+    rm "$1"
     rm -rf "$tarDest"
     rm -rf "$bdlDir"
     cleanup_apt gcc build-essential pkg-config libssl-dev mold
@@ -339,13 +346,13 @@ download_floresta() {
         clean_on_error "$ascDest"
     fi
 
-    cd /tmp
+    cd /tmp || exit 1
     tarBaseName=$(basename "$tarDest")
     if ! grep "$tarBaseName" "$shaDest" | sha256sum -c --status -; then
         echo "❌ Integrity check failed for $tarDest"
         clean_on_error "$tarDest"
     fi
-    cd - >/dev/null
+    cd - >/dev/null || exit 1
     echo "🌳 Integrity check passed"
 }
 
@@ -355,11 +362,11 @@ download_floresta() {
 # and floresta-cli (command line interface) into /usr/local/bin
 build_floresta() {
     echo "🌳 Extracting floresta $tarDest to /tmp..."
-    tar -xzf $tarDest -C /tmp
+    tar -xzf "$tarDest" -C /tmp
 
     echo "🦀 Building florestad and floresta-cli $defaultTag..."
-    cd $bdlDir
-    RUSTFLAGS="-C link-arg=-fuse-ld=mold -C target-cpu=native"
+    cd "$bdlDir" || exit 1
+    export RUSTFLAGS="-C link-arg=-fuse-ld=mold -C target-cpu=native"
     cargo build --release \
         --bin florestad \
         --bin floresta-cli \
@@ -367,8 +374,8 @@ build_floresta() {
         --locked
 
     echo "🌳 Copying binaries to /usr/local/bin (need sudo)..."
-    sudo install -m 0755 -t /usr/local/bin/ $bdlDir/target/release/florestad
-    sudo install -m 0755 -t /usr/local/bin/ $bdlDir/target/release/floresta-cli
+    sudo install -m 0755 -t /usr/local/bin/ "$bdlDir"/target/release/florestad
+    sudo install -m 0755 -t /usr/local/bin/ "$bdlDir"/target/release/floresta-cli
 }
 
 # func: setup_service
@@ -383,8 +390,7 @@ setup_service() {
     echo "🐧 Setup floresta sysusers.d..."
     echo "u florestad - - $florestaDir" | sudo tee $florestaUserPath >/dev/null
     echo "🐧 Applying $florestaUserPath (need sudo)"
-    sudo systemd-sysusers
-    if [ $? -ne 0 ]; then
+    if ! sudo systemd-sysusers; then
         echo "❌ Failed to create systemd-sysusers"
         exit 1
     fi
@@ -394,8 +400,7 @@ setup_service() {
     echo "d $florestaDir 0710 florestad florestad - -" | sudo tee $florestaTmpPath >/dev/null
     echo "d $florestaLib 0710 florestad florestad - -" | sudo tee -a $florestaTmpPath >/dev/null
     echo "🐧 Applying $florestaTmpPath (need sudo)"
-    sudo systemd-tmpfiles --create
-    if [ $? -ne 0 ]; then
+    if ! sudo systemd-tmpfiles --create; then
         echo "❌ Failed to create systemd-tmpfiles"
         exit 1
     fi
@@ -914,8 +919,8 @@ interactive_select_proxy() {
         edited=$?
         check_dialog_escape
 
-        # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        # Check if user pressed Cancel
+        if [ "$edited" -ne 0 ]; then
             dialog --title "Floresta" \
                 --msgbox "❌ Proxy input canceled. Returning to setup menu." 8 45
             check_dialog_escape
@@ -953,23 +958,25 @@ interactive_connect() {
     local connect_regex="^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(:([0-9]{1,5}))?$"
 
     while true; do
-        # Prompt user for proxy input
+        # Prompt user for connect input
         connect=$(dialog --title "Floresta-Installer (Set a node to connect)" \
             --inputbox "We'll connect ONLY to this node. It should be an ipv4 address in the format <address>[:<port>]." \
             10 60 \
             3>&1 1>&2 2>&3)
+
+        edited=$?
         check_dialog_escape
 
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$edited" -ne 0 ]; then
             dialog --title "Floresta-Installer" --msgbox "❌ Connect input canceled. Returning to setup menu." 8 45
             check_dialog_escape
             interactive_advanced_setup
             return 1
         fi
 
-        # Validate proxy format
-        if [[ "$proxy" =~ $proxy_regex ]]; then
+        # Validate connect format
+        if [[ "$connect" =~ $connect_regex ]]; then
             dialog --title "Floresta-Installer" --msgbox "✅ A node to connect to set successfully: $connect" 10 60
             check_dialog_escape
             interactive_advanced_setup
@@ -994,8 +1001,9 @@ interactive_zeromq() {
             10 60 \
             3>&1 1>&2 2>&3)
 
+        edited=$?
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$edited" -ne 0 ]; then
             dialog --title "Floresta-Installer (Set zeromq)" --msgbox "❌ ZeroMQ input canceled. Returning to setup menu." 8 45
             check_dialog_escape
             interactive_advanced_setup
@@ -1023,16 +1031,16 @@ interactive_filters() {
 
     while true; do
         # Prompt user for filters_start_height input
-        echo "sha256sum: $sha256res == $sha256exp"
         filters_start_height=$(dialog --title "Floresta-Installer (Set enable filters)" \
             --inputbox $'Do you want to use \'cfilters\' and \'filters-start-height\'?\n\n"cfilters" let you query for chain data after IBD, like wallet rescan, finding a utxo, finding specific tx_ids. Will cause more disk usage.\n\n"filters-start-height" download block filters starting at this height. Negative numbers are relative to the current tip. For example, if the current tip is at height 1000, and we set this value to -100, we will start downloading filters from height 900.\n' \
             20 60 \
             3>&1 1>&2 2>&3)
 
+        edited=$?
         check_dialog_escape
 
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$edited" -ne 0 ]; then
             enable_cfilters=false
             dialog --title "Floresta-Installer (Set enable filters)" --msgbox "❌ Enable filters input canceled. Returning to setup menu." 8 45
             check_dialog_escape
@@ -1062,8 +1070,7 @@ interactive_ask_assume_valid() {
 
     if dialog --title "Floresta-Installer" --yesno "Do you want to use 'assume-valid'?\n\nThis option assumes that scripts before this height are valid." 15 60; then
         check_dialog_escape
-        interactive_assume_valid
-        if [ $? -ne 0 ]; then
+        if ! interactive_assume_valid; then
             assume_valid="" # Clear invalid value
             dialog --title "Floresta-Installer" --msgbox "❌ Invalid BLOCK_HEIGHT detected. Must be a numeric value." 8 45
             check_dialog_escape
@@ -1241,18 +1248,19 @@ interactive_ask_for_add_descriptors() {
 # wallet_descriptors array and show a confirmation.
 # If the user provides an invalid one, clear the list and restart the process.
 interactive_add_descriptor() {
-    local temp_file=$(mktemp)
+    local temp_file
+    temp_file=$(mktemp)
     echo "" >"$temp_file"
 
     while true; do
+        # shellcheck disable=SC2094
         dialog --title "Floresta" \
             --editbox "$temp_file" 15 80 2>"$temp_file"
 
         edited=$?
         check_dialog_escape
 
-        result=$?
-        if [ result -ne 0 ]; then
+        if [ "$edited" -ne 0 ]; then
             rm -f "$temp_file"
             return 1
         fi
@@ -1354,7 +1362,7 @@ interactive_review() {
     review_message+="Proxy:              $([ -n "$proxy" ] && echo "$proxy" || echo "Not configured")\n"
     review_message+="ZeroMQ:             $([ -n "$zeromq" ] && echo "$zeromq" || echo "Not configured")\n"
     review_message+="Connect to:         $([ -n "$connect" ] && echo "$connect" || echo "Not configured")\n"
-    review_message+="Filters:            $([ -n "$filters_start_height" ] && echo $filters_start_height || echo "Not configured")\n"
+    review_message+="Filters:            $([ -n "$filters_start_height" ] && echo "$filters_start_height" || echo "Not configured")\n"
     review_message+="Assume valid:       $([ -n "$assume_valid" ] && echo "$assume_valid" || echo "Not configured")\n"
     review_message+="Assume utreexo:     $assume_utreexo\n"
     review_message+="Enable TLS:         $enable_tls\n"
@@ -1401,7 +1409,6 @@ main() {
         if [ "$uninstall_mode" = true ]; then
             clear
             uninstall_floresta
-            exit 0
         else
             interactive_setup
         fi

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "floresta-chain"
-version = "0.5.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
+categories = ["cryptography::cryptocurrencies", "database"]
 description = """
     Reusable components for building consensus-critical Bitcoin applications.
     Using floresta-chain, you can create a Bitcoin node that validates blocks
     and transactions, according to the Bitcoin consensus rules.
 """
-repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
-readme.workspace = true # Floresta/README.md
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "node", "consensus"]
-categories = ["cryptography::cryptocurrencies", "database"]
+license = "MIT"
+name = "floresta-chain"
+readme.workspace = true # Floresta/README.md
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -27,11 +27,14 @@ serde = { workspace = true, optional = true }
 sha2 = { workspace = true, features = ["std"] }
 spin = { workspace = true }
 tracing = { workspace = true }
-twox-hash = { version = "2.1", default-features = false, features = ["xxhash3_64", "std"], optional = true }
+twox-hash = { version = "2.1", default-features = false, features = [
+  "xxhash3_64",
+  "std",
+], optional = true }
 
 # Local dependencies
 floresta-common = { workspace = true, features = ["std"] }
-metrics = { workspace = true,  optional = true }
+metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 bitcoin = { workspace = true, features = ["serde"] }
@@ -44,15 +47,15 @@ tempfile = { workspace = true }
 zstd = { workspace = true }
 
 [features]
-default = []
 bitcoinkernel = ["dep:bitcoinkernel"]
+default = []
+flat-chainstore = ["dep:memmap2", "dep:lru", "dep:twox-hash"]
 metrics = ["dep:metrics"]
 test-utils = ["dep:serde"]
-flat-chainstore = ["dep:memmap2", "dep:lru", "dep:twox-hash"]
 
 [[bench]]
-name = "chain_state_bench"
 harness = false
+name = "chain_state_bench"
 required-features = ["flat-chainstore", "test-utils"]
 
 [lints]

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "floresta-common"
-version = "0.5.0"
-edition = "2021"
-description = "Common types and functions for Floresta"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
+description = "Common types and functions for Floresta"
+edition = "2021"
 license = "MIT"
+name = "floresta-common"
+readme.workspace = true                                     # Floresta/README.md
 repository = "https://github.com/getfloresta/Floresta"
-readme.workspace = true # Floresta/README.md
+version = "0.5.0"
 
 [dependencies]
 bitcoin = { workspace = true }
@@ -19,8 +19,8 @@ spin = { workspace = true }
 default = ["std", "descriptors-std"]
 std = ["bitcoin/std", "sha2/std"]
 # Both features can be set at the same time, but for `no_std` only the latter should be used
-descriptors-std = ["miniscript/std"]
 descriptors-no-std = ["miniscript/no-std"]
+descriptors-std = ["miniscript/std"]
 
 [lints]
 workspace = true

--- a/crates/floresta-compact-filters/Cargo.toml
+++ b/crates/floresta-compact-filters/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "floresta-compact-filters"
-version = "0.5.0"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-edition = "2018"
-homepage = "https://github.com/davidson-souza/floresta"
-repository = "https://github.com/davidson-souza/floresta"
 description = """
 BIP158 compact filters for easy rescan of the blockchain in light clients.
 """
+edition = "2018"
+homepage = "https://github.com/davidson-souza/floresta"
+name = "floresta-compact-filters"
 readme.workspace = true # Floresta/README.md
+repository = "https://github.com/davidson-souza/floresta"
+version = "0.5.0"
 
 [dependencies]
 bitcoin = { workspace = true }

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "floresta-electrum"
-version = "0.5.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
+categories = ["cryptography::cryptocurrencies"]
 description = """
     A simple Electrum server implementation for Floresta. It is based on the
     Electrum protocol specification and works out of the box with any wallet
     that supports Electrum servers.
 """
-repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
-readme.workspace = true # Floresta/README.md
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
-categories = ["cryptography::cryptocurrencies"]
+license = "MIT"
+name = "floresta-electrum"
+readme.workspace = true # Floresta/README.md
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [dependencies]
 bitcoin = { workspace = true }
@@ -26,8 +26,8 @@ tracing = { workspace = true }
 
 # Local dependencies
 floresta-chain = { workspace = true, features = ["bitcoinkernel"] }
-floresta-compact-filters = { workspace = true }
 floresta-common = { workspace = true }
+floresta-compact-filters = { workspace = true }
 floresta-watch-only = { workspace = true }
 floresta-wire = { workspace = true }
 

--- a/crates/floresta-mempool/Cargo.toml
+++ b/crates/floresta-mempool/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "floresta-mempool"
-version = "0.5.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 description = """
     A policy-driven, stateful transaction mempool for Floresta,
     responsible for transaction relay decisions, fee estimation, and
     block template construction.
 """
-repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
-readme.workspace = true
+edition = "2021"
 keywords = ["bitcoin", "mempool", "transactions"]
+license = "MIT"
+name = "floresta-mempool"
+readme.workspace = true
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [dependencies]
 ahash = { version = "0.8", default-features = false }

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "floresta-node"
-version = "0.9.0"
-edition = "2021"
-readme.workspace = true # Floresta/README.md
 authors = ["Floresta Developers <contact@getfloresta.org>"]
+edition = "2021"
+name = "floresta-node"
+readme.workspace = true                                     # Floresta/README.md
+version = "0.9.0"
 
 [dependencies]
 axum = { workspace = true, optional = true }
@@ -24,13 +24,13 @@ zmq = { version = "0.10", optional = true, default-features = false }
 
 # Local dependencies
 floresta-chain = { workspace = true, features = ["bitcoinkernel"] }
-floresta-compact-filters = { workspace = true, optional = true }
 floresta-common = { workspace = true }
+floresta-compact-filters = { workspace = true, optional = true }
 floresta-electrum = { workspace = true }
 floresta-mempool = { workspace = true }
 floresta-watch-only = { workspace = true }
 floresta-wire = { workspace = true }
-metrics = { workspace = true,  optional = true }
+metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4"
@@ -43,10 +43,10 @@ libc = "0.2"
 
 [features]
 compact-filters = ["dep:floresta-compact-filters"]
-zmq-server = ["dep:zmq"]
-json-rpc = ["dep:axum", "dep:tower-http", "compact-filters"]
 default = ["json-rpc"]
+json-rpc = ["dep:axum", "dep:tower-http", "compact-filters"]
 metrics = ["dep:metrics", "floresta-wire/metrics", "floresta-chain/metrics"]
+zmq-server = ["dep:zmq"]
 
 [lints]
 workspace = true

--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "floresta-rpc"
-version = "0.5.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 description = """
 floresta-rpc is a Rust library that provides a JSON-RPC interface for interacting with Floresta. It allows
 users to perform various operations such as querying blockchain data, managing wallets, and
 broadcasting transactions through a simple and efficient API.
 """
-repository = "https://github.com/getfloresta/Floresta"
-readme.workspace = true # Floresta/README.md
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
-categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
+license = "MIT"
+name = "floresta-rpc"
+readme.workspace = true # Floresta/README.md
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [dependencies]
 bitcoin = { workspace = true }
@@ -27,9 +27,9 @@ rand = { workspace = true }
 rcgen = { workspace = true }
 
 [features]
+clap = ["dep:clap"]
 default = ["with-jsonrpc"]
 with-jsonrpc = ["dep:jsonrpc"]
-clap = ["dep:clap"]
 
 [lints]
 workspace = true

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "floresta-watch-only"
-version = "0.5.0"
-edition = "2021"
-description = "A simple, lightweight and Electrum-First, watch-only wallet"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-keywords = ["bitcoin", "watch-only", "electrum-server"]
 categories = ["cryptography::cryptocurrencies"]
+description = "A simple, lightweight and Electrum-First, watch-only wallet"
+edition = "2021"
+keywords = ["bitcoin", "watch-only", "electrum-server"]
 license = "MIT"
+name = "floresta-watch-only"
+readme.workspace = true                                                     # Floresta/README.md
 repository = "https://github.com/getfloresta/Floresta"
-readme.workspace = true # Floresta/README.md
+version = "0.5.0"
 
 [dependencies]
 bitcoin = { workspace = true, features = ["serde"] }

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name = "floresta-wire"
-version = "0.5.0"
-edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
+categories = ["cryptography::cryptocurrencies", "network-programming"]
 description = """
     Some utreexo-aware wire protocol for floresta. You can use this crate
     to fetch blocks and transactions from the network, and to broadcast
     your own transactions.
 """
-repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
-readme = "README.md"
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "p2p", "networking"]
-categories = ["cryptography::cryptocurrencies", "network-programming"]
+license = "MIT"
+name = "floresta-wire"
+readme = "README.md"
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [dependencies]
-bip324 = { version = "0.10", features = [ "tokio" ] }
+bip324 = { version = "0.10", features = ["tokio"] }
 bitcoin = { workspace = true }
 dns-lookup = { workspace = true }
 rand = { workspace = true }
@@ -25,18 +25,22 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
-ureq = { version = "3.1", features = ["socks-proxy", "json", "rustls-no-provider"], default-features = false }
+ureq = { version = "3.1", features = [
+  "socks-proxy",
+  "json",
+  "rustls-no-provider",
+], default-features = false }
 
 # Local dependencies
 floresta-chain = { workspace = true, features = ["flat-chainstore"] }
-floresta-compact-filters = { workspace = true }
 floresta-common = { workspace = true }
+floresta-compact-filters = { workspace = true }
 floresta-mempool = { workspace = true }
-metrics = { workspace = true,  optional = true }
+metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
-zstd = { workspace = true }
 derive_more = { version = "2.1", features = ["constructor"] }
+zstd = { workspace = true }
 
 [features]
 default = []

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
-name = "floresta"
-version = "0.5.0"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-edition = "2021"
+categories = ["cryptography::cryptocurrencies"]
 description = """
     A modular and extensible framework for building Utreexo based Bitcoin nodes.
 
@@ -16,11 +14,13 @@ description = """
     See the examples directory for examples of how to use this library, and
     each crate's documentation for more information on how to use each module.
 """
-repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
-readme.workspace = true # Floresta/README.md
+edition = "2021"
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
-categories = ["cryptography::cryptocurrencies"]
+license = "MIT"
+name = "floresta"
+readme.workspace = true # Floresta/README.md
+repository = "https://github.com/getfloresta/Floresta"
+version = "0.5.0"
 
 [dependencies]
 # Local dependencies
@@ -39,20 +39,25 @@ tokio = { workspace = true }
 
 # Local dependencies
 floresta = { path = "../floresta", features = [
-    "bitcoinkernel",
-    "memory-database",
-    "electrum-server",
-    "watch-only-wallet",
+  "bitcoinkernel",
+  "memory-database",
+  "electrum-server",
+  "watch-only-wallet",
 ] }
 
 [features]
-default = ["electrum-server", "watch-only-wallet", "bitcoinkernel", "flat-chainstore"]
-electrum-server = ["dep:floresta-electrum"]
 bitcoinkernel = ["floresta-chain/bitcoinkernel"]
+default = [
+  "electrum-server",
+  "watch-only-wallet",
+  "bitcoinkernel",
+  "flat-chainstore",
+]
+electrum-server = ["dep:floresta-electrum"]
 watch-only-wallet = ["dep:floresta-watch-only"]
 # Works only if `watch-only-wallet` is set
-memory-database = ["floresta-watch-only?/memory-database"]
 flat-chainstore = ["floresta-chain/flat-chainstore"]
+memory-database = ["floresta-watch-only?/memory-database"]
 
 [lib]
 crate-type = ["cdylib", "rlib", "staticlib"]

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,17 @@
                   enable = true;
                   stages = [ "pre-commit" ];
                 };
+                justfmt-hook = {
+                  enable = true;
+                  name = "justfmt-hook";
+                  entry = "${pkgs.just}/bin/just just-fmt --check";
+                  language = "system";
+                  stages = [ "pre-commit" ];
+                  types = [ "file" ];
+                  files = "justfile";
+                  pass_filenames = false;
+                  verbose = true;
+                };
                 rustfmt-hook = {
                   enable = true;
                   name = "rustfmt-hook";

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
                 rustfmt-hook = {
                   enable = true;
                   name = "rustfmt-hook";
-                  entry = "${pkgs.just}/bin/just format";
+                  entry = "${pkgs.just}/bin/just fmt --check";
                   language = "system";
                   stages = [ "pre-commit" ];
                   types = [ "rust" ];

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,8 @@
               cmake
               typos
               taplo
+              shellcheck
+              shfmt
               python312
               uv
               gcc
@@ -100,6 +102,26 @@
                 flake-checker = {
                   enable = true;
                   stages = [ "pre-commit" ];
+                };
+                shfmt-hook = {
+                  enable = true;
+                  name = "shfmt-hook";
+                  entry = "${pkgs.just}/bin/just sh-fmt --check";
+                  language = "system";
+                  stages = [ "pre-commit" ];
+                  types = [ "shell" ];
+                  pass_filenames = false;
+                  verbose = true;
+                };
+                shellcheck-hook = {
+                  enable = true;
+                  name = "shellcheck-hook";
+                  entry = "${pkgs.just}/bin/just sh-lint";
+                  language = "system";
+                  stages = [ "pre-commit" ];
+                  types = [ "shell" ];
+                  pass_filenames = false;
+                  verbose = true;
                 };
                 tomlfmt-hook = {
                   enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
               taplo
               shellcheck
               shfmt
+              hadolint
               python312
               uv
               gcc
@@ -102,6 +103,17 @@
                 flake-checker = {
                   enable = true;
                   stages = [ "pre-commit" ];
+                };
+                hadolint-hook = {
+                  enable = true;
+                  name = "hadolint-hook";
+                  entry = "${pkgs.just}/bin/just docker-lint";
+                  language = "system";
+                  stages = [ "pre-commit" ];
+                  types = [ "file" ];
+                  files = "Dockerfile";
+                  pass_filenames = false;
+                  verbose = true;
                 };
                 shfmt-hook = {
                   enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
               boost
               cmake
               typos
+              taplo
               python312
               uv
               gcc
@@ -99,6 +100,16 @@
                 flake-checker = {
                   enable = true;
                   stages = [ "pre-commit" ];
+                };
+                tomlfmt-hook = {
+                  enable = true;
+                  name = "tomlfmt-hook";
+                  entry = "${pkgs.just}/bin/just toml-fmt --check";
+                  language = "system";
+                  stages = [ "pre-commit" ];
+                  types = [ "toml" ];
+                  pass_filenames = false;
+                  verbose = true;
                 };
                 justfmt-hook = {
                   enable = true;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "floresta-fuzz"
-version = "0.1.0"
-publish = false
 edition = "2021"
+name = "floresta-fuzz"
+publish = false
+version = "0.1.0"
 
 [package.metadata]
 cargo-fuzz = true
@@ -18,60 +18,60 @@ floresta-chain = { workspace = true, features = ["flat-chainstore"] }
 floresta-wire = { workspace = true }
 
 [[bin]]
+bench = false
+doc = false
 name = "local_address_str"
 path = "fuzz_targets/local_address_str.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "utreexo_proof_des"
 path = "fuzz_targets/utreexo_proof_des.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "addrman"
 path = "fuzz_targets/addrman.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "best_chain_decode"
 path = "fuzz_targets/best_chain_decode.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "flat_chainstore_header_insertion"
 path = "fuzz_targets/flat_chainstore_header_insertion.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "best_chain_roundtrip"
 path = "fuzz_targets/best_chain_roundtrip.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "disk_block_header_decode"
 path = "fuzz_targets/disk_block_header_decode.rs"
 test = false
-doc = false
-bench = false
 
 [[bin]]
+bench = false
+doc = false
 name = "disk_block_header_roundtrip"
 path = "fuzz_targets/disk_block_header_roundtrip.rs"
 test = false
-doc = false
-bench = false
 
 [lints]
 workspace = true

--- a/justfile
+++ b/justfile
@@ -87,7 +87,7 @@ doc-check:
 
 # Format code and run configured linters
 lint:
-    @just fmt
+    @just fmt --check
     @just doc-check
 
     # 1) Run with no features
@@ -101,13 +101,9 @@ lint:
     # Lint the functional tests
     @just test-functional-uv-fmt
 
-# Format code
-fmt:
-    cargo +nightly fmt --all
-
-# Checks the formatting
-format:
-    cargo +nightly fmt --all --check
+# Format Rust code (pass '--check' to verify without modifying)
+fmt *args="":
+    cargo +nightly fmt --all {{ args }}
 
 # Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
@@ -118,7 +114,7 @@ test-features arg="":
 lint-features arg="":
     @just check-command "cargo-hack" "lint-features" "cargo install cargo-hack --locked --version 0.6.34"
 
-    @just fmt
+    @just fmt --check
     @just doc-check
     @just spell-check
 

--- a/justfile
+++ b/justfile
@@ -92,6 +92,7 @@ lint:
     @just toml-fmt --check
     @just sh-fmt --check
     @just sh-lint
+    @just docker-lint
     @just doc-check
 
     # 1) Run with no features
@@ -136,6 +137,11 @@ sh-lint:
     @just check-command shellcheck sh-lint "https://github.com/koalaman/shellcheck"
     shellcheck {{ shell-files }}
 
+# Lint Dockerfiles with hadolint
+docker-lint:
+    @just check-command hadolint docker-lint "https://github.com/hadolint/hadolint"
+    hadolint Dockerfile
+
 # Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     @just check-command "cargo-hack" "test-features" "cargo install cargo-hack --locked --version 0.6.34"
@@ -150,6 +156,7 @@ lint-features arg="":
     @just toml-fmt --check
     @just sh-fmt --check
     @just sh-lint
+    @just docker-lint
     @just doc-check
     @just spell-check
 

--- a/justfile
+++ b/justfile
@@ -88,6 +88,7 @@ doc-check:
 # Format code and run configured linters
 lint:
     @just fmt --check
+    @just just-fmt --check
     @just doc-check
 
     # 1) Run with no features
@@ -105,6 +106,10 @@ lint:
 fmt *args="":
     cargo +nightly fmt --all {{ args }}
 
+# Format justfile (pass '--check' to verify without modifying)
+just-fmt *args="":
+    just --fmt --unstable {{ args }}
+
 # Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     @just check-command "cargo-hack" "test-features" "cargo install cargo-hack --locked --version 0.6.34"
@@ -115,6 +120,7 @@ lint-features arg="":
     @just check-command "cargo-hack" "lint-features" "cargo install cargo-hack --locked --version 0.6.34"
 
     @just fmt --check
+    @just just-fmt --check
     @just doc-check
     @just spell-check
 

--- a/justfile
+++ b/justfile
@@ -90,6 +90,8 @@ lint:
     @just fmt --check
     @just just-fmt --check
     @just toml-fmt --check
+    @just sh-fmt --check
+    @just sh-lint
     @just doc-check
 
     # 1) Run with no features
@@ -116,6 +118,24 @@ toml-fmt *args="":
     @just check-command taplo toml-fmt "https://github.com/tamasfe/taplo"
     taplo fmt {{ args }}
 
+# Shell files managed by sh-fmt and sh-lint
+
+shell-files := "contrib/clean_data.sh contrib/feature_matrix.sh contrib/dist/gen_manpages.sh contrib/install.sh tests/prepare.sh tests/run.sh"
+
+# Format shell scripts (pass '--check' to verify without modifying)
+sh-fmt *args="":
+    @just check-command shfmt sh-fmt "https://github.com/mvdan/sh"
+    if echo "{{ args }}" | grep -q -- '--check'; then \
+        shfmt -d {{ shell-files }}; \
+    else \
+        shfmt -w {{ shell-files }}; \
+    fi
+
+# Lint shell scripts with shellcheck
+sh-lint:
+    @just check-command shellcheck sh-lint "https://github.com/koalaman/shellcheck"
+    shellcheck {{ shell-files }}
+
 # Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     @just check-command "cargo-hack" "test-features" "cargo install cargo-hack --locked --version 0.6.34"
@@ -128,6 +148,8 @@ lint-features arg="":
     @just fmt --check
     @just just-fmt --check
     @just toml-fmt --check
+    @just sh-fmt --check
+    @just sh-lint
     @just doc-check
     @just spell-check
 

--- a/justfile
+++ b/justfile
@@ -89,6 +89,7 @@ doc-check:
 lint:
     @just fmt --check
     @just just-fmt --check
+    @just toml-fmt --check
     @just doc-check
 
     # 1) Run with no features
@@ -110,6 +111,11 @@ fmt *args="":
 just-fmt *args="":
     just --fmt --unstable {{ args }}
 
+# Format TOML files (pass '--check' to verify without modifying)
+toml-fmt *args="":
+    @just check-command taplo toml-fmt "https://github.com/tamasfe/taplo"
+    taplo fmt {{ args }}
+
 # Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     @just check-command "cargo-hack" "test-features" "cargo install cargo-hack --locked --version 0.6.34"
@@ -121,6 +127,7 @@ lint-features arg="":
 
     @just fmt --check
     @just just-fmt --check
+    @just toml-fmt --check
     @just doc-check
     @just spell-check
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition = "2021"
 name = "metrics"
 version = "0.2.0"
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,22 @@
 [project]
-name = "floresta-functional-tests"
-version = "0.0.3"
-description = "Collection of tools to help with the functional tests of Floresta"
 authors = [{ name = "The Floresta Project Developers" }]
-license = { text = "MIT" }
-requires-python = ">=3.12"
 dependencies = [
   "jsonrpclib>=0.2.1",
   "requests>=2.32.3",
   "black>=26.3.1",
   "pylint>=3.3.2",
   "cryptography>=46.0.5",
-  "pyOpenSSL>=25.0.0"
+  "pyOpenSSL>=25.0.0",
 ]
+description = "Collection of tools to help with the functional tests of Floresta"
+license = { text = "MIT" }
+name = "floresta-functional-tests"
+requires-python = ">=3.12"
+version = "0.0.3"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tests/test_framework"]
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,4 @@
+exclude = [".cz.toml", "target/**", ".direnv/**"]
+
+[formatting]
+reorder_keys = true

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -11,9 +11,9 @@ FORCE_BUILD=0
 BUILD_RELEASE=0
 for ARG in "$@"; do
     case "$ARG" in
-        --build) FORCE_BUILD=1 ;;
-        --release) BUILD_RELEASE=1 ;;
-        *) ;;
+    --build) FORCE_BUILD=1 ;;
+    --release) BUILD_RELEASE=1 ;;
+    *) ;;
     esac
 done
 
@@ -84,31 +84,37 @@ download_prebuilt_bitcoind() {
 
     # Map uname -> platform name used by Bitcoin Core distribution filenames
     case "$UNAME_S" in
-        Linux)
-            case "$UNAME_M" in
-                x86_64) PLATFORM="x86_64-linux-gnu" ;;
-                aarch64|arm64) PLATFORM="aarch64-linux-gnu" ;;
-                armv7l) PLATFORM="arm-linux-gnueabihf" ;;
-                *) echo "Unsupported architecture for prebuilt bitcoind: $UNAME_M"; return 1 ;;
-            esac
-            FILE_EXT="tar.gz"
-            ;;
-        Darwin)
-            case "$UNAME_M" in
-                x86_64) PLATFORM="x86_64-apple-darwin" ;;
-                aarch64|arm64) PLATFORM="arm64-apple-darwin" ;;
-                *) echo "Unsupported architecture for prebuilt bitcoind on macOS: $UNAME_M"; return 1 ;;
-            esac
-            FILE_EXT="tar.gz"
-            ;;
-        MINGW*|MSYS*|CYGWIN*|Windows_NT)
-            PLATFORM="win64"
-            FILE_EXT="zip"
-            ;;
+    Linux)
+        case "$UNAME_M" in
+        x86_64) PLATFORM="x86_64-linux-gnu" ;;
+        aarch64 | arm64) PLATFORM="aarch64-linux-gnu" ;;
+        armv7l) PLATFORM="arm-linux-gnueabihf" ;;
         *)
-            echo "Unsupported OS for prebuilt bitcoind: $UNAME_S"
+            echo "Unsupported architecture for prebuilt bitcoind: $UNAME_M"
             return 1
             ;;
+        esac
+        FILE_EXT="tar.gz"
+        ;;
+    Darwin)
+        case "$UNAME_M" in
+        x86_64) PLATFORM="x86_64-apple-darwin" ;;
+        aarch64 | arm64) PLATFORM="arm64-apple-darwin" ;;
+        *)
+            echo "Unsupported architecture for prebuilt bitcoind on macOS: $UNAME_M"
+            return 1
+            ;;
+        esac
+        FILE_EXT="tar.gz"
+        ;;
+    MINGW* | MSYS* | CYGWIN* | Windows_NT)
+        PLATFORM="win64"
+        FILE_EXT="zip"
+        ;;
+    *)
+        echo "Unsupported OS for prebuilt bitcoind: $UNAME_S"
+        return 1
+        ;;
     esac
 
     FILE_NAME="bitcoin-${BITCOIN_REVISION}-${PLATFORM}.${FILE_EXT}"
@@ -217,7 +223,7 @@ build_bitcoind_from_source() {
             --without-gui \
             --disable-tests \
             --disable-bench \
-        make_nprocs="${BUILD_BITCOIND_NPROCS:-4}" || exit 1
+            make_nprocs="${BUILD_BITCOIND_NPROCS:-4}" || exit 1
         make -j"$(make_nprocs)" || exit 1
         mv "$DISPOSABLE_DIR/bitcoin/src/bitcoind" "$BINARIES_DIR/bitcoind" || exit 1
     fi

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,5 @@
 [files]
-extend-exclude = ["bin/florestad/docs/tutorial(PT-BR).md", "crates/floresta-wire/seeds"]
+extend-exclude = [
+  "bin/florestad/docs/tutorial(PT-BR).md",
+  "crates/floresta-wire/seeds",
+]


### PR DESCRIPTION
### Description and Notes

Fixes #730

Rebased on top of #924 which unifies the linting job, this pr introduces formatting and linting for other auxiliary files that we had around the codebase, the most cool one is taplo that help us to maintain the organization done back there in https://github.com/getfloresta/Floresta/commit/53430b700db2b5334ac0b1aa6079c7a8f70e47c3

I decided to address #730 myself because, together with it I could address some things that bothered me on the justfile related to linting and formatting (81429481ea52c5e1ebe74c21e4e5c8cb3a7fd3c2). Also its safer for such a "big" change to be made by a member of the team or a known contributor.

Each commit: 
* introduces a new linter and formatter for such a language/file
* with a configuration file if needed (ex: taplo needs it)
* include dependency on flake.nix so I can use it on my current dev setup.
* CI job that checks it
* The changes accross the database that such a linter/formatter applies.

draft until i do a self-review

### How to verify the changes you have done?

For those who have nix its easier to verify since it makes impossible to a formatter change to scape the commit that it were added.

To verify the changes i ran: 

git rebase --exec "nix develop --command just lint" upstream/master

For a non nix environment a similar would be, just be sure to have the formatters available and exposed to just:

git rebase --exec "just lint" upstream/master