### PR TITLE
fix(rpc): add missing fields and verbose support to getblockheader

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -86,7 +86,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.send_raw_transaction(tx)?)?
         }
         Methods::GetBlockHeader { hash } => {
-            serde_json::to_string_pretty(&client.get_block_header(hash)?)?
+            serde_json::to_string_pretty(&client.get_block_header(hash, None)?)?
         }
         Methods::LoadDescriptor { desc } => {
             serde_json::to_string_pretty(&client.load_descriptor(desc)?)?

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -24,6 +24,8 @@ use serde_json::json;
 use serde_json::Value;
 use tracing::debug;
 
+use super::res::GetBlockHeaderRes;
+use super::res::GetBlockHeaderVerboseRes;
 use super::res::GetBlockchainInfoRes;
 use super::res::GetTxOutProof;
 use super::res::JsonRpcError;
@@ -302,10 +304,64 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     }
 
     // getblockheader
-    pub(super) fn get_block_header(&self, hash: BlockHash) -> Result<Header, JsonRpcError> {
-        self.chain
+    pub(super) fn get_block_header(
+        &self,
+        hash: BlockHash,
+        verbose: bool,
+    ) -> Result<GetBlockHeaderRes, JsonRpcError> {
+        let header = self
+            .chain
             .get_block_header(&hash)
-            .map_err(|_| JsonRpcError::BlockNotFound)
+            .map_err(|_| JsonRpcError::BlockNotFound)?;
+
+        if !verbose {
+            let hex = serialize_hex(&header);
+            return Ok(GetBlockHeaderRes::Hex(hex));
+        }
+
+        let height = header.get_height(&self.chain)?;
+        let median_time = header.calculate_median_time_past(&self.chain)?;
+        let chain_work = header.calculate_chain_work(&self.chain)?.to_string_hex();
+        let confirmations = header.get_confirmations(&self.chain)? as i64;
+        let version_hex = header.get_version_hex();
+        let bits = header.get_bits_hex();
+        let difficulty = header.get_difficulty();
+        let target = header.get_target_hex();
+
+        let next_block_hash = header
+            .get_next_block_hash(&self.chain)?
+            .map(|h| h.to_string());
+
+        let previous_block_hash = (header.prev_blockhash != BlockHash::all_zeros())
+            .then_some(header.prev_blockhash.to_string());
+
+        // nTx requires the full block; attempt to fetch it, default to 0 if unavailable
+        let n_tx = self
+            .chain
+            .get_block(&hash)
+            .map(|b| b.txdata.len() as i64)
+            .unwrap_or(0);
+
+        let res = GetBlockHeaderVerboseRes {
+            hash: header.block_hash().to_string(),
+            confirmations,
+            height: height as i64,
+            version: header.version.to_consensus(),
+            version_hex,
+            merkle_root: header.merkle_root.to_string(),
+            time: header.time as i64,
+            median_time: median_time as i64,
+            nonce: header.nonce as i64,
+            bits,
+            target,
+            difficulty,
+            chain_work,
+            n_tx,
+            previous_block_hash,
+            next_block_hash,
+        };
+
+        Ok(GetBlockHeaderRes::Verbose(Box::new(res)))
     }
 
     // getblockstats

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -131,6 +131,42 @@ pub enum GetBlockRes {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetBlockHeaderRes {
+    /// Verbosity 0: hex-encoded serialized header
+    Hex(String),
+    /// Verbosity 1 (default): verbose JSON object
+    Verbose(Box<GetBlockHeaderVerboseRes>),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetBlockHeaderVerboseRes {
+    pub hash: String,
+    pub confirmations: i64,
+    pub height: i64,
+    pub version: i32,
+    #[serde(rename = "versionHex")]
+    pub version_hex: String,
+    #[serde(rename = "merkleroot")]
+    pub merkle_root: String,
+    pub time: i64,
+    #[serde(rename = "mediantime")]
+    pub median_time: i64,
+    pub nonce: i64,
+    pub bits: String,
+    pub target: String,
+    pub difficulty: f64,
+    #[serde(rename = "chainwork")]
+    pub chain_work: String,
+    #[serde(rename = "nTx")]
+    pub n_tx: i64,
+    #[serde(rename = "previousblockhash", skip_serializing_if = "Option::is_none")]
+    pub previous_block_hash: Option<String>,
+    #[serde(rename = "nextblockhash", skip_serializing_if = "Option::is_none")]
+    pub next_block_hash: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RpcError {
     pub code: i32,
     pub message: String,

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -274,8 +274,10 @@ async fn handle_json_rpc_request(
 
         "getblockheader" => {
             let hash = get_hash(&params, 0, "block_hash")?;
+            let verbose =
+                get_optional_field(&params, 1, "verbose", get_bool)?.unwrap_or(true);
             state
-                .get_block_header(hash)
+                .get_block_header(hash, verbose)
                 .map(|h| serde_json::to_value(h).unwrap())
         }
 

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -226,9 +226,13 @@ mod tests {
         let (_proc, client) = start_florestad();
 
         let blockhash = client.get_block_hash(0).expect("rpc not working");
-        let block_header = client.get_block_header(blockhash).expect("rpc not working");
+        let block_header = client.get_block_header(blockhash, None).expect("rpc not working");
 
-        assert_eq!(block_header.block_hash(), blockhash);
+        assert_eq!(block_header["hash"].as_str().unwrap(), blockhash.to_string());
+        assert!(block_header["mediantime"].is_number());
+        assert!(block_header["chainwork"].is_string());
+        assert!(block_header["target"].is_string());
+        assert!(block_header["nTx"].is_number());
     }
 
     #[test]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -2,7 +2,6 @@
 
 use core::fmt::Debug;
 
-use bitcoin::block::Header as BlockHeader;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
@@ -38,11 +37,11 @@ pub trait FlorestaRPC {
     fn get_block_hash(&self, height: u32) -> Result<BlockHash>;
     /// Returns the block header for the given block hash
     ///
-    /// This method returns the block header for the given block hash, as defined
-    /// in the Bitcoin protocol specification. A header contains the block's version,
-    /// the previous block hash, the merkle root, the timestamp, the difficulty target,
-    /// and the nonce.
-    fn get_block_header(&self, hash: BlockHash) -> Result<BlockHeader>;
+    /// If verbose is true (the default), returns a JSON object with detailed header
+    /// information including hash, confirmations, height, version, merkleroot, time,
+    /// mediantime, nonce, bits, target, difficulty, chainwork, nTx, previousblockhash,
+    /// and nextblockhash. If verbose is false, returns the header as a hex-encoded string.
+    fn get_block_header(&self, hash: BlockHash, verbose: Option<bool>) -> Result<Value>;
     /// Gets a transaction from the blockchain
     ///
     /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
@@ -323,8 +322,12 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockfilter", &[Value::Number(Number::from(height))])
     }
 
-    fn get_block_header(&self, hash: BlockHash) -> Result<BlockHeader> {
-        self.call("getblockheader", &[Value::String(hash.to_string())])
+    fn get_block_header(&self, hash: BlockHash, verbose: Option<bool>) -> Result<Value> {
+        let mut params = vec![Value::String(hash.to_string())];
+        if let Some(v) = verbose {
+            params.push(Value::Bool(v));
+        }
+        self.call("getblockheader", &params)
     }
 
     fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes> {

--- a/tests/floresta-cli/getblockheader.py
+++ b/tests/floresta-cli/getblockheader.py
@@ -12,30 +12,12 @@ from test_framework.node import NodeType
 
 class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
     """
-    Test `getblockheader` with a fresh node and expect a result like this:
-
-    ````bash
-    $> ./target/release floresta_cli --network=regtest getblockheader \
-        0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
-    {
-       "version": 1,
-       "prev_blockhash": "0000000000000000000000000000000000000000000000000000000000000000",
-       "merkle_root": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
-       "time": 1296688602,
-       "bits": 545259519,
-       "nonce": 2
-    }
-    ```
+    Test `getblockheader` with a fresh node and expect a verbose result
+    matching Bitcoin Core's response format for the regtest genesis block.
     """
 
     nodes = [-1]
-    version = 1
     blockhash = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
-    prev_blockhash = "0000000000000000000000000000000000000000000000000000000000000000"
-    merkle_root = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
-    time = 1296688602
-    bits = 545259519
-    nonce = 2
 
     def set_test_params(self):
         """
@@ -54,16 +36,35 @@ class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
         response = self.florestad.rpc.get_blockheader(
             GetBlockheaderHeightZeroTest.blockhash
         )
-        self.assertEqual(response["version"], GetBlockheaderHeightZeroTest.version)
+
         self.assertEqual(
-            response["prev_blockhash"], GetBlockheaderHeightZeroTest.prev_blockhash
+            response["hash"],
+            "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
         )
+        self.assertEqual(response["confirmations"], 1)
+        self.assertEqual(response["height"], 0)
+        self.assertEqual(response["version"], 1)
+        self.assertEqual(response["versionHex"], "00000001")
         self.assertEqual(
-            response["merkle_root"], GetBlockheaderHeightZeroTest.merkle_root
+            response["merkleroot"],
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
         )
-        self.assertEqual(response["time"], GetBlockheaderHeightZeroTest.time)
-        self.assertEqual(response["bits"], GetBlockheaderHeightZeroTest.bits)
-        self.assertEqual(response["nonce"], GetBlockheaderHeightZeroTest.nonce)
+        self.assertEqual(response["time"], 1296688602)
+        self.assertEqual(response["mediantime"], 1296688602)
+        self.assertEqual(response["nonce"], 2)
+        self.assertEqual(response["bits"], "207fffff")
+        self.assertEqual(
+            response["target"],
+            "7fffff0000000000000000000000000000000000000000000000000000000000",
+        )
+
+        # Genesis block should not have previousblockhash
+        self.assertEqual("previousblockhash" in response, False)
+
+        # Verify additional fields are present
+        self.assertIn("difficulty", list(response.keys()))
+        self.assertIn("chainwork", list(response.keys()))
+        self.assertIn("nTx", list(response.keys()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description and Notes
Added missing fields to getblockheader response: mediantime, target, chainwork, nTx, hash, confirmations, height, versionHex, difficulty (now correctly calculated), and nextblockhash
previousblockhash is now omitted for the genesis block instead of returning the zero hash
Added verbose parameter support (defaults to true; when false, returns hex-encoded serialized header)
Updated RPC client trait, CLI, and tests to match the new response format

Fixes #606

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
