### PR TITLE
rpc: implement getdifficulty

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -62,6 +62,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         }
         Methods::GetBestBlockHash => serde_json::to_string_pretty(&client.get_best_block_hash()?)?,
         Methods::GetBlockCount => serde_json::to_string_pretty(&client.get_block_count()?)?,
+        Methods::GetDifficulty => serde_json::to_string_pretty(&client.get_difficulty()?)?,
         Methods::GetTxOut { txid, vout } => {
             serde_json::to_string_pretty(&client.get_tx_out(txid, vout)?)?
         }
@@ -199,6 +200,15 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetBlockCount,
+
+    #[doc = include_str!("../../../doc/rpc/getdifficulty.md")]
+    #[command(
+        name = "getdifficulty",
+        about = "Returns the proof-of-work difficulty as a multiple of the minimum difficulty.",
+        long_about = Some(include_str!("../../../doc/rpc/getdifficulty.md")),
+        disable_help_subcommand = true
+    )]
+    GetDifficulty,
 
     /// Returns the proof that one or more transactions were included in a block
     #[command(name = "gettxoutproof")]

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -312,7 +312,20 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     // getchaintips
     // getchaintxstats
     // getdeploymentinfo
+
     // getdifficulty
+    pub(super) fn get_difficulty(&self) -> Result<f64, JsonRpcError> {
+        let (_, hash) = self
+            .chain
+            .get_best_block()
+            .map_err(|_| JsonRpcError::Chain)?;
+        let header = self
+            .chain
+            .get_block_header(&hash)
+            .map_err(|_| JsonRpcError::BlockNotFound)?;
+        Ok(header.difficulty_float())
+    }
+
     // getmempoolancestors
     // getmempooldescendants
     // getmempoolentry

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -263,6 +263,10 @@ async fn handle_json_rpc_request(
                 .map(|h| serde_json::to_value(h).unwrap())
         }
 
+        "getdifficulty" => state
+            .get_difficulty()
+            .map(|v| serde_json::to_value(v).unwrap()),
+
         "gettxout" => {
             let txid = get_hash(&params, 0, "txid")?;
             let vout = get_numeric(&params, 1, "vout")?;

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -79,6 +79,9 @@ pub trait FlorestaRPC {
 
     /// Returns the current height of the blockchain
     fn get_block_count(&self) -> Result<u32>;
+
+    #[doc = include_str!("../../../doc/rpc/getdifficulty.md")]
+    fn get_difficulty(&self) -> Result<f64>;
     /// Sends a hex-encoded transaction to the network
     ///
     /// This method sends a transaction to the network. The transaction should be encoded as a
@@ -264,6 +267,10 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_block_count(&self) -> Result<u32> {
         self.call("getblockcount", &[])
+    }
+
+    fn get_difficulty(&self) -> Result<f64> {
+        self.call("getdifficulty", &[])
     }
 
     fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut> {

--- a/doc/rpc/getdifficulty.md
+++ b/doc/rpc/getdifficulty.md
@@ -1,0 +1,28 @@
+# `getdifficulty`
+
+Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+
+## Usage
+
+### Synopsis
+
+floresta-cli getdifficulty
+
+### Examples
+
+```bash
+floresta-cli getdifficulty
+```
+
+## Returns
+
+### Ok response
+
+- `difficulty` - (numeric) The proof-of-work difficulty as a multiple of the minimum difficulty.
+
+## Notes
+
+- The returned value may differ from `bitcoin-cli getdifficulty` at the last
+  digits of the f64 mantissa due to floating-point rounding in rust-bitcoin's
+  implementation. The difference is on the order of machine epsilon (~1e-16)
+  and has no practical effect.

--- a/tests/floresta-cli/getdifficulty.py
+++ b/tests/floresta-cli/getdifficulty.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getdifficulty.py
+
+Functional test for the `getdifficulty` RPC. Verifies parity between
+florestad and bitcoind at genesis for Bitcoin Core compliance.
+"""
+
+import math
+import pytest
+
+# Bitcoin Core and rust-bitcoin compute difficulty with slightly different
+# float arithmetic, so allow a small relative tolerance on the parity check.
+TOLERANCE = 1e-9
+
+
+@pytest.mark.rpc
+def test_get_difficulty(florestad_bitcoind):
+    """
+    Test `getdifficulty` by comparing florestad's response against bitcoind's.
+    Both nodes start at the regtest genesis block and should report the same
+    difficulty for that target.
+    """
+    florestad, bitcoind = florestad_bitcoind
+
+    floresta_difficulty = florestad.rpc.get_difficulty()
+    bitcoind_difficulty = bitcoind.rpc.get_difficulty()
+
+    assert floresta_difficulty is not None
+    assert floresta_difficulty > 0
+    assert math.isclose(floresta_difficulty, bitcoind_difficulty, rel_tol=TOLERANCE)

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -259,6 +259,12 @@ class BaseRPC(ABC):
         """
         return self.perform_request("getblockcount")
 
+    def get_difficulty(self) -> float:
+        """
+        Get the proof-of-work difficulty as a multiple of the minimum difficulty
+        """
+        return self.perform_request("getdifficulty")
+
     def get_blockheader(self, blockhash: str, verbosity: bool | None = None) -> dict:
         """
         Get the header of a block


### PR DESCRIPTION
### Description and Notes
This PR implements `getdifficulty`, which returns the proof-of-work difficulty at the chain tip as a multiple of the minimum difficulty.

- Uses the underlying implementations of using `chain.get_best_block()` and `chain.get_block_header()` to get  the difficulty_float() from headers.

- It returns an f64 difficulty which matches Bitcoin Core's output shape

## Test plan

- [x] Functional test `getdifficulty.py` - spins up florestad + bitcoind on regtest, asserts both report a positive difficulty and match within `rel_tol=1e-9` (a small drift between rust-bitcoin and Bitcoin Core's C++ arithmetic)
- [x] Manually tested on local regtest node against `bitcoin-cli getdifficulty` for parity
- [x] Clippy clean, fmt clean, build passes

<img width="739" height="99" alt="image" src="https://github.com/user-attachments/assets/cb400d11-ba17-4cef-b445-2fe33cfb2748" />