### PR TITLE
fix: normalize peer latency by request weight

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -109,6 +109,37 @@ pub enum NodeRequest {
     GetBlockProof((BlockHash, Bitmap, Bitmap)),
 }
 
+impl NodeRequest {
+    /// Returns the relative cost of the expected response for this request,
+    /// used to normalize peer latency measurements in [`register_message_time`].
+    pub fn weight(&self) -> f64 {
+        match self {
+            // 4 MB max per BIP 141
+            NodeRequest::GetBlock(_) => 25.0,
+
+            NodeRequest::GetBlockProof(_) => 25.0,
+
+            NodeRequest::GetUtreexoState(_) => 0.1,
+
+            // BIP 158 filters: ~20 KB per block empirically
+            NodeRequest::GetFilter(_) => 0.13,
+
+            // Baseline: 2000 × 80 bytes = 160 KB
+            NodeRequest::GetHeaders(_) => 1.0,
+
+            NodeRequest::MempoolTransaction(_) => 0.01,
+
+            // Returning 1.0 as a neutral fallback,
+            // because these variants are never registered as inflight
+            NodeRequest::GetAddresses
+            | NodeRequest::BroadcastTransaction(_)
+            | NodeRequest::SendAddresses(_)
+            | NodeRequest::Ping
+            | NodeRequest::Shutdown => 1.0,
+        }
+    }
+}
+
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub(crate) enum InflightRequests {
     /// Requests the peer to send us the next block headers in their main chain

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -6,10 +6,12 @@ use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use bitcoin::hashes::Hash;
 use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::p2p::ServiceFlags;
+use bitcoin::BlockHash;
 use bitcoin::Transaction;
 use floresta_chain::ChainBackend;
 use floresta_common::service_flags;
@@ -744,33 +746,39 @@ where
         peer: PeerId,
         read_at: Instant,
     ) -> Option<()> {
-        let sent_at = match notification {
+        let (sent_at, weight) = match notification {
             PeerMessages::Block(block) => {
                 let inflight = self
                     .inflight
                     .get(&InflightRequests::Blocks(block.block_hash()))?;
 
-                inflight.1
+                (inflight.1, NodeRequest::GetBlock(vec![]).weight())
             }
 
             PeerMessages::Ready(_) => {
                 let inflight = self.inflight.get(&InflightRequests::Connect(peer))?;
-                inflight.1
+                (inflight.1, NodeRequest::Ping.weight())
             }
 
             PeerMessages::Headers(_) => {
                 let inflight = self.inflight.get(&InflightRequests::Headers)?;
-                inflight.1
+                (inflight.1, NodeRequest::GetHeaders(vec![]).weight())
             }
 
             PeerMessages::BlockFilter((_, _)) => {
                 let inflight = self.inflight.get(&InflightRequests::GetFilters)?;
-                inflight.1
+                (
+                    inflight.1,
+                    NodeRequest::GetFilter((BlockHash::all_zeros(), 0)).weight(),
+                )
             }
 
             PeerMessages::UtreexoState(_) => {
                 let inflight = self.inflight.get(&InflightRequests::UtreexoState(peer))?;
-                inflight.1
+                (
+                    inflight.1,
+                    NodeRequest::GetUtreexoState((BlockHash::all_zeros(), 0)).weight(),
+                )
             }
 
             _ => return None,
@@ -778,7 +786,7 @@ where
 
         let elapsed = read_at.duration_since(sent_at).as_secs_f64();
         if let Some(peer) = self.peers.get_mut(&peer) {
-            peer.message_times.add(elapsed * 1_000.0); // milliseconds
+            peer.message_times.add((elapsed / weight) * 1_000.0); // milliseconds
         }
 
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
fixes: #887 

Add `NodeRequest::weight()` to normalize peer latency measurements by expected response size. 

The `NodeRequest::weight()` returns expected response size for each request type, normalized so that `GetHeaders` = 1.0 (its max response is precisely defined: 2000 × 80 bytes = 160 KB). And all other weights are derived as `expected_bytes / 160_000`

## Changelog
```
- Normalize peer latency measurements by request weight in  `register_message_time` to prevent large-response requests from unfairly penalizing fast peers during peer selection
```
