### PR TITLE
feat: added JSON RPC authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -934,6 +943,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1072,6 +1093,7 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "clap",
+ "dirs 5.0.1",
  "floresta-rpc",
  "serde_json",
 ]
@@ -1148,6 +1170,7 @@ name = "floresta-node"
 version = "0.9.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "bitcoin",
  "corepc-types",
  "dns-lookup",
@@ -1162,6 +1185,7 @@ dependencies = [
  "metrics",
  "miniscript",
  "pretty_assertions",
+ "rand",
  "rcgen",
  "rustreexo",
  "serde",
@@ -1233,7 +1257,7 @@ dependencies = [
  "bitcoin",
  "clap",
  "console-subscriber",
- "dirs",
+ "dirs 4.0.0",
  "floresta-node",
  "libc",
  "tokio",
@@ -2062,6 +2086,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -3622,6 +3652,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3645,6 +3684,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3691,6 +3745,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3703,6 +3763,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3712,6 +3778,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3739,6 +3811,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3748,6 +3826,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3763,6 +3847,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3772,6 +3862,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0"
+dirs = "5"
 bitcoin = { workspace = true }
 clap = { workspace = true, features = ["help"] }
 serde_json = { workspace = true }

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Create a new JSON-RPC client using the host from the CLI arguments
-    let client = Client::new(get_host(&cli));
+    let client = build_client(&cli);
 
     // Perform the requested RPC call and get the result
     let res = do_request(&cli, client)?;
@@ -30,6 +30,48 @@ fn main() -> anyhow::Result<()> {
 
     // Return Ok to indicate the program ran successfully
     anyhow::Ok(())
+}
+
+fn build_client(cli: &Cli) -> Client {
+    let host = get_host(cli);
+
+    // Explicit user & password provided by the caller.
+    if let (Some(user), Some(pass)) = (cli.rpc_user.clone(), cli.rpc_password.clone()) {
+        return Client::new_with_auth(host, user, pass);
+    }
+
+    // Explicit cookie file path provided by the caller.
+    if let Some(ref cookie_path) = cli.rpc_cookie_file {
+        if !std::path::Path::new(cookie_path).exists() {
+            std::process::exit(1);
+        }
+        return Client::new_with_cookie(host, cookie_path.clone());
+    }
+
+    let default_cookie = default_cookie_path(cli.network);
+    if std::path::Path::new(&default_cookie).exists() {
+        return Client::new_with_cookie(host, default_cookie);
+    }
+
+    Client::new(host)
+}
+
+/// Returns the default path of the cookie file that `florestad` writes on startup.
+fn default_cookie_path(network: Network) -> String {
+    let mut base = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".floresta");
+
+    match network {
+        Network::Bitcoin => {}
+        Network::Signet => base.push("signet"),
+        Network::Testnet => base.push("testnet3"),
+        Network::Testnet4 => base.push("testnet4"),
+        Network::Regtest => base.push("regtest"),
+    }
+
+    base.push(".cookie");
+    base.to_string_lossy().into_owned()
 }
 
 // Function to determine the RPC host based on CLI arguments and network type
@@ -157,6 +199,9 @@ pub struct Cli {
     /// The RPC password to use
     #[arg(short = 'P', long, value_name = "PASSWORD")]
     pub rpc_password: Option<String>,
+    /// Path to a cookie file to use or generate for JSON-RPC Auth.
+    #[arg(long, value_name = "PATH")]
+    pub rpc_cookie_file: Option<String>,
     /// An actual RPC command to run
     #[command(subcommand)]
     pub methods: Methods,

--- a/bin/florestad/src/cli.rs
+++ b/bin/florestad/src/cli.rs
@@ -185,6 +185,21 @@ pub struct Cli {
     /// This will run in the background and wont't affect node's operation. However,
     /// to disable backfilling, run floresta using this flag.
     pub no_backfill: bool,
+
+    /// Optional username for JSON-RPC HTTP Basic Auth.
+    #[cfg(feature = "json-rpc")]
+    #[arg(long, value_name = "USERNAME")]
+    pub rpc_user: Option<String>,
+
+    /// Optional password for JSON-RPC HTTP Basic Auth.
+    #[cfg(feature = "json-rpc")]
+    #[arg(long, value_name = "PASSWORD")]
+    pub rpc_pass: Option<String>,
+
+    /// Path to a cookie file to use or generate for JSON-RPC Auth.
+    #[cfg(feature = "json-rpc")]
+    #[arg(long, value_name = "PATH")]
+    pub rpc_cookie_file: Option<String>,
 }
 
 impl Cli {
@@ -201,6 +216,20 @@ impl Cli {
                     "--pid-file requires that --daemon be set",
                 )
                 .exit();
+        }
+        #[cfg(feature = "json-rpc")]
+        {
+            let has_user = self.rpc_user.is_some();
+            let has_pass = self.rpc_pass.is_some();
+            if has_user != has_pass {
+                #[cfg(unix)]
+                Cli::command()
+                    .error(
+                        clap::error::ErrorKind::MissingRequiredArgument,
+                        "--rpc-user and --rpc-pass must be provided, or neither",
+                    )
+                    .exit();
+            }
         }
     }
 }

