### PR TITLE
docs: updated CLI paths and commands

### DIFF
--- a/bin/florestad/docs/tutorial(EN).md
+++ b/bin/florestad/docs/tutorial(EN).md
@@ -45,17 +45,17 @@ For multisig addresses, a wallet like Sparrow is recommended. Simply copy the "o
 See [below](#config_example) for an example of a valid file.
 
 ```bash
-floresta -c config.toml --network signet run
+florestad -c config.toml --network signet
 ```
 or
 
 ```bash
-./target/release/floresta -c config.toml --network signet run
+./target/release/florestad -c config.toml --network signet
 ```
 or
 
 ```bash
-cargo run --release -- -c config.toml --network signet
+cargo run --release --bin florestad -- -c config.toml --network signet
 ```
 Where:
 

--- a/bin/florestad/docs/tutorial(PT-BR).md
+++ b/bin/florestad/docs/tutorial(PT-BR).md
@@ -46,19 +46,19 @@ Para endereços multisig, uma carteira como Sparrow é recomendada. Basta copiar
 Veja [abaixo](#config_example) um exemplo de arquivo válido.
 
 ```bash
-floresta -c config.toml --network signet run
+florestad -c config.toml --network signet
 ```
 
 ou
 
 ```bash
-./target/release/floresta -c config.toml --network signet run
+./target/release/florestad -c config.toml --network signet
 ```
 
 ou
 
 ```bash
-cargo run --release -- -c config.toml --network signet
+cargo run --release --bin florestad -- -c config.toml --network signet
 ```
 
 Onde:

--- a/doc/run.md
+++ b/doc/run.md
@@ -19,7 +19,7 @@ This will start the full node, and you can connect to it with an Electrum wallet
 floresta-cli getblockchaininfo
 ```
 
-For more information on how to use the `floresta-cli` tool, you can check the [API documentation](https://github.com/getfloresta/Floresta/blob/master/crates/floresta-cli/README.md).
+For more information on how to use the `floresta-cli` tool, you can check the [API documentation](https://github.com/getfloresta/Floresta/blob/master/bin/floresta-cli/README.md).
 
 ## TLS
 
@@ -96,10 +96,10 @@ Floresta comes with a watch-only wallet that you can use to track your transacti
 information, either as a configuration file or as a command line argument. See the [sample configuration file](../config.toml.sample) for an example config. Floresta supports SLIP-132 extended public keys (xpubs) and output descriptors. You can add new wallets to follow at any time, just
 call the `rescanblockchain` rpc after adding the wallet.
 
-You can add new descriptors to the wallet with the `importdescriptor` rpc.
+You can add new descriptors to the wallet with the `loaddescriptor` rpc.
 
 ```bash
-floresta-cli importdescriptor "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)"
+floresta-cli loaddescriptor "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)"
 ```
 
 The rescan assumes that you have compact block filters for the blocks that you're scanning. You can either download all the filters


### PR DESCRIPTION
### Description and Notes
This PR fixes outdated command examples and CLI paths in docs. I updated the binary name from `floresta` to `florestad` in tutorials and updated descriptor wallet examples to use `loaddescriptor` instead of `importdescriptor`

### How to verify the changes :
- Confirmed `florestad` is actual daemon binary.
- Confirmed `florestad --network signet` is accepted.
- Confirmed `florestad --network signet run` is rejected, so removed `run` subcommand.
- Confimed `floresta-cli loaddescriptor --help` works.

