### PR TITLE
feat(wasm): add floresta-wasm crate with WASM bindings for chain validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ config.toml
 # uv python management
 .venv
 
+# wasm-pack output
+crates/floresta-wasm/pkg/
+
 # tests pycache
 tests/**/__pycache__/*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "floresta-wasm"
+version = "0.5.0"
+dependencies = [
+ "bitcoin",
+ "floresta-chain",
+ "floresta-common",
+ "floresta-watch-only",
+ "js-sys",
+ "rustreexo",
+ "serde",
+ "serde_json",
+ "sha2",
+ "spin",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "floresta-watch-only"
 version = "0.5.0"
 dependencies = [
@@ -1828,6 +1846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1947,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2021,6 +2055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3400,6 +3435,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,6 +3479,45 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/floresta-watch-only",
     "crates/floresta-wire",
     "crates/floresta-mempool",
+    "crates/floresta-wasm",
 
     # Binaries
     "bin/florestad",

--- a/crates/floresta-wasm/Cargo.toml
+++ b/crates/floresta-wasm/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "floresta-wasm"
+version = "0.5.0"
+edition = "2021"
+authors = ["Floresta Developers <contact@getfloresta.org>"]
+description = """
+    WebAssembly bindings for Floresta's core chain validation and watch-only
+    wallet components.  Runs in the browser or any WASM runtime.
+"""
+repository = "https://github.com/getfloresta/Floresta"
+license = "MIT"
+readme.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bitcoin = { workspace = true, features = ["serde"] }
+floresta-chain = { workspace = true }
+floresta-common = { workspace = true, features = ["std"] }
+floresta-watch-only = { workspace = true, features = ["memory-database"] }
+rustreexo = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true, features = ["std"] }
+spin = { workspace = true }
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[lints]
+workspace = true

--- a/crates/floresta-wasm/src/lib.rs
+++ b/crates/floresta-wasm/src/lib.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! # Floresta WASM
+//!
+//! WebAssembly bindings for Floresta's core chain validation and watch-only wallet.
+//!
+//! This crate compiles the WASM-compatible subset of Floresta — primarily the chain
+//! validation engine ([`floresta_chain`]) and the in-memory watch-only wallet
+//! ([`floresta_watch_only`]) — and exposes them to JavaScript via `wasm-bindgen`.
+//!
+//! ## What works in WASM
+//!
+//! * Header validation and chain state management
+//! * Block connection and consensus checks (pure-Rust path, no `bitcoinkernel`)
+//! * Utreexo accumulator
+//! * Watch-only wallet with in-memory database
+//!
+//! ## What does **not** work in WASM
+//!
+//! * P2P networking (TCP sockets) — use a JS-side transport instead
+//! * Filesystem-backed storage — data lives in memory (persist via IndexedDB from JS)
+//! * `libbitcoinkernel` C++ FFI — disabled automatically
+
+mod memory_chain_store;
+
+use std::sync::Arc;
+
+use bitcoin::consensus::deserialize;
+use bitcoin::Block;
+use bitcoin::BlockHash;
+use bitcoin::Network;
+use floresta_chain::AssumeValidArg;
+use floresta_chain::BlockchainInterface;
+use floresta_chain::ChainState;
+use floresta_chain::pruned_utreexo::chain_state_builder::ChainStateBuilder;
+use floresta_chain::pruned_utreexo::UpdatableChainstate;
+use wasm_bindgen::prelude::*;
+
+pub use crate::memory_chain_store::MemoryChainStore;
+
+// ---------------------------------------------------------------------------
+// Error helper
+// ---------------------------------------------------------------------------
+
+fn to_js_err<E: std::fmt::Debug>(e: E) -> JsError {
+    JsError::new(&format!("{e:?}"))
+}
+
+fn str_to_js_err(e: String) -> JsError {
+    JsError::new(&e)
+}
+
+// ---------------------------------------------------------------------------
+// WasmChainState — the main JS-facing type
+// ---------------------------------------------------------------------------
+
+/// A lightweight Bitcoin chain-state that runs entirely in WASM.
+///
+/// Validates headers and blocks using Floresta's consensus engine (pure Rust,
+/// no `libbitcoinkernel`).  Storage is kept in memory; callers can serialise
+/// and persist externally (e.g. IndexedDB).
+#[wasm_bindgen]
+pub struct WasmChainState {
+    inner: Arc<ChainState<MemoryChainStore>>,
+}
+
+#[wasm_bindgen]
+impl WasmChainState {
+    /// Create a new chain-state for the given network.
+    ///
+    /// `network` must be one of: `"bitcoin"`, `"testnet"`, `"signet"`, `"regtest"`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(network: &str) -> Result<WasmChainState, JsError> {
+        let net = parse_network(network).map_err(str_to_js_err)?;
+        let params = floresta_chain::ChainParams::from(net);
+        let store = MemoryChainStore::new();
+
+        let chain = ChainStateBuilder::new()
+            .with_chainstore(store)
+            .with_chain_params(params)
+            .toggle_ibd(true)
+            .build()
+            .map_err(to_js_err)?;
+
+        Ok(Self {
+            inner: Arc::new(chain),
+        })
+    }
+
+    /// Create a chain-state with an assume-valid block hash for faster IBD.
+    ///
+    /// When set, script validation is skipped for blocks at or below the
+    /// specified hash, greatly speeding up initial sync.
+    #[wasm_bindgen(js_name = "newWithAssumeValid")]
+    pub fn new_with_assume_valid(
+        network: &str,
+        assume_valid_hex: &str,
+    ) -> Result<WasmChainState, JsError> {
+        let net = parse_network(network).map_err(str_to_js_err)?;
+        let params = floresta_chain::ChainParams::from(net);
+        let store = MemoryChainStore::new();
+
+        let av_hash: BlockHash = assume_valid_hex.parse().map_err(to_js_err)?;
+        let av = AssumeValidArg::UserInput(av_hash);
+
+        let chain = ChainStateBuilder::new()
+            .with_chainstore(store)
+            .with_chain_params(params)
+            .with_assume_valid(av, net)
+            .toggle_ibd(true)
+            .build()
+            .map_err(to_js_err)?;
+
+        Ok(Self {
+            inner: Arc::new(chain),
+        })
+    }
+
+    // -- Queries -----------------------------------------------------------
+
+    /// Returns the height of the best known chain tip.
+    #[wasm_bindgen(js_name = "getBestBlockHeight")]
+    pub fn get_best_block_height(&self) -> Result<u32, JsError> {
+        let (height, _) = self.inner.get_best_block().map_err(to_js_err)?;
+        Ok(height)
+    }
+
+    /// Returns the hash of the best known chain tip as a hex string.
+    #[wasm_bindgen(js_name = "getBestBlockHash")]
+    pub fn get_best_block_hash(&self) -> Result<String, JsError> {
+        let (_, hash) = self.inner.get_best_block().map_err(to_js_err)?;
+        Ok(hash.to_string())
+    }
+
+    /// Returns the block hash at the given height as a hex string.
+    #[wasm_bindgen(js_name = "getBlockHash")]
+    pub fn get_block_hash(&self, height: u32) -> Result<String, JsError> {
+        let hash = self.inner.get_block_hash(height).map_err(to_js_err)?;
+        Ok(hash.to_string())
+    }
+
+    /// Returns true if the node is in Initial Block Download mode.
+    #[wasm_bindgen(js_name = "isInIbd")]
+    pub fn is_in_ibd(&self) -> bool {
+        self.inner.is_in_ibd()
+    }
+
+    /// Returns the height up to which blocks have been fully validated.
+    #[wasm_bindgen(js_name = "getValidationIndex")]
+    pub fn get_validation_index(&self) -> Result<u32, JsError> {
+        self.inner.get_validation_index().map_err(to_js_err)
+    }
+
+    // -- Header acceptance -------------------------------------------------
+
+    /// Accept a raw block header (80 bytes, hex-encoded).
+    ///
+    /// This extends the header chain without full block validation.  Returns
+    /// the resulting best-chain height.
+    #[wasm_bindgen(js_name = "acceptHeader")]
+    pub fn accept_header(&self, header_hex: &str) -> Result<u32, JsError> {
+        let bytes = hex_decode(header_hex).map_err(str_to_js_err)?;
+        let header: bitcoin::block::Header = deserialize(&bytes).map_err(to_js_err)?;
+        self.inner.accept_header(header).map_err(to_js_err)?;
+        let (height, _) = self.inner.get_best_block().map_err(to_js_err)?;
+        Ok(height)
+    }
+
+    /// Accept multiple raw block headers (concatenated 80-byte headers, hex-encoded).
+    #[wasm_bindgen(js_name = "acceptHeaders")]
+    pub fn accept_headers(&self, headers_hex: &str) -> Result<u32, JsError> {
+        let bytes = hex_decode(headers_hex).map_err(str_to_js_err)?;
+        if bytes.len() % 80 != 0 {
+            return Err(JsError::new("headers length must be a multiple of 80 bytes"));
+        }
+        for chunk in bytes.chunks(80) {
+            let header: bitcoin::block::Header = deserialize(chunk).map_err(to_js_err)?;
+            self.inner.accept_header(header).map_err(to_js_err)?;
+        }
+        let (height, _) = self.inner.get_best_block().map_err(to_js_err)?;
+        Ok(height)
+    }
+
+    // -- Block connection --------------------------------------------------
+
+    /// Connect (validate and apply) a full serialized block (hex-encoded).
+    ///
+    /// The block's header must have been accepted first via `acceptHeader`.
+    /// On success returns the new validation index height.
+    #[wasm_bindgen(js_name = "connectBlock")]
+    pub fn connect_block(&self, block_hex: &str) -> Result<u32, JsError> {
+        let bytes = hex_decode(block_hex).map_err(str_to_js_err)?;
+        let block: Block = deserialize(&bytes).map_err(to_js_err)?;
+        self.inner.connect_block(&block, Default::default(), Default::default(), Default::default()).map_err(to_js_err)?;
+        self.inner.get_validation_index().map_err(to_js_err)
+    }
+
+    // -- State toggling ----------------------------------------------------
+
+    /// Toggle Initial Block Download mode on or off.
+    #[wasm_bindgen(js_name = "toggleIbd")]
+    pub fn toggle_ibd(&self, ibd: bool) {
+        self.inner.toggle_ibd(ibd);
+    }
+
+    /// Flush any cached state.  No-op for the in-memory store, but kept for
+    /// API compatibility.
+    pub fn flush(&self) -> Result<(), JsError> {
+        self.inner.flush().map_err(to_js_err)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_network(s: &str) -> Result<Network, String> {
+    match s {
+        "bitcoin" | "mainnet" => Ok(Network::Bitcoin),
+        "testnet" | "testnet3" => Ok(Network::Testnet),
+        "signet" => Ok(Network::Signet),
+        "regtest" => Ok(Network::Regtest),
+        _ => Err(format!(
+            "unknown network \"{s}\"; expected bitcoin, testnet, signet, or regtest"
+        )),
+    }
+}
+
+fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
+    if s.len() % 2 != 0 {
+        return Err("hex string has odd length".to_string());
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| e.to_string()))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests (native)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use floresta_chain::BlockchainInterface;
+    use floresta_chain::ChainStore;
+
+    use super::memory_chain_store::MemoryChainStore;
+
+    #[test]
+    fn memory_chain_store_basic() {
+        let store = MemoryChainStore::new();
+        assert!(store.load_height().unwrap().is_none());
+        assert!(store.check_integrity().is_ok());
+    }
+
+    #[test]
+    fn create_regtest_chainstate() {
+        let params = floresta_chain::ChainParams::from(bitcoin::Network::Regtest);
+        let store = MemoryChainStore::new();
+        let chain = floresta_chain::pruned_utreexo::chain_state_builder::ChainStateBuilder::new()
+            .with_chainstore(store)
+            .with_chain_params(params)
+            .toggle_ibd(true)
+            .build()
+            .expect("should build regtest chainstate");
+        let (height, _) = chain.get_best_block().unwrap();
+        assert_eq!(height, 0);
+        assert!(chain.is_in_ibd());
+    }
+
+    #[test]
+    fn create_signet_chainstate() {
+        let params = floresta_chain::ChainParams::from(bitcoin::Network::Signet);
+        let store = MemoryChainStore::new();
+        let chain = floresta_chain::pruned_utreexo::chain_state_builder::ChainStateBuilder::new()
+            .with_chainstore(store)
+            .with_chain_params(params)
+            .toggle_ibd(true)
+            .build()
+            .expect("should build signet chainstate");
+        let (height, _) = chain.get_best_block().unwrap();
+        assert_eq!(height, 0);
+    }
+
+    #[test]
+    fn parse_network_variants() {
+        use super::parse_network;
+        assert!(parse_network("bitcoin").is_ok());
+        assert!(parse_network("mainnet").is_ok());
+        assert!(parse_network("testnet").is_ok());
+        assert!(parse_network("signet").is_ok());
+        assert!(parse_network("regtest").is_ok());
+        assert!(parse_network("fakenet").is_err());
+    }
+
+    #[test]
+    fn hex_decode_works() {
+        use super::hex_decode;
+        assert_eq!(hex_decode("deadbeef").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+        assert!(hex_decode("xyz").is_err());
+        assert!(hex_decode("0").is_err()); // odd length
+    }
+}

--- a/crates/floresta-wasm/src/memory_chain_store.rs
+++ b/crates/floresta-wasm/src/memory_chain_store.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! In-memory [`ChainStore`] implementation for WASM environments where filesystem
+//! access is unavailable.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::RwLock;
+
+use bitcoin::BlockHash;
+use floresta_chain::BestChain;
+use floresta_chain::ChainStore;
+use floresta_chain::DatabaseError;
+use floresta_chain::DiskBlockHeader;
+
+#[derive(Debug)]
+pub enum MemoryChainStoreError {
+    PoisonedLock,
+}
+
+impl fmt::Display for MemoryChainStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MemoryChainStoreError::PoisonedLock => write!(f, "poisoned lock"),
+        }
+    }
+}
+
+impl DatabaseError for MemoryChainStoreError {}
+
+struct Inner {
+    headers: HashMap<BlockHash, DiskBlockHeader>,
+    height_to_hash: HashMap<u32, BlockHash>,
+    best_chain: Option<BestChain>,
+    roots: HashMap<u32, Vec<u8>>,
+}
+
+/// An in-memory chain store suitable for WASM targets.
+pub struct MemoryChainStore {
+    inner: RwLock<Inner>,
+}
+
+impl MemoryChainStore {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                headers: HashMap::new(),
+                height_to_hash: HashMap::new(),
+                best_chain: None,
+                roots: HashMap::new(),
+            }),
+        }
+    }
+}
+
+impl Default for MemoryChainStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChainStore for MemoryChainStore {
+    type Error = MemoryChainStoreError;
+
+    fn save_roots_for_block(&mut self, roots: Vec<u8>, height: u32) -> Result<(), Self::Error> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        inner.roots.insert(height, roots);
+        Ok(())
+    }
+
+    fn load_roots_for_block(&mut self, height: u32) -> Result<Option<Vec<u8>>, Self::Error> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        Ok(inner.roots.get(&height).cloned())
+    }
+
+    fn load_height(&self) -> Result<Option<BestChain>, Self::Error> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        Ok(inner.best_chain.clone())
+    }
+
+    fn save_height(&mut self, height: &BestChain) -> Result<(), Self::Error> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        inner.best_chain = Some(height.clone());
+        Ok(())
+    }
+
+    fn get_header(&self, block_hash: &BlockHash) -> Result<Option<DiskBlockHeader>, Self::Error> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        Ok(inner.headers.get(block_hash).copied())
+    }
+
+    fn get_header_by_height(&self, height: u32) -> Result<Option<DiskBlockHeader>, Self::Error> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        let hash = match inner.height_to_hash.get(&height) {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+        Ok(inner.headers.get(hash).copied())
+    }
+
+    fn save_header(&mut self, header: &DiskBlockHeader) -> Result<(), Self::Error> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        inner.headers.insert(header.block_hash(), *header);
+        if let Some(height) = header.height() {
+            inner.height_to_hash.insert(height, header.block_hash());
+        }
+        Ok(())
+    }
+
+    fn get_block_hash(&self, height: u32) -> Result<Option<BlockHash>, Self::Error> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        Ok(inner.height_to_hash.get(&height).copied())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        // No-op for in-memory store
+        Ok(())
+    }
+
+    fn update_block_index(&mut self, height: u32, hash: BlockHash) -> Result<(), Self::Error> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| MemoryChainStoreError::PoisonedLock)?;
+        inner.height_to_hash.insert(height, hash);
+        Ok(())
+    }
+
+    fn check_integrity(&self) -> Result<(), Self::Error> {
+        // Always passes for in-memory store
+        Ok(())
+    }
+}

--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -35,7 +35,9 @@ pub use p2p_wire::node;
 pub use p2p_wire::node_context;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::node_interface;
+#[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::transport::TransportProtocol;
+#[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::UtreexoNodeConfig;
 
 /// NodeHooks is a trait that defines the hooks that a node can use to interact with the network


### PR DESCRIPTION

### Description and Notes
Instead of compiling florestad directly to WASM (which is infeasible due to TCP sockets, filesystem access, and C++ FFI dependencies), this PR takes the approach suggested in the issue discussion: extract the WASM-compatible core components into a new floresta-wasm crate.

Closes #672 

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