--- a/bin/florestad/src/main.rs
+++ b/bin/florestad/src/main.rs
@@ -92,6 +92,9 @@ fn main() {
         tls_key_path: params.tls_key_path,
         allow_v1_fallback: params.allow_v1_fallback,
         backfill: !params.no_backfill,
+        rpc_user: params.rpc_user,
+        rpc_pass: params.rpc_pass,
+        rpc_cookie_file: params.rpc_cookie_file,
     };
 
     #[cfg(unix)]

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -31,6 +31,8 @@ floresta-mempool = { workspace = true }
 floresta-watch-only = { workspace = true }
 floresta-wire = { workspace = true }
 metrics = { workspace = true,  optional = true }
+base64 = "0.22.1"
+rand.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -62,6 +62,7 @@ use crate::error::FlorestadError;
 use crate::florestad::fs::OpenOptions;
 #[cfg(feature = "json-rpc")]
 use crate::json_rpc;
+use crate::json_rpc::server::AuthConfig;
 use crate::wallet_input::InitialWalletSetup;
 #[cfg(feature = "zmq-server")]
 use crate::zmq::ZMQServer;
@@ -217,6 +218,18 @@ pub struct Config {
     /// and won't affect the node's operation. You may notice that this will take a lot of CPU
     /// and bandwidth to run.
     pub backfill: bool,
+
+    /// Optional username for JSON-RPC HTTP Basic Auth.
+    #[cfg(feature = "json-rpc")]
+    pub rpc_user: Option<String>,
+
+    /// Optional password for JSON-RPC HTTP Basic Auth.
+    #[cfg(feature = "json-rpc")]
+    pub rpc_pass: Option<String>,
+
+    /// Path to a cookie file to use (or generate) for JSON-RPC authentication.
+    #[cfg(feature = "json-rpc")]
+    pub rpc_cookie_file: Option<String>,
 }
 
 impl Config {
@@ -251,6 +264,12 @@ impl Config {
             tls_cert_path: None,
             allow_v1_fallback: false,
             backfill: false,
+            #[cfg(feature = "json-rpc")]
+            rpc_user: None,
+            #[cfg(feature = "json-rpc")]
+            rpc_pass: None,
+            #[cfg(feature = "json-rpc")]
+            rpc_cookie_file: None,
         }
     }
 }
