### PR TITLE
Duplicate input detection

### DIFF
--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -8,6 +8,7 @@ use std::io::Cursor;
 use bitcoin::Block;
 use bitcoin::Network;
 use bitcoin::OutPoint;
+use bitcoin::Transaction;
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::deserialize;
@@ -276,6 +277,23 @@ fn chainstore_checksum_benchmark(c: &mut Criterion) {
     });
 }
 
+fn check_transaction_context_free_benchmark(c: &mut Criterion) {
+    let block_file = File::open("./testdata/block_866342/raw.zst").unwrap();
+    let block_bytes = zstd::decode_all(block_file).unwrap();
+    let block: Block = deserialize(&block_bytes).unwrap();
+
+    // Collect all non-coinbase transactions from the block
+    let transactions: Vec<Transaction> = block.txdata.into_iter().skip(1).collect();
+
+    c.bench_function("check_transaction_context_free_block_866342", |b| {
+        b.iter(|| {
+            for tx in &transactions {
+                black_box(Consensus::check_transaction_context_free(tx)).ok();
+            }
+        })
+    });
+}
+
 criterion_group!(
     benches,
     initialize_chainstore_benchmark,
@@ -285,6 +303,7 @@ criterion_group!(
     connect_blocks_benchmark,
     validate_full_block_benchmark,
     validate_many_inputs_block_benchmark,
-    chainstore_checksum_benchmark
+    chainstore_checksum_benchmark,
+    check_transaction_context_free_benchmark
 );
 criterion_main!(benches);

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -449,6 +449,30 @@ impl Consensus {
         Ok(())
     }
 
+    /// Returns `true` if the transaction contains duplicate inputs
+    /// (the same `OutPoint` is spent more than once).
+    ///
+    /// Optimized for the most common cases: over 80% of Bitcoin transactions
+    /// have a single input (see <https://mainnet.observer/charts/transactions-1in/>),
+    /// which is handled with no allocation. Two-input transactions are handled
+    /// with a single equality check. Only transactions with three or more inputs
+    /// fall back to a `HashSet`.
+    fn has_duplicate_inputs(inputs: &[TxIn]) -> bool {
+        match inputs.len() {
+            1 => false,
+            2 => inputs[0].previous_output == inputs[1].previous_output,
+            _ => {
+                let mut seen = HashSet::with_capacity(inputs.len());
+                for input in inputs {
+                    if !seen.insert(&input.previous_output) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+
     /// Performs consensus checks that are independent of the spent outputs (non-coinbase only).
     /// Returns the total output value as an [`Amount`].
     pub fn check_transaction_context_free(
@@ -469,11 +493,23 @@ impl Consensus {
                 Err(tx_err!(txid, NullPrevOut))?;
             }
 
-            // Check script sizes (current tx scriptsig and TODO witness if present)
+            // Witness size is intentionally not checked here — witness-specific
+            // limits are enforced during script execution, not in context-free checks.
+            // This matches Bitcoin Core's CheckTransaction() which explicitly skips
+            // witness in context-free checks because witness data has not been
+            // checked for malleability at this point.
+            // See: https://github.com/bitcoin/bitcoin/blob/master/src/consensus/tx_check.cpp
             Self::validate_script_size(&input.script_sig, txid)?;
-            // TODO check also witness script size
         }
 
+        // Check for duplicate inputs (CVE-2018-17144).
+        // UpdateCoins does not detect duplicates — a duplicate prevout causes either
+        // a crash or an inflation bug depending on the coins database implementation.
+        // Bitcoin Core catches this explicitly in CheckTransaction() for the same reason.
+        // after:
+        if Self::has_duplicate_inputs(&transaction.input) {
+            Err(tx_err!(txid, DuplicateInput))?;
+        }
         let out_value = Self::total_out_value(transaction)?;
 
         // Sanity check
@@ -1372,6 +1408,43 @@ mod tests {
             Err(BlockchainError::BlockValidation(BlockValidationErrors::TooManyCoins)) => (),
             other => panic!("Expected TooManyCoins, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_duplicate_inputs_rejected() {
+        let outpoint = dummy_outpoint();
+        let outpoint2 = OutPoint {
+            txid: Txid::all_zeros(),
+            vout: 1,
+        };
+
+        // 2-input fast path
+        let tx = build_tx(
+            vec![txin!(outpoint), txin!(outpoint)],
+            vec![txout!(0, ScriptBuf::new())],
+        );
+
+        assert!(matches!(
+            Consensus::check_transaction_context_free(&tx),
+            Err(BlockchainError::TransactionError(TransactionError {
+                error: BlockValidationErrors::DuplicateInput,
+                ..
+            }))
+        ));
+
+        // 3+-input HashSet path
+        let tx = build_tx(
+            vec![txin!(outpoint), txin!(outpoint2), txin!(outpoint)],
+            vec![txout!(0, ScriptBuf::new())],
+        );
+
+        assert!(matches!(
+            Consensus::check_transaction_context_free(&tx),
+            Err(BlockchainError::TransactionError(TransactionError {
+                error: BlockValidationErrors::DuplicateInput,
+                ..
+            }))
+        ));
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -145,6 +145,7 @@ pub enum BlockValidationErrors {
     CoinbaseNotMatured,
     UnspendableUTXO,
     BIP94TimeWarp,
+    DuplicateInput,
 }
 
 // Helpful macro for generating a TransactionError
@@ -237,6 +238,9 @@ impl Display for BlockValidationErrors {
             }
             Self::BIP94TimeWarp => {
                 write!(f, "BIP94 time warp detected")
+            }
+            Self::DuplicateInput => {
+                write!(f, "This transaction has duplicate inputs")
             }
         }
     }

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -392,6 +392,11 @@ mod tests {
             };
 
             let inputs = rng.random_range(1..10);
+
+            // Track outpoints already used in this transaction to avoid
+            // duplicate inputs within a single tx, which is never valid.
+            // Conflicts are only meaningful across separate transactions.
+            let mut used_in_this_tx = HashSet::new();
             for _ in 0..inputs {
                 if outputs.is_empty() {
                     break;
@@ -402,6 +407,11 @@ mod tests {
                     false => outputs.remove(index),
                     true => *outputs.get(index).unwrap(),
                 };
+
+                // Skip if this outpoint is already an input in this tx
+                if !used_in_this_tx.insert(previous_output) {
+                    continue;
+                }
 
                 let input = bitcoin::TxIn {
                     previous_output,
@@ -476,7 +486,7 @@ mod tests {
         for tx in transactions {
             match mempool.accept_to_mempool(tx) {
                 Ok(_) => {}
-                Err(MempoolError::ConflictingTransaction) | Err(MempoolError::DuplicatedInputs) => {
+                Err(MempoolError::ConflictingTransaction) => {
                     did_conflict = true;
                 }
                 Err(e) => {

--- a/crates/floresta-wire/src/p2p_wire/node/blocks.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/blocks.rs
@@ -357,6 +357,7 @@ where
             BlockValidationErrors::InvalidCoinbase(_)
             | BlockValidationErrors::ScriptValidationError(_)
             | BlockValidationErrors::NullPrevOut
+            | BlockValidationErrors::DuplicateInput
             | BlockValidationErrors::EmptyInputs
             | BlockValidationErrors::EmptyOutputs
             | BlockValidationErrors::ScriptError


### PR DESCRIPTION
### Description and Notes

This PR adds duplicate input detection inside `check_transaction_context_free()`, closing a missing consensus-level validation gap.

Floresta had no context-free check for duplicate inputs. A transaction spending the same `OutPoint` twice could pass consensus checks and proceed further into verification. Mempool tests were also constructing duplicate inputs inside a single transaction, which masked the missing consensus validation.

Bitcoin Core performs this check in `CheckTransaction()` (see CVE-2018-17144) because missing it can cause crashes or inflation bugs depending on UTXO handling.

In Floresta, `get_utxo()` uses `.get()` on the UTXO map, so the same UTXO value could be counted twice toward `in_value`, creating a potential inflation vector.

### Changes

- Added `DuplicateInput` to `BlockValidationErrors` with a corresponding `Display` implementation
- Added a `HashSet`-based duplicate prevout check in `check_transaction_context_free()`
- Placed the check after null prevout validation and before output value checks, matching Bitcoin Core’s ordering
- Updated mempool tests to use real cross-transaction conflicts instead of invalid single-transaction duplicate inputs, and changed the expected error from `DuplicatedInputs` to `ConflictingTransaction`
- Added handling for `DuplicateInput` in `floresta-wire` block validation flow
- Replaced witness-size TODO with an explicit comment clarifying that witness size is intentionally excluded from context-free checks, matching Bitcoin Core’s `CheckTransaction()` behavior

### How to verify the changes you have done?

```bash
cargo fmt
cargo test --all
cargo test test_duplicate_inputs_rejected
cargo test test_gbt_with_conflict
