### PR TITLE
[BUG] total txn weight calculation fix in get_block_template fn

### DIFF
--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -156,18 +156,31 @@ impl Mempool {
 
         let mut txs = Vec::new();
         for (_, tx) in self.transactions.iter() {
-            let tx_size = tx.transaction.weight().to_wu();
-            if size + tx_size > max_block_weight {
-                break;
-            }
-
             if txs.contains(&tx.transaction) {
                 continue;
             }
 
-            size += tx_size;
             let short_txid = self.hasher.hash_one(tx.transaction.compute_txid());
-            self.add_transaction_to_block(&mut txs, short_txid);
+
+            let mut dependent_txns = Vec::new();
+            self.add_transaction_to_block(&mut dependent_txns, short_txid);
+
+            let total_txn_weight: u64 = dependent_txns
+                .iter()
+                .filter(|txn| !txs.contains(txn))
+                .map(|txn| txn.weight().to_wu())
+                .sum();
+
+            if size + total_txn_weight > max_block_weight {
+                continue;
+            }
+
+            for txn in dependent_txns {
+                if !txs.contains(&txn) {
+                    size += txn.weight().to_wu();
+                    txs.push(txn);
+                }
+            }
         }
 
         let mut block = Block {


### PR DESCRIPTION
### Description and Notes

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->
Closes #958 
In the `get_block_template` function the current txn weight was added to the toatal weight variable named `size` but when `add_transaction_to_block` function was called it adds all the dependent txns also to the block but the weights of these txns were never added to the `size` variable. This would cause problem when let say the block is about to be full but it can accomodate the current txn weight then the `size`+`txn_weight` < `max_block_weight` check will pass and the function will try to add this txn as well as all its dependent txns but since the block is almost full then it will silently produce an overweight block, which would be hard to debug because it will give no panic or crash.

I created another temporary vector to store all dependent txns and then added all those weights to `size` variable and checked with the `max_block_weight`. Also removed the `break` statement and added `continue` statement to check if any other small txn can fit in the left space in the block.

Also another approach can be like this, we sum up the weights in the `add_transaction_to_block` itself and return it, in this way we can avoid a new vector creation and also the `for loop` used for adding  dependent txns from temporary vector to main vector, this would surely decrease the complexity. But it would change the function structure so I avoided it, please let me know if this approach is better than the one currently implemented.

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