@@ -463,8 +482,31 @@ impl Florestad {
         let wallet = Arc::new(wallet);
 
         // JSON-RPC
-        #[cfg(feature = "json-rpc")]
         {
+            let auth: Option<AuthConfig> = {
+                #[cfg(feature = "json-rpc")]
+                {
+                    if let (Some(user), Some(pass)) =
+                        (self.config.rpc_user.clone(), self.config.rpc_pass.clone())
+                    {
+                        Some(AuthConfig::from_user_pass(user, pass))
+                    } else {
+                        // Use a cookie file – either the specified one,
+                        // or the default location inside the data directory.
+                        let cookie_path = self
+                            .config
+                            .rpc_cookie_file
+                            .clone()
+                            .unwrap_or_else(|| format!("{data_dir}/.cookie"));
+
+                        Some(
+                            AuthConfig::from_cookie_file(&cookie_path)
+                                .expect("Failed to create RPC cookie file"),
+                        )
+                    }
+                }
+            };
+
             let server = tokio::spawn(json_rpc::server::RpcImpl::create(
                 blockchain_state.clone(),
                 wallet.clone(),
@@ -478,6 +520,7 @@ impl Florestad {
                     .map(|x| Self::resolve_hostname(x, 8332))
                     .transpose()?,
                 format!("{data_dir}/debug.log"),
+                auth,
             ));
 
             if self.json_rpc.set(server).is_err() {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -2,6 +2,8 @@
 
 use core::net::SocketAddr;
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 use std::slice;
 use std::sync::Arc;
 use std::time::Instant;
@@ -9,12 +11,15 @@ use std::time::Instant;
 use axum::body::Body;
 use axum::body::Bytes;
 use axum::extract::State;
+use axum::http::header::AUTHORIZATION;
 use axum::http::Method;
 use axum::http::Response;
 use axum::http::StatusCode;
 use axum::routing::post;
 use axum::Json;
 use axum::Router;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::hashes::hex::FromHex;
@@ -36,6 +41,8 @@ use floresta_watch_only::kv_database::KvDatabase;
 use floresta_watch_only::AddressCache;
 use floresta_watch_only::CachedTransaction;
 use floresta_wire::node_interface::NodeInterface;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 use serde_json::json;
 use serde_json::Value;
 use tokio::sync::RwLock;
@@ -60,9 +67,65 @@ use crate::json_rpc::request::arg_parser::get_string;
 use crate::json_rpc::request::RpcRequest;
 use crate::json_rpc::res::RescanConfidence;
 
+/// The username written to the cookie file by floresta when no external credential are given
+const COOKIE_USERNAME: &str = "__cookie__";
+
+/// Length of the randomly generated cookie token.
+const COOKIE_TOKEN_LEN: usize = 32;
+
 pub(super) struct InflightRpc {
     pub method: String,
     pub when: Instant,
+}
+
+/// Holds the rpc credentials
+#[derive(Clone, Debug)]
+pub struct AuthConfig {
+    pub user: String,
+    pub pass: String,
+}
+
+impl AuthConfig {
+    /// Create an [`AuthConfig`] from an explicit username and password.
+    pub fn from_user_pass(user: String, pass: String) -> Self {
+        Self { user, pass }
+    }
+
+    /// Create an [`AuthConfig`] by generating a random cookie token and
+    /// writing to `cookie_path` in the format `__cookie__:<token>`.
+    ///
+    /// Returns the [`AuthConfig`] on success, or an error string on failure.
+    pub fn from_cookie_file(cookie_path: &str) -> Result<Self> {
+        let token: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(COOKIE_TOKEN_LEN)
+            .map(char::from)
+            .collect();
+
+        let cookie_contents = format!("{COOKIE_USERNAME}:{token}");
+
+        // Ensure the parent directory exists before writing.
+        if let Some(parent) = Path::new(cookie_path).parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                JsonRpcError::Decode(format!("Failed to create cookie directory: {e}"))
+            })?;
+        }
+
+        fs::write(cookie_path, &cookie_contents).map_err(|e| {
+            JsonRpcError::Decode(format!("Failed to write cookie file '{cookie_path}': {e}"))
+        })?;
+
+        info!("RPC cookie file written to {cookie_path}");
+
+        Ok(Self {
+            user: COOKIE_USERNAME.to_string(),
+            pass: token,
+        })
+    }
+
+    pub fn verify(&self, user: &str, pass: &str) -> bool {
+        self.user == user && self.pass == pass
+    }
 }
 
 /// Utility trait to ensure that the chain implements all the necessary traits
@@ -83,9 +146,82 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
     pub(super) log_path: String,
     pub(super) start_time: Instant,
+    pub(super) auth: Option<AuthConfig>,
 }
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
+
+/// Attempt to extract and verify HTTP Basic Auth credentials
+///
+/// Returns `Ok(())` when authentication succeeds or when its not required, and an
+/// `Err(Response)` containing a ready-to-send `401` response otherwise.
+fn authenticate(
+    headers: &axum::http::HeaderMap,
+    auth: &Option<AuthConfig>,
+) -> std::result::Result<(), Box<Response<Body>>> {
+    let Some(expected) = auth else {
+        // No authentication configured
+        return Ok(());
+    };
+
+    let unauthorized = || {
+        Box::new(
+            Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header("Content-Type", "application/json")
+                .header("WWW-Authenticate", "Basic realm=\"floresta\"")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "error": {
+                            "code": -32600,
+                            "message": "Unauthorized",
+                            "data": null
+                        },
+                        "result": null,
+                        "id": null
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+    };
+
+    // Extract the raw `Authorization` header value.
+    let auth_header = match headers.get(AUTHORIZATION) {
+        Some(v) => v,
+        None => return Err(unauthorized()),
+    };
+
+    let auth_str = match auth_header.to_str() {
+        Ok(s) => s,
+        Err(_) => return Err(unauthorized()),
+    };
+
+    let encoded = match auth_str.strip_prefix("Basic ") {
+        Some(e) => e,
+        None => return Err(unauthorized()),
+    };
+
+    // Decode the base64 payload.
+    let decoded_bytes = match BASE64.decode(encoded) {
+        Ok(b) => b,
+        Err(_) => return Err(unauthorized()),
+    };
+    let decoded = match String::from_utf8(decoded_bytes) {
+        Ok(s) => s,
+        Err(_) => return Err(unauthorized()),
+    };
+
+    let mut parts = decoded.splitn(2, ':');
+    let user = parts.next().unwrap_or("");
+    let pass = parts.next().unwrap_or("");
+
+    if expected.verify(user, pass) {
+        Ok(())
+    } else {
+        Err(unauthorized())
+    }
+}
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value> {
@@ -513,8 +649,13 @@ fn get_json_rpc_error_code(err: &JsonRpcError) -> i32 {
 
 async fn json_rpc_request(
     State(state): State<Arc<RpcImpl<impl RpcChain>>>,
+    headers: axum::http::HeaderMap,
     body: Bytes,
 ) -> Response<Body> {
+    if let Err(auth_err) = authenticate(&headers, &state.auth) {
+        return *auth_err;
+    }
+
     let req: RpcRequest = match serde_json::from_slice(&body) {
         Ok(req) => req,
         Err(e) => {
@@ -749,6 +890,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         address: Option<SocketAddr>,
         log_path: String,
+        auth: Option<AuthConfig>,
     ) {
         let address = address.unwrap_or_else(|| {
             format!("127.0.0.1:{}", Self::get_port(&network))
@@ -789,6 +931,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 inflight: Arc::new(RwLock::new(HashMap::new())),
                 log_path,
                 start_time: Instant::now(),
+                auth,
             }));
 
         axum::serve(listener, router)

--- a/crates/floresta-rpc/src/jsonrpc_client.rs
+++ b/crates/floresta-rpc/src/jsonrpc_client.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::fmt::Debug;
+use std::fs;
+use std::path::Path;
 
 use serde::Deserialize;
 
@@ -10,11 +12,55 @@ use crate::rpc::JsonRPCClient;
 #[derive(Debug)]
 pub struct Client(jsonrpc::Client);
 
+/// Authentication method for the JSON-RPC client.
+#[derive(Debug, Clone)]
+pub enum AuthMethod {
+    UserPass { user: String, pass: String },
+    CookieFile(String),
+    None,
+}
+
+impl AuthMethod {
+    /// Resolve the authentication method into `(user, pass)`,
+    /// returning `(None, None)` when no authentication is required.
+    ///
+    /// # Errors
+    /// Returns an error string if a cookie file path is provided but the file
+    /// cannot be read or parsed.
+    pub fn resolve(self) -> Result<(Option<String>, Option<String>), String> {
+        match self {
+            AuthMethod::UserPass { user, pass } => Ok((Some(user), Some(pass))),
+            AuthMethod::CookieFile(path) => {
+                let contents = fs::read_to_string(Path::new(&path))
+                    .map_err(|e| format!("Failed to read cookie file '{path}': {e}"))?;
+                let line = contents
+                    .lines()
+                    .next()
+                    .ok_or_else(|| format!("Cookie file '{path}' is empty"))?;
+                let mut parts = line.splitn(2, ':');
+                let user = parts
+                    .next()
+                    .ok_or_else(|| format!("Malformed cookie file '{path}'"))?
+                    .to_string();
+                let pass = parts
+                    .next()
+                    .ok_or_else(|| {
+                        format!("Malformed cookie file '{path}': missing ':' separator")
+                    })?
+                    .to_string();
+                Ok((Some(user), Some(pass)))
+            }
+            AuthMethod::None => Ok((None, None)),
+        }
+    }
+}
+
 // Configuration struct for JSON-RPC client
 pub struct JsonRPCConfig {
     pub url: String,
     pub user: Option<String>,
     pub pass: Option<String>,
+    pub cookie_file: Option<String>,
 }
 
 impl Client {
@@ -27,9 +73,32 @@ impl Client {
 
     // Constructor to create a new Client with a configuration
     pub fn new_with_config(config: JsonRPCConfig) -> Self {
+        let (user, pass) = if let Some(cookie_path) = config.cookie_file {
+            AuthMethod::CookieFile(cookie_path)
+                .resolve()
+                .expect("Failed to read cookie file")
+        } else {
+            (config.user.clone(), config.pass.clone())
+        };
         let client =
-            jsonrpc::Client::simple_http(&config.url, config.user.clone(), config.pass.clone())
-                .expect("Failed to create client");
+            jsonrpc::Client::simple_http(&config.url, user, pass).expect("Failed to create client");
+        Self(client)
+    }
+
+    /// Constructor to create a new Client using a cookie file.
+    pub fn new_with_cookie(url: String, cookie_file: String) -> Self {
+        let (user, pass) = AuthMethod::CookieFile(cookie_file)
+            .resolve()
+            .expect("Failed to read cookie file");
+        let client =
+            jsonrpc::Client::simple_http(&url, user, pass).expect("Failed to create client");
+        Self(client)
+    }
+
+    /// Constructor to create a new Client with explicit username and password.
+    pub fn new_with_auth(url: String, user: String, pass: String) -> Self {
+        let client = jsonrpc::Client::simple_http(&url, Some(user), Some(pass))
+            .expect("Failed to create client");
         Self(client)
     }
 


### PR DESCRIPTION
fixes: #651 

Added Json rpc authentication with username/password and cookie authentication.

With these changes, florestad resolves auth in priority order: explicit` --rpc-user`/`--rpc-pass` then `--rpc-cookie-file` if not found both will resolve to  auto-generated cookie at `{data_dir}/.cookie`


## Changelog
```
- Added AuthConfig to the RPC server that validates HTTP Basic Auth headers on every request, returning 401 Unauthorized on failure
- On startup, florestad resolves auth in priority order: explicit` --rpc-user`/`--rpc-pass` then `--rpc-cookie-file` if not found both will resolve to  auto-generated cookie at `{data_dir}/.cookie`
- Added AuthMethod enum and new_with_auth/new_with_cookie constructors to the RPC client.
- Added `--rpc-user`, `--rpc-pass`, `--rpc-cookie-file` flags to both florestad and floresta-cli.
```
