### PR TITLE
Implement `Display` & `Error` for error enums

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -885,7 +885,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         };
 
         let mut acc = acc.as_slice();
-        Stump::deserialize(&mut acc).map_err(BlockchainError::UtreexoError)
+        Stump::deserialize(&mut acc).map_err(BlockchainError::AccumulatorError)
     }
 
     fn update_view(
@@ -1083,7 +1083,7 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
             .collect();
 
         if !acc.verify(&proof, &del_hashes)? {
-            return Err(BlockValidationErrors::InvalidProof)?;
+            return Err(BlockValidationErrors::InvalidUtreexoProof)?;
         }
 
         let height = self

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -17,7 +17,6 @@ use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 
-use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitcoin::Txid;
 use floresta_common::impl_error_from;
@@ -31,26 +30,84 @@ use crate::pruned_utreexo::chain_state_builder::BlockchainBuilderError;
 pub trait DatabaseError: Debug + Send + Sync + 'static {}
 
 #[derive(Debug)]
-/// This is the highest level error type in floresta-chain, returned by the [crate::ChainState] methods.
-/// It represents errors encountered during blockchain validation.
+/// Errors that can happen whilst interacting with the local blockchain.
+///
+/// It's the highest level error type in [`floresta_chain`](crate),
+/// and is returned by [`ChainState`](crate::ChainState) methods.
 pub enum BlockchainError {
+    /// The block is not present in the [`ChainState`](crate::ChainState).
     BlockNotPresent,
+
+    /// The block is an orphan or is invalid.
     OrphanOrInvalidBlock,
-    Parsing(String),
+
+    /// The block failed validation.
     BlockValidation(BlockValidationErrors),
+
+    /// The block contains invalid transaction(s).
     TransactionError(TransactionError),
-    InvalidProof,
-    UtreexoError(StumpError),
+
+    /// The Utreexo proof for this block is invalid.
+    InvalidUtreexoProof,
+
+    /// Error whilst interacting with the [accumulator](rustreexo::stump::Stump).
+    AccumulatorError(StumpError),
+
+    /// Failed to reconstruct a scriptpubkey from a [leaf](crate::pruned_utreexo::udata::CompactLeafData).
     UtreexoLeaf(UtreexoLeafError),
+
+    /// Error whilst interacting with the the [`ChainStore`](crate::ChainStore).
     Database(Box<dyn DatabaseError>),
-    ConsensusDecode(bitcoin::consensus::encode::Error),
+
+    /// The [`ChainState`](crate::ChainState) is not initialized.
     ChainNotInitialized,
+
+    /// The [`ChainState`](crate::ChainState)'s tip is invalid.
     InvalidTip(String),
+
+    /// The [`ChainState`](crate::ChainState)'s validation index is invalid.
     BadValidationIndex,
+
+    /// A [`ChainState`](crate::ChainState) operation overflowed.
     OperationOverflow(ChainWorkOverflow),
 }
 
 impl_error_from!(BlockchainError, ChainWorkOverflow, OperationOverflow);
+impl Display for BlockchainError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BlockNotPresent => write!(f, "The block is not present in the ChainState"),
+            Self::OrphanOrInvalidBlock => write!(f, "The block was orphaned or is invalid"),
+            Self::BlockValidation(e) => write!(f, "Failed to validate the block: {e}"),
+            Self::TransactionError(e) => {
+                write!(f, "The block contains invalid transaction(s): {e}")
+            }
+            Self::InvalidUtreexoProof => write!(f, "The Utreexo proof for this block is invalid"),
+            Self::AccumulatorError(e) => {
+                write!(f, "Error whilst interacting with the accumulator: {e:?}")
+            }
+            Self::UtreexoLeaf(e) => write!(
+                f,
+                "Failed to reconstruct a scriptpubkey from Compact Leaf Data: {e}"
+            ),
+            Self::Database(e) => {
+                write!(f, "Error whilst interacting with the the ChainState: {e:?}")
+            }
+            Self::ChainNotInitialized => write!(f, "The ChainState is not initialized"),
+            Self::InvalidTip(e) => write!(f, "The ChainState's tip is invalid: {e}"),
+            Self::BadValidationIndex => write!(f, "The ChainState's validation index is invalid"),
+            Self::OperationOverflow(_) => write!(f, "A ChainState operation overflowed"),
+        }
+    }
+}
+
+impl Error for BlockchainError {}
+
+impl<T: DatabaseError> From<T> for BlockchainError {
+    fn from(value: T) -> Self {
+        BlockchainError::Database(Box::new(value))
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 /// Represents errors encountered during transaction validation.
@@ -84,7 +141,7 @@ pub enum BlockValidationErrors {
     EmptyBlock,
     BlockExtendsAnOrphanChain,
     BadBip34,
-    InvalidProof,
+    InvalidUtreexoProof,
     CoinbaseNotMatured,
     UnspendableUTXO,
     BIP94TimeWarp,
@@ -168,7 +225,7 @@ impl Display for BlockValidationErrors {
                 write!(f, "This block extends a chain we don't have the ancestors")
             }
             BlockValidationErrors::BadBip34 => write!(f, "BIP34 commitment mismatch"),
-            BlockValidationErrors::InvalidProof => write!(f, "Invalid proof"),
+            BlockValidationErrors::InvalidUtreexoProof => write!(f, "Invalid proof"),
             BlockValidationErrors::CoinbaseNotMatured => {
                 write!(f, "Coinbase not matured yet")
             }
@@ -182,12 +239,6 @@ impl Display for BlockValidationErrors {
     }
 }
 
-impl<T: DatabaseError> From<T> for BlockchainError {
-    fn from(value: T) -> Self {
-        BlockchainError::Database(Box::new(value))
-    }
-}
-
 impl<T: DatabaseError> From<T> for BlockchainBuilderError {
     fn from(value: T) -> Self {
         BlockchainBuilderError::Database(Box::new(value))
@@ -195,18 +246,5 @@ impl<T: DatabaseError> From<T> for BlockchainBuilderError {
 }
 
 impl_error_from!(BlockchainError, TransactionError, TransactionError);
-impl_error_from!(
-    BlockchainError,
-    bitcoin::consensus::encode::Error,
-    ConsensusDecode
-);
 impl_error_from!(BlockchainError, BlockValidationErrors, BlockValidation);
-impl_error_from!(BlockchainError, StumpError, UtreexoError);
-
-impl Display for BlockchainError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl Error for BlockchainError {}
+impl_error_from!(BlockchainError, StumpError, AccumulatorError);

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -46,8 +46,6 @@ pub enum BlockchainError {
     ConsensusDecode(bitcoin::consensus::encode::Error),
     ChainNotInitialized,
     InvalidTip(String),
-    Io(ioError),
-    UnsupportedNetwork(Network),
     BadValidationIndex,
     OperationOverflow(ChainWorkOverflow),
 }
@@ -196,7 +194,6 @@ impl<T: DatabaseError> From<T> for BlockchainBuilderError {
     }
 }
 
-impl_error_from!(BlockchainError, ioError, Io);
 impl_error_from!(BlockchainError, TransactionError, TransactionError);
 impl_error_from!(
     BlockchainError,

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -71,6 +71,10 @@
 
 extern crate std;
 
+use core::error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 use std::fs::DirBuilder;
@@ -78,6 +82,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 #[cfg(unix)]
 use std::fs::Permissions;
+use std::io;
 use std::io::Seek;
 use std::io::SeekFrom;
 #[cfg(unix)]
@@ -116,11 +121,15 @@ const FLAT_CHAINSTORE_VERSION: u32 = 1;
 /// again. This is the type of our cache
 type CacheType = LruCache<BlockHash, DiskBlockHeader>;
 
-/// How long an accumulator is.
+/// The maximum theoretical size of the Utreexo accumulator.
 ///
-/// Worst case, we have 64 roots, each with 32 bytes, and a 64 bits integer for the number of
-/// leaves. So 32 * 64 + 8 = 2048 + 8 = 2056 bytes
-const UTREEXO_ACC_SIZE: usize = 32 * 64 + 8;
+/// In the worst case that all leaves are filled:
+/// * The accumulator can have up to 64 roots
+/// * Each root is 32 bytes
+/// * The number of leaves is expressed as a [`u64`]
+///
+/// 64 (MAX_ROOTS) * 32 bytes (ROOT_SIZE) + 8 bytes (LEAF_COUNT) = 2056 bytes
+pub const MAX_ACCUMULATOR_SIZE: usize = 2056;
 
 #[derive(Clone)]
 /// Configuration for our flat chain store. See each field for more information
@@ -246,7 +255,7 @@ mod index_impl {
         pub fn new(index: u32) -> Result<Self, FlatChainstoreError> {
             if index >= Self::FORK_BIT {
                 // Index value is out of bounds for our 31-bit indexes
-                return Err(FlatChainstoreError::IndexTooBig);
+                return Err(FlatChainstoreError::OversizedIndex);
             }
 
             Ok(Index(index))
@@ -256,7 +265,7 @@ mod index_impl {
         pub fn new_fork(index: u32) -> Result<Self, FlatChainstoreError> {
             if index >= Self::FORK_BIT {
                 // Index value is out of bounds for our 31-bit indexes
-                return Err(FlatChainstoreError::IndexTooBig);
+                return Err(FlatChainstoreError::OversizedIndex);
             }
 
             Ok(Index(index | Self::FORK_BIT))
@@ -345,44 +354,67 @@ struct Metadata {
 }
 
 #[derive(Debug)]
-/// An error that can happen when we're dealing with our flat chain store
+/// Errors that can happen whilst interacting with the [`FlatChainStore`].
 pub enum FlatChainstoreError {
-    /// An I/O error happened
+    /// An I/O error.
     ///
-    /// Check the inner error for more information
-    Io(std::io::Error),
+    /// See the inner error for more information.
+    Io(io::Error),
 
-    /// We couldn't find the block we were looking for
-    BlockNotFound,
+    /// The requested block header was not found in the [`FlatChainStore`].
+    HeaderNotFound,
 
-    /// The index is full, we can't add more blocks to it
-    IndexIsFull,
+    /// Failed to add a block header to the [`FlatChainStore`] due to a full index.
+    FullIndex,
 
-    /// Tried to open a database with an unsupported version number
-    DbTooNew(u32),
+    /// Attempted to create an index larger than 31 bits.
+    OversizedIndex,
 
-    /// Our cache lock is poisoned
-    Poisoned,
+    /// Attempted to open a [`FlatChainStore`] database using an unsupported schema.
+    UnsupportedSchema(u32),
 
-    /// We encountered an invalid magic value, possibly database corruption
-    InvalidMagic(u32),
+    /// The cache lock is poisoned.
+    PoisonedLock,
 
-    /// The provided accumulator is too big
-    AccumulatorTooBig,
+    /// Invalid value for the database magic.
+    ///
+    /// Usually indicates that the database is corrupted.
+    BadMagic(u32),
 
-    /// Tried to create an index more than 31 bits long
-    IndexTooBig,
+    /// The accumulator is larger than [`MAX_ACCUMULATOR_SIZE`].
+    OversizedAccumulator,
 
-    /// Something wrong happened with the metadata file mmap
+    /// The [`FlatChainStore`] has a bad metadata file.
     InvalidMetadataPointer,
 
-    /// The database is corrupted
-    DbCorrupted,
+    /// The [`FlatChainStore`] is corrupted.
+    CorruptedDatabase,
 
-    /// The validation index doesn't have a height. This probably means it is in
-    /// a fork or invalid chain
+    /// No height present on the validation index.
+    ///
+    /// Usually indicates a fork or invalid chain.
     InvalidValidationIndex,
 }
+
+impl Display for FlatChainstoreError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "FlatChainStore I/O Error: {e:?}"),
+            Self::HeaderNotFound => write!(f, "The requested block header was not found in the FlatChainStore"),
+            Self::FullIndex => write!(f, "Failed to add a block to the FlatChainStore due to a full index"),
+            Self::OversizedIndex => write!(f, "Attempted to create an index larger than 31 bits"),
+            Self::UnsupportedSchema(schema_version) => write!(f, "Attempted to open the FlatChainStore database using an unsupported schema with version={}", schema_version),
+            Self::PoisonedLock => write!(f, "The FlatChainStore's cache lock is poisoned"),
+            Self::BadMagic(magic) => write!(f, "The FlatChainStore has bad magic={}", magic),
+            Self::OversizedAccumulator => write!(f, "The FlatChainStore's accumulator is larger than the maximum value of {}", MAX_ACCUMULATOR_SIZE),
+            Self::InvalidMetadataPointer => write!(f, "The FlatChainStore has invalid metadata"),
+            Self::CorruptedDatabase => write!(f, "The FlatChainStore is corrupted"),
+            Self::InvalidValidationIndex => write!(f, "The FlatChainStore has an invalid validation index"),
+        }
+    }
+}
+
+impl error::Error for FlatChainstoreError {}
 
 /// Need this to use [FlatChainstoreError] as a [DatabaseError] in [ChainStore]
 impl DatabaseError for FlatChainstoreError {}
@@ -391,7 +423,7 @@ impl_error_from!(FlatChainstoreError, std::io::Error, Io);
 
 impl From<PoisonError<MutexGuard<'_, CacheType>>> for FlatChainstoreError {
     fn from(_: PoisonError<MutexGuard<'_, CacheType>>) -> Self {
-        FlatChainstoreError::Poisoned
+        FlatChainstoreError::PoisonedLock
     }
 }
 
@@ -518,7 +550,7 @@ impl BlockIndex {
         }
 
         // If we reach here, it means the index is full. We should re-hash the map
-        Err(FlatChainstoreError::IndexIsFull)
+        Err(FlatChainstoreError::FullIndex)
     }
 
     /// The (short) hash function we use to compute where in the map a given index should be
@@ -696,11 +728,11 @@ impl FlatChainStore {
 
         // check the magic number and version
         if metadata.version > FLAT_CHAINSTORE_VERSION {
-            return Err(FlatChainstoreError::DbTooNew(metadata.version));
+            return Err(FlatChainstoreError::UnsupportedSchema(metadata.version));
         }
 
         if metadata.magic != FLAT_CHAINSTORE_MAGIC {
-            return Err(FlatChainstoreError::InvalidMagic(metadata.magic));
+            return Err(FlatChainstoreError::BadMagic(metadata.magic));
         }
 
         let index_path = format!("{}/blocks_index.bin", config.path);
@@ -749,7 +781,7 @@ impl FlatChainStore {
         let next_occupancy = metadata.block_index_occupancy + 1;
 
         if next_occupancy >= metadata.index_capacity {
-            return Err(FlatChainstoreError::IndexIsFull);
+            return Err(FlatChainstoreError::FullIndex);
         }
 
         let is_new = self
@@ -780,7 +812,7 @@ impl FlatChainStore {
         let metadata = unsafe { self.get_metadata()? };
 
         if metadata.checksum != computed_checksum {
-            return Err(FlatChainstoreError::DbCorrupted);
+            return Err(FlatChainstoreError::CorruptedDatabase);
         }
 
         Ok(())
@@ -865,7 +897,7 @@ impl FlatChainStore {
 
         let index = index.index() as usize;
         if index >= max_size {
-            return Err(FlatChainstoreError::IndexIsFull);
+            return Err(FlatChainstoreError::FullIndex);
         }
 
         // SAFETY: we've checked index < max_size
@@ -874,7 +906,7 @@ impl FlatChainStore {
 
         // Uninitialized memory means we haven't written anything here yet
         if header.hash == BlockHash::all_zeros() {
-            return Err(FlatChainstoreError::BlockNotFound);
+            return Err(FlatChainstoreError::HeaderNotFound);
         }
 
         Ok(header)
@@ -894,7 +926,7 @@ impl FlatChainStore {
 
         let index = index.index() as usize;
         if index >= max_size {
-            return Err(FlatChainstoreError::IndexIsFull);
+            return Err(FlatChainstoreError::FullIndex);
         }
 
         // SAFETY: we've checked index < max_size
@@ -1118,14 +1150,14 @@ impl ChainStore for FlatChainStore {
         let pos = self.accumulator_file.seek(SeekFrom::End(0))?;
         let size = roots.len();
 
-        if size > UTREEXO_ACC_SIZE {
-            return Err(FlatChainstoreError::AccumulatorTooBig);
+        if size > MAX_ACCUMULATOR_SIZE {
+            return Err(FlatChainstoreError::OversizedAccumulator);
         }
 
         let header = unsafe { self.get_disk_header_mut(index)? };
         // Only write to this header if we actually have it in our store
         if header.hash == BlockHash::all_zeros() {
-            return Err(FlatChainstoreError::BlockNotFound);
+            return Err(FlatChainstoreError::HeaderNotFound);
         }
 
         header.acc_pos = pos as u32;
@@ -1180,7 +1212,7 @@ impl ChainStore for FlatChainStore {
         unsafe {
             match self.get_disk_header(index) {
                 Ok(header) => Ok(Some(header.header)),
-                Err(FlatChainstoreError::BlockNotFound) => Ok(None),
+                Err(FlatChainstoreError::HeaderNotFound) => Ok(None),
                 Err(e) => Err(e),
             }
         }
@@ -1219,7 +1251,7 @@ impl ChainStore for FlatChainStore {
         unsafe {
             match self.get_disk_header(index) {
                 Ok(header) => Ok(Some(header.hash)),
-                Err(FlatChainstoreError::BlockNotFound) => Ok(None),
+                Err(FlatChainstoreError::HeaderNotFound) => Ok(None),
                 Err(e) => Err(e),
             }
         }
@@ -1435,7 +1467,7 @@ mod tests {
             let store_id = tweak_version_and_magic(version, FLAT_CHAINSTORE_MAGIC);
 
             match get_test_chainstore(Some(store_id)) {
-                Err(FlatChainstoreError::DbTooNew(v)) if v == version => {},
+                Err(FlatChainstoreError::UnsupportedSchema(v)) if v == version => {},
                 Err(e) => panic!("Should have failed with `FlatChainstoreError::DbTooNew({version})`, instead we got {e:?}"),
                 Ok(_) => panic!("Should have failed with `FlatChainstoreError::DbTooNew({version})`, instead we got `Ok`"),
             }
@@ -1449,7 +1481,7 @@ mod tests {
             let store_id = tweak_version_and_magic(FLAT_CHAINSTORE_VERSION, magic);
 
             match get_test_chainstore(Some(store_id)) {
-                Err(FlatChainstoreError::InvalidMagic(m)) if m == magic => {},
+                Err(FlatChainstoreError::BadMagic(m)) if m == magic => {},
                 Err(e) => panic!("Should have failed with `FlatChainstoreError::InvalidMagic({magic})`, instead we got {e:?}"),
                 Ok(_) => panic!("Should have failed with `FlatChainstoreError::InvalidMagic({magic})`, instead we got `Ok`"),
             }
@@ -1592,19 +1624,19 @@ mod tests {
         // Test that the inner header-fetching function returns the proper error for mainnet indices
         unsafe {
             match store.get_disk_header(Index::new(151).unwrap()) {
-                Err(FlatChainstoreError::BlockNotFound) => (),
+                Err(FlatChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found a header at height 151: {val:?}"),
             }
             // Last available position
             match store.get_disk_header(Index::new(32_767).unwrap()) {
-                Err(FlatChainstoreError::BlockNotFound) => (),
+                Err(FlatChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found a header at height 32767: {val:?}"),
             }
             // Exceeds header file capacity
             match store.get_disk_header(Index::new(32_768).unwrap()) {
-                Err(FlatChainstoreError::IndexIsFull) => (),
+                Err(FlatChainstoreError::FullIndex) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => {
                     panic!("Should not have found a header exceeding file capacity: {val:?}")
@@ -1615,19 +1647,19 @@ mod tests {
         // Test that the inner header-fetching function returns the proper error for fork indices
         unsafe {
             match store.get_disk_header(Index::new_fork(0).unwrap()) {
-                Err(FlatChainstoreError::BlockNotFound) => (),
+                Err(FlatChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found any fork header: {val:?}"),
             }
             // Last available position
             match store.get_disk_header(Index::new_fork(16_383).unwrap()) {
-                Err(FlatChainstoreError::BlockNotFound) => (),
+                Err(FlatChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found any fork header: {val:?}"),
             }
             // Exceeds fork file capacity
             match store.get_disk_header(Index::new_fork(16_384).unwrap()) {
-                Err(FlatChainstoreError::IndexIsFull) => (),
+                Err(FlatChainstoreError::FullIndex) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => {
                     panic!("Should not have found a header exceeding file capacity: {val:?}")
@@ -1791,7 +1823,7 @@ mod tests {
         let result = store.save_roots_for_block(acc.clone(), 10);
 
         match result {
-            Err(FlatChainstoreError::BlockNotFound) => (),
+            Err(FlatChainstoreError::HeaderNotFound) => (),
             Err(e) => panic!("Unexpected err: {e:?}"),
             Ok(_) => panic!("Should not have been able to save roots for a block we don't have"),
         }

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -148,8 +148,8 @@ impl PartialChainStateInner {
         let acc = match Consensus::update_acc(&self.current_acc, block, height, proof, del_hashes) {
             Ok(acc) => acc,
             Err(_) => {
-                self.error = Some(BlockValidationErrors::InvalidProof);
-                return Err(BlockchainError::InvalidProof);
+                self.error = Some(BlockValidationErrors::InvalidUtreexoProof);
+                return Err(BlockchainError::InvalidUtreexoProof);
             }
         };
 

--- a/crates/floresta-compact-filters/src/flat_filters_store.rs
+++ b/crates/floresta-compact-filters/src/flat_filters_store.rs
@@ -15,6 +15,9 @@ use std::sync::PoisonError;
 use crate::IterableFilterStore;
 use crate::IterableFilterStoreError;
 
+/// The maximum size that a block filter can have.
+pub const MAX_FILTER_SIZE: u32 = 1_000_000;
+
 pub struct FiltersIterator {
     reader: BufReader<File>,
 }
@@ -54,7 +57,7 @@ struct FlatFiltersStoreInner {
 
 impl From<PoisonError<MutexGuard<'_, FlatFiltersStoreInner>>> for IterableFilterStoreError {
     fn from(_: PoisonError<MutexGuard<'_, FlatFiltersStoreInner>>) -> Self {
-        IterableFilterStoreError::Poisoned
+        IterableFilterStoreError::PoisonedLock
     }
 }
 
@@ -181,8 +184,8 @@ impl IterableFilterStore for FlatFiltersStore {
     ) -> Result<(), IterableFilterStoreError> {
         let length = block_filter.content.len() as u32;
 
-        if length > 1_000_000 {
-            return Err(IterableFilterStoreError::FilterTooLarge);
+        if length > MAX_FILTER_SIZE {
+            return Err(IterableFilterStoreError::OversizedBlockFilter);
         }
 
         let mut inner = self.0.lock()?;

--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -18,10 +18,12 @@
 )]
 #![allow(clippy::manual_is_multiple_of)]
 
+use core::error;
 use core::fmt;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
+use std::io;
 use std::sync::PoisonError;
 use std::sync::RwLockWriteGuard;
 
@@ -43,43 +45,46 @@ pub trait BlockFilterStore: Send + Sync {
     fn get_height(&self) -> Option<u32>;
 }
 
+/// Errors that can happen whilst interacting with the [`IterableFilterStore`].
+#[derive(Debug)]
 pub enum IterableFilterStoreError {
-    /// I/O error
-    Io(std::io::Error),
-    /// End of the file
+    /// An I/O error.
+    ///
+    /// See the inner error for more information.
+    Io(io::Error),
+
+    /// The reader reached the end of the file.
     Eof,
-    /// Lock error
-    Poisoned,
-    /// Filter too large, probably a bug
-    FilterTooLarge,
-}
 
-impl Debug for IterableFilterStoreError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            IterableFilterStoreError::Io(e) => write!(f, "I/O error: {e}"),
-            IterableFilterStoreError::Eof => write!(f, "End of file"),
-            IterableFilterStoreError::Poisoned => write!(f, "Lock poisoned"),
-            IterableFilterStoreError::FilterTooLarge => write!(f, "Filter too large"),
-        }
-    }
-}
+    /// The cache lock is poisoned.
+    PoisonedLock,
 
-impl From<std::io::Error> for IterableFilterStoreError {
-    fn from(e: std::io::Error) -> Self {
-        IterableFilterStoreError::Io(e)
-    }
+    /// The filter is larger than [`MAX_FILTER_SIZE`](crate::flat_filters_store::MAX_FILTER_SIZE).
+    OversizedBlockFilter,
 }
 
 impl Display for IterableFilterStoreError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Debug::fmt(self, f)
+        match self {
+            IterableFilterStoreError::Io(e) => write!(f, "IterableFilterStore I/O Error: {e:?}"),
+            IterableFilterStoreError::Eof => write!(f, "The IterableFilterStore reached EOF"),
+            IterableFilterStoreError::PoisonedLock => write!(f, "The lock is poisoned"),
+            IterableFilterStoreError::OversizedBlockFilter => write!(f, "The filter is too large"),
+        }
+    }
+}
+
+impl error::Error for IterableFilterStoreError {}
+
+impl From<io::Error> for IterableFilterStoreError {
+    fn from(e: io::Error) -> Self {
+        IterableFilterStoreError::Io(e)
     }
 }
 
 impl From<PoisonError<RwLockWriteGuard<'_, FlatFiltersStore>>> for IterableFilterStoreError {
     fn from(_: PoisonError<RwLockWriteGuard<'_, FlatFiltersStore>>) -> Self {
-        IterableFilterStoreError::Poisoned
+        IterableFilterStoreError::PoisonedLock
     }
 }
 

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -4,8 +4,10 @@
 //! our transactions every 1 hour.
 //! Once our transaction is included in a block, we remove it from the mempool.
 
-use core::error;
+use core::error::Error;
 use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -68,9 +70,9 @@ pub struct Mempool {
     hasher: ahash::RandomState,
 }
 
-/// Errors that can occur whilst trying to add a transaction to the [`Mempool`].
 #[derive(Debug)]
-pub enum AcceptToMempoolError {
+/// Errors that can occur whilst trying to add a transaction to the [`Mempool`].
+pub enum MempoolError {
     /// The [`Mempool`] is full and cannot accept more [`Transaction`]s.
     FullMempool,
 
@@ -86,29 +88,32 @@ pub enum AcceptToMempoolError {
     ConsensusValidation(BlockchainError),
 }
 
-impl fmt::Display for AcceptToMempoolError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+impl Display for MempoolError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AcceptToMempoolError::FullMempool => {
-                write!(f, " The mempool is full and cannot accept more transaction")
+            Self::FullMempool => {
+                write!(
+                    f,
+                    "The mempool is full and cannot accept any more transactions"
+                )
             }
-            AcceptToMempoolError::ConflictingTransaction => {
+            Self::ConflictingTransaction => {
                 write!(
                     f,
                     "The transaction conflicts with another transaction in the mempool"
                 )
             }
-            AcceptToMempoolError::DuplicatedInputs => {
+            Self::DuplicatedInputs => {
                 write!(f, "The transaction has duplicate inputs")
             }
-            AcceptToMempoolError::ConsensusValidation(e) => {
+            Self::ConsensusValidation(e) => {
                 write!(f, "The transaction failed consensus validation: {e}")
             }
         }
     }
 }
 
-impl error::Error for AcceptToMempoolError {}
+impl Error for MempoolError {}
 
 impl Mempool {
     /// Creates a new mempool with a given maximum size
@@ -251,7 +256,7 @@ impl Mempool {
     }
 
     /// Checks if the transaction doesn't have conflicting inputs or spends the same input twice.
-    fn check_for_conflicts(&self, transaction: &Transaction) -> Result<(), AcceptToMempoolError> {
+    fn check_for_conflicts(&self, transaction: &Transaction) -> Result<(), MempoolError> {
         // check for duplicate inputs
         let inputs = transaction
             .input
@@ -260,14 +265,14 @@ impl Mempool {
             .collect::<BTreeSet<_>>();
 
         if inputs.len() != transaction.input.len() {
-            return Err(AcceptToMempoolError::DuplicatedInputs);
+            return Err(MempoolError::DuplicatedInputs);
         }
 
         // Check this transaction doesn't conflict with another transaction in the mempool
         // TODO(davidson): RBF
         for input in transaction.input.iter() {
             if self.is_already_spent(&input.previous_output) {
-                return Err(AcceptToMempoolError::ConflictingTransaction);
+                return Err(MempoolError::ConflictingTransaction);
             }
         }
 
@@ -288,10 +293,7 @@ impl Mempool {
     ///    the theoretical maximum amount of Bitcoins
     ///  - If either vIn or vOut are empty
     ///  - If any script is larger than the maximum allowed size
-    pub fn accept_to_mempool(
-        &mut self,
-        transaction: Transaction,
-    ) -> Result<(), AcceptToMempoolError> {
+    pub fn accept_to_mempool(&mut self, transaction: Transaction) -> Result<(), MempoolError> {
         debug!(
             "Accepting {} to mempool {:?}",
             transaction.compute_txid(),
@@ -301,7 +303,7 @@ impl Mempool {
         // Make sure our mempool has space
         let tx_size = transaction.total_size();
         if self.mempool_size + tx_size > self.max_mempool_size {
-            return Err(AcceptToMempoolError::FullMempool);
+            return Err(MempoolError::FullMempool);
         }
 
         let short_txid = self.hasher.hash_one(transaction.compute_txid());
@@ -313,7 +315,7 @@ impl Mempool {
 
         // Perform context-free consensus checks
         Consensus::check_transaction_context_free(&transaction)
-            .map_err(AcceptToMempoolError::ConsensusValidation)?;
+            .map_err(MempoolError::ConsensusValidation)?;
 
         // Make sure transaction won't conflict with other mempool transaction
         self.check_for_conflicts(&transaction)?;
@@ -394,7 +396,7 @@ mod tests {
     use rand::SeedableRng;
 
     use super::Mempool;
-    use crate::mempool::AcceptToMempoolError;
+    use crate::mempool::MempoolError;
 
     /// builds a list of transactions in a pseudo-random way
     ///
@@ -508,7 +510,7 @@ mod tests {
         for tx in transactions {
             match mempool.accept_to_mempool(tx) {
                 Ok(_) => {}
-                Err(AcceptToMempoolError::DuplicatedInputs) => {
+                Err(MempoolError::DuplicatedInputs) => {
                     did_conflict = true;
                 }
 

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -4,10 +4,8 @@
 //! our transactions every 1 hour.
 //! Once our transaction is included in a block, we remove it from the mempool.
 
-use core::error::Error;
+use core::error;
 use core::fmt;
-use core::fmt::Display;
-use core::fmt::Formatter;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -70,42 +68,47 @@ pub struct Mempool {
     hasher: ahash::RandomState,
 }
 
+/// Errors that can occur whilst trying to add a transaction to the [`Mempool`].
 #[derive(Debug)]
-/// An error returned when we try to add a transaction to the mempool.
 pub enum AcceptToMempoolError {
-    /// Memory usage is too high.
-    MemoryUsageTooHigh,
+    /// The [`Mempool`] is full and cannot accept more [`Transaction`]s.
+    FullMempool,
 
-    /// The transaction is conflicting with another transaction in the mempool.
+    /// The [`Transaction`] conflicts with another [`Transaction`] in the [`Mempool`].
     ConflictingTransaction,
 
-    /// This transaction has duplicated inputs
+    /// The [`Transaction`] has duplicate inputs.
     DuplicatedInputs,
 
-    /// A validation error happened while consensus checking a transaction
     // TODO(davidson): we might want to make an error type specific for consensus,
     // instead of reusing BlockchainError.
-    Consensus(BlockchainError),
+    /// The [`Transaction`] failed consensus validation.
+    ConsensusValidation(BlockchainError),
 }
 
-impl Display for AcceptToMempoolError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+impl fmt::Display for AcceptToMempoolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            AcceptToMempoolError::MemoryUsageTooHigh => write!(f, "we are running out of memory"),
+            AcceptToMempoolError::FullMempool => {
+                write!(f, " The mempool is full and cannot accept more transaction")
+            }
             AcceptToMempoolError::ConflictingTransaction => {
-                write!(f, "we have another transaction that spends the same input")
+                write!(
+                    f,
+                    "The transaction conflicts with another transaction in the mempool"
+                )
             }
             AcceptToMempoolError::DuplicatedInputs => {
-                write!(f, "this transaction has duplicated inputs")
+                write!(f, "The transaction has duplicate inputs")
             }
-            AcceptToMempoolError::Consensus(e) => {
-                write!(f, "the transaction failed consensus validation: {e}")
+            AcceptToMempoolError::ConsensusValidation(e) => {
+                write!(f, "The transaction failed consensus validation: {e}")
             }
         }
     }
 }
 
-impl Error for AcceptToMempoolError {}
+impl error::Error for AcceptToMempoolError {}
 
 impl Mempool {
     /// Creates a new mempool with a given maximum size
@@ -298,7 +301,7 @@ impl Mempool {
         // Make sure our mempool has space
         let tx_size = transaction.total_size();
         if self.mempool_size + tx_size > self.max_mempool_size {
-            return Err(AcceptToMempoolError::MemoryUsageTooHigh);
+            return Err(AcceptToMempoolError::FullMempool);
         }
 
         let short_txid = self.hasher.hash_one(transaction.compute_txid());
@@ -310,7 +313,7 @@ impl Mempool {
 
         // Perform context-free consensus checks
         Consensus::check_transaction_context_free(&transaction)
-            .map_err(AcceptToMempoolError::Consensus)?;
+            .map_err(AcceptToMempoolError::ConsensusValidation)?;
 
         // Make sure transaction won't conflict with other mempool transaction
         self.check_for_conflicts(&transaction)?;

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -112,9 +112,6 @@ pub enum FlorestadError {
     /// Failed to push a descriptor to the wallet.
     CouldNotPushDescriptor(String),
 
-    /// The network is unsupported.
-    UnsupportedNetwork(bitcoin::Network),
-
     /// Invalid Ip address error.
     InvalidIpAddress(AddrParseError),
 
@@ -208,9 +205,6 @@ impl Display for FlorestadError {
             }
             FlorestadError::CouldNotPushDescriptor(err) => {
                 write!(f, "Could not push descriptor to wallet: {err}")
-            }
-            FlorestadError::UnsupportedNetwork(err) => {
-                write!(f, "Unsupported network: {err}")
             }
             FlorestadError::InvalidIpAddress(err) => {
                 write!(f, "Invalid IP address: {err}")

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -9,7 +9,7 @@ use axum::response::IntoResponse;
 use corepc_types::v30::GetBlockVerboseOne;
 use floresta_chain::extensions::HeaderExtError;
 use floresta_common::impl_error_from;
-use floresta_mempool::mempool::AcceptToMempoolError;
+use floresta_mempool::mempool::MempoolError;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -224,10 +224,10 @@ pub enum JsonRpcError {
     InvalidTimestamp,
 
     /// Something went wrong when attempting to publish a transaction to mempool
-    MempoolAccept(AcceptToMempoolError),
+    MempoolAccept(MempoolError),
 }
 
-impl_error_from!(JsonRpcError, AcceptToMempoolError, MempoolAccept);
+impl_error_from!(JsonRpcError, MempoolError, MempoolAccept);
 
 impl Display for JsonRpcError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/crates/floresta-wire/src/p2p_wire/node/blocks.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/blocks.rs
@@ -316,8 +316,8 @@ where
             BlockchainError::TransactionError(tx_err) => Some(tx_err.error),
             BlockchainError::BlockValidation(block_err) => Some(block_err),
             // TODO: we need clearer error definitions for utreexo failures
-            BlockchainError::UtreexoError(_) | BlockchainError::InvalidProof => {
-                Some(BlockValidationErrors::InvalidProof)
+            BlockchainError::AccumulatorError(_) | BlockchainError::InvalidUtreexoProof => {
+                Some(BlockValidationErrors::InvalidUtreexoProof)
             }
             _ => None,
         }
@@ -336,7 +336,7 @@ where
         let hash = block.block_hash();
         match e {
             // The utreexo peer sent us an invalid utreexo proof. Block is not yet processed.
-            BlockValidationErrors::InvalidProof => {
+            BlockValidationErrors::InvalidUtreexoProof => {
                 self.blocks
                     .insert(hash, InflightBlock::new(block, block_peer));
 

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -12,7 +12,7 @@ use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
 use bitcoin::Txid;
-use floresta_mempool::mempool::AcceptToMempoolError;
+use floresta_mempool::mempool::MempoolError;
 use rustreexo::proof::Proof;
 use serde::Serialize;
 use tokio::sync::mpsc::UnboundedSender;
@@ -156,7 +156,7 @@ pub enum NodeResponse {
     Ping(bool),
 
     /// Transaction broadcast
-    TransactionBroadcastResult(Result<Txid, AcceptToMempoolError>),
+    TransactionBroadcastResult(Result<Txid, MempoolError>),
 }
 
 #[derive(Debug, Clone)]
@@ -207,7 +207,7 @@ impl NodeInterface {
     pub async fn broadcast_transaction(
         &self,
         transaction: Transaction,
-    ) -> Result<Result<Txid, AcceptToMempoolError>, oneshot::error::RecvError> {
+    ) -> Result<Result<Txid, MempoolError>, oneshot::error::RecvError> {
         let val = self
             .send_request(UserRequest::SendTransaction(transaction))
             .await?;


### PR DESCRIPTION
Implements a `Display` and `Error` for a few error enums, removes a few unused variants, and renames a bunch of variants.

I specifically did these as they are the errors that `bdk_floresta` consumes. Other enums can be done on follow ups.

## Changelog
```
- Add `MAX_FILTER_SIZE` constant
- Add `MAX_ACCUMULATOR_SIZE` constant

- Implement `Display` and `Error` for `FlatChainstoreError`
- Implement `Display` and `Error` for `IterableFilterStoreError`
- Implement `Display` and `Error` for `AcceptToMempoolErro`
- Implement `Display` and `Error` for `BlockChainError`

- Rename `BlockchainError::UtreexoError` to `BlockchainError::AccumulatorError`
- Rename `BlockValidationErrors::InvalidProof` to `BlockValidationErrors::InvalidUtreexoProof`
- Rename `FlatChainstoreError::Poisoned` to `FlatChainstoreError::PoisonedLock`
- Rename `FlatChainstoreError::IndexIsFull` to FlatChainstoreError::FullIndex`
- Rename `FlatChainstoreError::DbTooNew` to `FlatChainstoreError::UnsupportedSchema`
- Rename `FlatChainstoreError::InvalidMagic` to `FlatChainstoreError::BadMagic`
- Rename `FlatChainstoreError::DbCorrupted` to `FlatChainstoreError::CorruptedDatabase`
- Rename `FlatChainstoreError::BlockNotFound` to `FlatChainstoreError::HeaderNotFound`
- Rename `FlatChainstoreError::AccumulatorTooBig` to `FlatChainstoreError::OversizedAccumulator`
- Rename `IterableFilterStoreError::Poisoned` to `IterableFilterStoreError::PoisonedLock`
- Rename `IterableFilterStoreError::FilterTooLarge` to `IterableFilterStoreError::OversizedBlockFilter`
- Rename `AcceptToMempoolError::MemoryUsageTooHigh ` to `AcceptToMempoolError::FullMempool`
- Rename `AcceptToMempoolError::Consensus` to `MempoolError::ConsensusValidation`
- Rename `AcceptToMempoolError` to `MempoolError`

- Remove unused `BlockchainError::ConsensusDecode` variant 
- Remove unused `BlockchainError::Io` variant
- Remove unused `BlockchainError::UnsupportedNetwork` variant
```