### PR TITLE
feat(wire)!: Add a new `BitcoinSocketAddr` struct to unify address parsing

### DIFF
--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -2,11 +2,8 @@
 
 //! This module holds all RPC server side methods for interacting with our node's network stack.
 
-use core::net::IpAddr;
-use core::net::SocketAddr;
 use std::collections::BTreeMap;
 
-use bitcoin::Network;
 use corepc_types::v26::AddrManInfoNetwork;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
@@ -16,6 +13,8 @@ use floresta_common::advertised_services;
 use floresta_common::service_flags_strings;
 use floresta_wire::address_man::NetworkStats;
 use floresta_wire::address_man::ReachableNetworks;
+use floresta_wire::bitcoin_socket_addr::BitcoinSocketAddr;
+use floresta_wire::bitcoin_socket_addr::SystemResolver;
 use floresta_wire::node_interface::NetworkMethods;
 use floresta_wire::node_interface::PeerInfo;
 use serde_json::Value;
@@ -48,19 +47,6 @@ fn parse_mmmmpp(version: &str) -> usize {
 }
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
-    /// Returns the default P2P port for the current network.
-    // TODO: use `NetworkExt` to append the correct port once
-    // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
-    pub(crate) fn default_network_port(&self) -> u16 {
-        match self.network {
-            Network::Bitcoin => 8333,
-            Network::Signet => 38333,
-            Network::Testnet => 18333,
-            Network::Testnet4 => 48333,
-            Network::Regtest => 18444,
-        }
-    }
-
     pub(crate) async fn ping(&self) -> Result<bool> {
         self.node
             .ping()
@@ -70,26 +56,17 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
     pub(crate) async fn add_node(
         &self,
-        node_address: String,
+        address: String,
         command: String,
         v2transport: bool,
     ) -> Result<Value> {
-        // Try to parse both IP address and port.
-        let (addr, port) = if let Ok(socket_addr) = node_address.parse::<SocketAddr>() {
-            (socket_addr.ip(), socket_addr.port())
-        // Try to parse the IP address only, and append the default P2P port for the network.
-        } else {
-            let ip = node_address
-                .parse::<IpAddr>()
-                .map_err(|_| JsonRpcError::InvalidAddress)?;
-
-            (ip, self.default_network_port())
-        };
+        let address =
+            BitcoinSocketAddr::parse_address(&address, Some(self.network), SystemResolver)?;
 
         let _ = match command.as_str() {
-            "add" => self.node.add_peer(addr, port, v2transport).await,
-            "remove" => self.node.remove_peer(addr, port).await,
-            "onetry" => self.node.onetry_peer(addr, port, v2transport).await,
+            "add" => self.node.add_peer(address, v2transport).await,
+            "remove" => self.node.remove_peer(address).await,
+            "onetry" => self.node.onetry_peer(address, v2transport).await,
             _ => return Err(JsonRpcError::InvalidAddnodeCommand),
         };
 
@@ -101,17 +78,12 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         node_address: String,
         node_id: Option<u32>,
     ) -> Result<Value> {
-        let (peer_addr, peer_port) = match (node_address.is_empty(), node_id) {
+        let peer_addr = match (node_address.is_empty(), node_id) {
             // Reference the peer by it's IP address and port.
             (false, None) => {
-                // Try to parse `node_address` into a `SocketAddr`.
-                // This will handle IPv4:port and IPv6:port.
-                let socket_addr = node_address
-                    .parse::<SocketAddr>()
-                    .map_err(|_| JsonRpcError::InvalidAddress)?;
-
-                (socket_addr.ip(), socket_addr.port())
+                BitcoinSocketAddr::parse_address(&node_address, Some(self.network), SystemResolver)?
             }
+
             // Reference the peer by it's ID.
             (true, Some(node_id)) => {
                 let peer_info = self
@@ -121,12 +93,13 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                     .map_err(|e| JsonRpcError::Node(e.to_string()))?;
 
                 let peer = peer_info
-                    .iter()
+                    .into_iter()
                     .find(|peer| peer.id == node_id)
                     .ok_or(JsonRpcError::PeerNotFound)?;
 
-                (peer.address.ip(), peer.address.port())
+                peer.address
             }
+
             // Both address and ID were provided, or neither was provided.
             _ => {
                 return Err(JsonRpcError::InvalidDisconnectNodeCommand);
@@ -135,7 +108,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
         let disconnected = self
             .node
-            .disconnect_peer(peer_addr, peer_port)
+            .disconnect_peer(peer_addr)
             .await
             .map_err(|e| JsonRpcError::Node(e.to_string()))?;
 

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -44,6 +44,7 @@ pub mod jsonrpc_interface {
     use floresta_common::impl_error_from;
     use floresta_mempool::mempool::MempoolError;
     use floresta_watch_only::WatchOnlyError;
+    use floresta_wire::bitcoin_socket_addr::InvalidAddressError;
     use serde::Deserialize;
     use serde::Serialize;
     use serde_json::Value;
@@ -206,9 +207,6 @@ pub mod jsonrpc_interface {
         /// Failed to decode the request payload.
         Decode(String),
 
-        /// The provided network address is invalid.
-        InvalidAddress,
-
         /// Node-level error (e.g. not connected or unresponsive).
         Node(String),
 
@@ -251,16 +249,19 @@ pub mod jsonrpc_interface {
 
         /// A numeric conversion overflows, e.g., u64 to u32
         ConversionOverflow(String),
+
+        /// The provided net address is invalid
+        InvalidNetAddress(InvalidAddressError),
     }
 
     impl_error_from!(JsonRpcError, MempoolError, MempoolAccept);
+    impl_error_from!(JsonRpcError, InvalidAddressError, InvalidNetAddress);
 
     impl JsonRpcError {
         pub fn http_code(&self) -> StatusCode {
             match self {
                 // 400 Bad Request - client sent invalid data
                 JsonRpcError::InvalidHex
-                | JsonRpcError::InvalidAddress
                 | JsonRpcError::InvalidScript
                 | JsonRpcError::InvalidRequest
                 | JsonRpcError::InvalidDescriptor(_)
@@ -277,6 +278,7 @@ pub mod jsonrpc_interface {
                 | JsonRpcError::InvalidParameterType(_)
                 | JsonRpcError::InvalidParameterStructure(_)
                 | JsonRpcError::MissingParameter(_)
+                | JsonRpcError::InvalidNetAddress(_)
                 | JsonRpcError::Wallet(_) => StatusCode::BAD_REQUEST,
 
                 // 404 Not Found - resource/method doesn't exist
@@ -326,11 +328,6 @@ pub mod jsonrpc_interface {
                 JsonRpcError::InvalidHex => RpcError {
                     code: INVALID_METHOD_PARAMETERS,
                     message: "Invalid hex encoding".into(),
-                    data: None,
-                },
-                JsonRpcError::InvalidAddress => RpcError {
-                    code: INVALID_METHOD_PARAMETERS,
-                    message: "Invalid address".into(),
                     data: None,
                 },
                 JsonRpcError::InvalidScript => RpcError {
@@ -394,6 +391,11 @@ pub mod jsonrpc_interface {
                     code: INVALID_METHOD_PARAMETERS,
                     message: "Missing parameter".into(),
                     data: Some(Value::String(param.clone())),
+                },
+                JsonRpcError::InvalidNetAddress(err) => RpcError {
+                    code: INVALID_METHOD_PARAMETERS,
+                    message: "Invalid network address provided".into(),
+                    data: Some(Value::String(err.to_string())),
                 },
 
                 // Internal error

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography::cryptocurrencies", "network-programming"]
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bip324 = { version = "=0.10.0", features = [ "tokio" ] }
-bitcoin = { workspace = true }
+bitcoin = { workspace = true, features = ["serde"] }
 dns-lookup = { workspace = true }
 rand = { workspace = true }
 rustls = { version = "=0.23.40", default-features = false, features = ["ring", "std", "tls12"] }

--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -26,6 +26,7 @@ mod p2p_wire;
 pub use p2p_wire::UtreexoNodeConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::address_man;
+pub use p2p_wire::bitcoin_socket_addr;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::block_proof;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -32,6 +32,9 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+use crate::bitcoin_socket_addr::InvalidAddressError;
+
 /// How long we'll wait before trying to connect to a peer that failed
 const RETRY_TIME: u64 = 10 * 60; // 10 minutes
 
@@ -139,21 +142,34 @@ pub struct ConnectionStats {
 /// How do we store peers locally
 pub struct LocalAddress {
     /// An actual address
-    address: AddrV2,
+    address: BitcoinSocketAddr,
+
     /// Last time we successfully connected to this peer, only relevant is state == State::Tried
     last_connected: u64,
+
     /// Our local state for this peer, as defined in AddressState
     state: AddressState,
+
     /// Network services announced by this peer
     services: ServiceFlags,
-    /// Network port this peers listens to
-    port: u16,
+
     /// Random id for this peer
     pub id: usize,
 }
 
-impl From<AddrV2> for LocalAddress {
-    fn from(value: AddrV2) -> Self {
+impl Display for LocalAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let addr: String = self
+            .get_net_address()
+            .map(|ip| ip.to_string())
+            .unwrap_or(String::from("unknown"));
+
+        write!(f, "{}:{}", addr, self.address.get_port())
+    }
+}
+
+impl From<BitcoinSocketAddr> for LocalAddress {
+    fn from(value: BitcoinSocketAddr) -> Self {
         LocalAddress {
             address: value,
             last_connected: SystemTime::now()
@@ -162,7 +178,8 @@ impl From<AddrV2> for LocalAddress {
                 .as_secs(),
             state: AddressState::NeverTried,
             services: ServiceFlags::NONE,
-            port: 8333,
+
+            // TODO(Davidson): Refactor `id` to be a `u64`?
             id: rand::random::<u64>() as usize,
         }
     }
@@ -170,58 +187,44 @@ impl From<AddrV2> for LocalAddress {
 
 impl From<AddrV2Message> for LocalAddress {
     fn from(value: AddrV2Message) -> Self {
+        let socket_addr = BitcoinSocketAddr::new(value.addr, value.port);
         LocalAddress {
-            address: value.addr,
+            address: socket_addr,
             last_connected: value.time.into(),
             state: AddressState::NeverTried,
             services: value.services,
-            port: value.port,
+            // TODO(Davidson): Refactor `id` to be a `u64`?
             id: rand::random::<u64>() as usize,
         }
     }
 }
 
 impl FromStr for LocalAddress {
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        LocalAddress::try_from(s)
-    }
-    type Err = core::net::AddrParseError;
-}
-
-// Note that, since we can't know the network we are operating in, this code
-// can't know what's the default port. Therefore, it will only work if you give
-// a SocketAddr, i.e. <IP:PORT>
-impl TryFrom<&str> for LocalAddress {
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let address = value.parse::<SocketAddr>()?;
-        let ip = match address {
-            SocketAddr::V4(ipv4) => AddrV2::Ipv4(*ipv4.ip()),
-            SocketAddr::V6(ipv6) => AddrV2::Ipv6(*ipv6.ip()),
-        };
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let address = value.parse::<BitcoinSocketAddr>()?;
 
         Ok(LocalAddress::new(
-            ip,
+            address,
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
             super::address_man::AddressState::NeverTried,
             ServiceFlags::NONE,
-            address.port(),
+            // TODO(Davidson): Refactor `id` to be a `u64`?
             rand::random::<u64>() as usize,
         ))
     }
 
-    type Error = core::net::AddrParseError;
+    type Err = InvalidAddressError;
 }
 
 impl LocalAddress {
     pub fn new(
-        address: AddrV2,
+        address: BitcoinSocketAddr,
         last_connected: u64,
         state: AddressState,
         services: ServiceFlags,
-        port: u16,
         id: usize,
     ) -> LocalAddress {
         LocalAddress {
@@ -229,32 +232,23 @@ impl LocalAddress {
             last_connected,
             state,
             services,
-            port,
             id,
         }
     }
 
-    /// Get the [`AddrV2`] for this [`LocalAddress`].
-    pub fn get_addrv2(&self) -> AddrV2 {
-        self.address.clone()
-    }
-
     /// Get the [`SocketAddr`] for this [`LocalAddress`].
-    pub fn get_socket_address(&self) -> SocketAddr {
-        let ip = self.get_net_address();
-        let port = self.get_port();
-
-        SocketAddr::new(ip, port)
+    pub fn as_bitcoin_socket_addr(&self) -> &BitcoinSocketAddr {
+        &self.address
     }
 
     /// Get the `port` for this [`LocalAddress`].
     pub fn get_port(&self) -> u16 {
-        self.port
+        self.address.get_port()
     }
 
     /// Set the `port` for this [`LocalAddress`].
     pub fn set_port(&mut self, port: u16) {
-        self.port = port;
+        self.address.set_port(port);
     }
 
     /// Get the [`ServiceFlags`] for this [`LocalAddress`].
@@ -267,15 +261,45 @@ impl LocalAddress {
         self.services = services;
     }
 
-    /// Get the [`IpAddr`] for with this [`LocalAddress`].
-    pub fn get_net_address(&self) -> IpAddr {
-        match self.address {
+    pub fn get_socket_addr(&self) -> Option<SocketAddr> {
+        let ip = match self.as_addrv2() {
+            AddrV2::Ipv6(ipv6) => IpAddr::V6(*ipv6),
+            AddrV2::Ipv4(ipv4) => IpAddr::V4(*ipv4),
+
+            _ => return None,
+        };
+
+        let port = self.get_port();
+        Some(SocketAddr::new(ip, port))
+    }
+
+    /// Return an IP address associated with this peer address, if any
+    ///
+    /// Note: For domain-based addresses such as Tor and I2P this function will return [`None`]
+    pub const fn get_net_address(&self) -> Option<IpAddr> {
+        match *self.address.as_addrv2() {
             // IPV4
-            AddrV2::Ipv4(ipv4) => IpAddr::V4(ipv4),
+            AddrV2::Ipv4(ipv4) => Some(IpAddr::V4(ipv4)),
+
             // IPV6
-            AddrV2::Ipv6(ipv6) => IpAddr::V6(ipv6),
-            _ => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            AddrV2::Ipv6(ipv6) => Some(IpAddr::V6(ipv6)),
+
+            // CJDNS
+            AddrV2::Cjdns(cjdns) => Some(IpAddr::V6(cjdns)),
+
+            // Others - These are domain-based, and can't be encoded as an IP address
+            _ => None,
         }
+    }
+
+    /// Returns a reference to the inner [`BitcoinSocketAddr`].
+    pub fn as_addrv2(&self) -> &AddrV2 {
+        self.address.as_addrv2()
+    }
+
+    /// Converts this [`LocalAddress`] into an [`AddrV2`]
+    pub fn into_addrv2(self) -> AddrV2 {
+        self.address.into_addrv2()
     }
 
     /// Return whether the address can be reached from our node
@@ -284,9 +308,9 @@ impl LocalAddress {
     /// those includes documentation, reserved and private ones ranges.
     /// Since we can't connect with them, there's no point into keeping them
     const fn is_routable(&self) -> bool {
-        match self.address {
-            AddrV2::Ipv4(ipv4) => Self::is_routable_ipv4(&ipv4),
-            AddrV2::Ipv6(ipv6) => Self::is_routable_ipv6(&ipv6),
+        match self.address.as_addrv2() {
+            AddrV2::Ipv4(ipv4) => Self::is_routable_ipv4(ipv4),
+            AddrV2::Ipv6(ipv6) => Self::is_routable_ipv6(ipv6),
             AddrV2::Cjdns(address) => {
                 let octets = address.octets();
                 // CJDNS addresses use a special range for local addresses (FC00::/8)
@@ -482,7 +506,7 @@ impl AddressMan {
 
     /// Check if we can reach this address based on our reachable networks
     fn is_net_reachable(&self, address: &LocalAddress) -> bool {
-        match address.address {
+        match address.address.as_addrv2() {
             AddrV2::Ipv4(_) => self.reachable_networks.contains(&ReachableNetworks::IPv4),
             AddrV2::Ipv6(_) => self.reachable_networks.contains(&ReachableNetworks::IPv6),
             AddrV2::TorV3(_) => self.reachable_networks.contains(&ReachableNetworks::TorV3),
@@ -538,7 +562,7 @@ impl AddressMan {
         let mut stats = ConnectionStats::default();
 
         for addr in self.addresses.values() {
-            let bucket = match &addr.address {
+            let bucket = match &addr.address.as_addrv2() {
                 AddrV2::Ipv4(_) => &mut stats.ipv4,
                 AddrV2::Ipv6(_) => &mut stats.ipv6,
                 AddrV2::TorV3(_) => &mut stats.onion,
@@ -603,10 +627,10 @@ impl AddressMan {
             .filter_map(|id| {
                 let address = self.addresses.get(id)?;
                 Some((
-                    address.address.clone(),
+                    address.address.as_addrv2().clone(),
                     address.last_connected,
                     address.services,
-                    address.port,
+                    address.get_port(),
                 ))
             })
             .collect()
@@ -640,7 +664,7 @@ impl AddressMan {
 
         let mut addresses = Vec::new();
         for ip in ips {
-            if let Ok(ip) = LocalAddress::try_from(format!("{ip}:{default_port}").as_str()) {
+            if let Ok(ip) = format!("{ip}:{default_port}").parse::<LocalAddress>() {
                 addresses.push(ip);
             }
         }
@@ -1118,7 +1142,7 @@ pub struct DiskLocalAddress {
 
 impl From<LocalAddress> for DiskLocalAddress {
     fn from(value: LocalAddress) -> Self {
-        let address = match value.address {
+        let address = match *value.address.as_addrv2() {
             AddrV2::Ipv4(ip) => Address::V4(ip),
             AddrV2::Ipv6(ip) => Address::V6(ip),
             AddrV2::Cjdns(ip) => Address::Cjdns(ip),
@@ -1142,11 +1166,12 @@ impl From<LocalAddress> for DiskLocalAddress {
                 value.state
             },
             services: value.services.to_u64(),
-            port: value.port,
+            port: value.get_port(),
             id: Some(value.id),
         }
     }
 }
+
 impl From<DiskLocalAddress> for LocalAddress {
     fn from(value: DiskLocalAddress) -> Self {
         let address = match value.address {
@@ -1158,12 +1183,13 @@ impl From<DiskLocalAddress> for LocalAddress {
             Address::OnionV3(ip) => AddrV2::TorV3(ip),
         };
         let services = ServiceFlags::from(value.services);
+        let sock_addr = BitcoinSocketAddr::new(address, value.port);
+
         LocalAddress {
-            address,
+            address: sock_addr,
             last_connected: value.last_connected,
             state: value.state,
             services,
-            port: value.port,
             id: value
                 .id
                 .unwrap_or_else(|| rand::rng().random_range(0..usize::MAX)),
@@ -1174,15 +1200,20 @@ impl From<DiskLocalAddress> for LocalAddress {
 pub enum Address {
     /// Regular ipv4 address
     V4(Ipv4Addr),
+
     /// Regular ipv6 address
     V6(Ipv6Addr),
+
     /// Tor v2 address, this may never be used, as OnionV2 is deprecated
     /// but we'll keep it here for completeness sake
     OnionV2([u8; 10]),
+
     /// Tor v3 address. This is the preferred way to connect to a tor node
     OnionV3([u8; 32]),
+
     /// Cjdns ipv6 address
     Cjdns(Ipv6Addr),
+
     /// I2p address, a 32 byte node key
     I2p([u8; 32]),
 }
@@ -1309,6 +1340,7 @@ mod test {
     use crate::address_man::AddressMan;
     use crate::address_man::DiskLocalAddress;
     use crate::address_man::ReachableNetworks;
+    use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 
     fn load_addresses_from_json(file_path: impl AsRef<Path>) -> io::Result<Vec<LocalAddress>> {
         let mut contents = String::new();
@@ -1326,11 +1358,10 @@ mod test {
             };
 
             let local_address = LocalAddress {
-                address: seed.address.into(),
+                address: BitcoinSocketAddr::new(seed.address.into(), seed.port),
                 last_connected: seed.last_connected,
                 state,
                 services: ServiceFlags::from(seed.services),
-                port: seed.port,
                 id: rng.random::<u64>() as usize,
             };
             addresses.push(local_address);
@@ -1355,14 +1386,16 @@ mod test {
         ];
 
         for addr_str in ips {
-            let local_address = LocalAddress::try_from(format!("{addr_str}:8333").as_str())
+            let local_address = format!("{addr_str}:8333")
+                .parse::<LocalAddress>()
                 .unwrap_or_else(|_| panic!("failed to parse {addr_str}"));
 
             assert_eq!(
-                local_address.address,
+                *local_address.address.as_addrv2(),
                 AddrV2::Ipv4(addr_str.parse().unwrap())
             );
-            assert_eq!(local_address.port, 8333);
+
+            assert_eq!(local_address.get_port(), 8333);
         }
 
         // v6
@@ -1380,14 +1413,16 @@ mod test {
         ];
 
         for addr_str in ips {
-            let local_address = LocalAddress::try_from(format!("[{addr_str}]:8333").as_str())
+            let local_address = format!("[{addr_str}]:8333")
+                .parse::<LocalAddress>()
                 .unwrap_or_else(|_| panic!("failed to parse {addr_str}"));
 
             assert_eq!(
-                local_address.address,
+                *local_address.address.as_addrv2(),
                 AddrV2::Ipv6(addr_str.parse().unwrap())
             );
-            assert_eq!(local_address.port, 8333);
+
+            assert_eq!(local_address.get_port(), 8333);
         }
     }
 
@@ -1515,7 +1550,8 @@ mod test {
         ]
         .into_iter()
         .map(|s| {
-            LocalAddress::try_from(s).unwrap_or_else(|_| panic!("Failed to parse address: {s}"))
+            s.parse::<LocalAddress>()
+                .unwrap_or_else(|_| panic!("Failed to parse address: {s}"))
         })
         .collect::<Vec<_>>();
 
@@ -1596,38 +1632,34 @@ mod test {
             AddressMan::new(None, &[ReachableNetworks::IPv4, ReachableNetworks::IPv6]);
 
         assert!(address_man.is_net_reachable(&LocalAddress {
-            address: addr_v4,
+            address: BitcoinSocketAddr::new(addr_v4, 8333),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::default(),
-            port: 8333,
             id: 0,
         }));
 
         assert!(address_man.is_net_reachable(&LocalAddress {
-            address: addr_v6,
+            address: BitcoinSocketAddr::new(addr_v6, 8333),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::default(),
-            port: 8333,
             id: 0,
         }));
 
         assert!(!address_man.is_net_reachable(&LocalAddress {
-            address: addr_onionv3,
+            address: BitcoinSocketAddr::new(addr_onionv3, 8333),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::default(),
-            port: 8333,
             id: 0,
         }));
 
         assert!(!address_man.is_net_reachable(&LocalAddress {
-            address: addr_i2p,
+            address: BitcoinSocketAddr::new(addr_i2p, 8333),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::default(),
-            port: 8333,
             id: 0,
         }));
     }
@@ -1636,60 +1668,57 @@ mod test {
     fn test_push_address() {
         let mut address_man = AddressMan::new(None, &[ReachableNetworks::IPv4]);
         let v4_no_witness = LocalAddress {
-            address: AddrV2::Ipv4("12.146.182.45".parse().unwrap()),
+            address: "12.146.182.45:8333".parse().unwrap(),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::NETWORK | ServiceFlags::NETWORK_LIMITED,
-            port: 8333,
             id: 0,
         };
 
         let v4_with_witness = LocalAddress {
-            address: AddrV2::Ipv4("12.146.182.45".parse().unwrap()),
+            address: "12.146.182.45:8333".parse().unwrap(),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::NETWORK | ServiceFlags::NETWORK_LIMITED | ServiceFlags::WITNESS,
-            port: 8333,
             id: 1,
         };
 
         let v6_with_witness = LocalAddress {
-            address: AddrV2::Ipv6("fd3a:9f2b:4c10:1a2b::1".parse().unwrap()),
+            address: "[fd3a:9f2b:4c10:1a2b::1]:8333".parse().unwrap(),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::NETWORK_LIMITED | ServiceFlags::NETWORK | ServiceFlags::WITNESS,
-            port: 8333,
             id: 2,
         };
 
         let v4_not_routable = LocalAddress {
-            address: AddrV2::Ipv4("127.0.0.1".parse().unwrap()),
+            address: "127.0.0.1:8333".parse().unwrap(),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::NETWORK_LIMITED | ServiceFlags::NETWORK | ServiceFlags::WITNESS,
-            port: 8333,
             id: 3,
         };
 
         let v6_not_routable = LocalAddress {
-            address: AddrV2::Ipv6("::1".parse().unwrap()),
+            address: "[::1]:8333".parse().unwrap(),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::NETWORK_LIMITED | ServiceFlags::NETWORK | ServiceFlags::WITNESS,
-            port: 8333,
             id: 4,
         };
 
         let onion = LocalAddress {
-            address: AddrV2::TorV3([
-                0x89, 0x6c, 0x6a, 0x71, 0x70, 0x6b, 0x67, 0x61, 0x62, 0x67, 0x34, 0x68, 0x72, 0x63,
-                0x68, 0x62, 0x6f, 0x7a, 0x77, 0x6f, 0x76, 0x66, 0x66, 0x79, 0x6b, 0x37, 0x66, 0x6f,
-                0x62, 0x70, 0x6f, 0x76,
-            ]),
+            address: BitcoinSocketAddr::new(
+                AddrV2::TorV3([
+                    0x89, 0x6c, 0x6a, 0x71, 0x70, 0x6b, 0x67, 0x61, 0x62, 0x67, 0x34, 0x68, 0x72,
+                    0x63, 0x68, 0x62, 0x6f, 0x7a, 0x77, 0x6f, 0x76, 0x66, 0x66, 0x79, 0x6b, 0x37,
+                    0x66, 0x6f, 0x62, 0x70, 0x6f, 0x76,
+                ]),
+                8333,
+            ),
             last_connected: 0,
             state: AddressState::NeverTried,
             services: ServiceFlags::NETWORK_LIMITED | ServiceFlags::NETWORK | ServiceFlags::WITNESS,
-            port: 8333,
             id: 5,
         };
 

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -426,3 +426,113 @@ impl From<BitcoinSocketAddr> for AddrV2 {
         value.into_addrv2()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+
+    use bitcoin::Network;
+
+    use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+    use crate::bitcoin_socket_addr::DnsResolver;
+
+    pub struct TestResolver;
+
+    impl DnsResolver for TestResolver {
+        type Error = io::Error;
+
+        fn resolve(&self, name: &str) -> Result<Vec<IpAddr>, Self::Error> {
+            // don't resolve the bad cases below
+            let bad_cases = ["321.321.321.321", "example"];
+            if bad_cases.contains(&name) {
+                return Ok(vec![]);
+            }
+
+            Ok(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+        }
+    }
+
+    fn check_address_resolving(address: &str, should_succeed: bool, description: &str) {
+        let result =
+            BitcoinSocketAddr::parse_address(address, Some(Network::Bitcoin), TestResolver);
+        if should_succeed {
+            assert!(result.is_ok(), "Failed: {description}");
+        } else {
+            assert!(result.is_err(), "Unexpected success: {description}");
+        }
+    }
+
+    #[test]
+    fn test_parse_address() {
+        // IPv6 Tests
+        check_address_resolving("[::1]", true, "Valid IPv6 without port");
+        check_address_resolving("[::1", false, "Invalid IPv6 format");
+        check_address_resolving("[::1]:8333", true, "Valid IPv6 with port");
+        check_address_resolving("[::1]:8333:8333", false, "Invalid IPv6 with multiple ports");
+
+        // IPv4 Tests
+        check_address_resolving("127.0.0.1", true, "Valid IPv4 without port");
+        check_address_resolving("321.321.321.321", false, "Invalid IPv4 format");
+        check_address_resolving("127.0.0.1:8333", true, "Valid IPv4 with port");
+        check_address_resolving(
+            "127.0.0.1:8333:8333",
+            false,
+            "Invalid IPv4 with multiple ports",
+        );
+
+        // Hostname Tests
+        check_address_resolving("example.com", true, "Valid hostname without port");
+        check_address_resolving("example", false, "Invalid hostname");
+        check_address_resolving("example.com:8333", true, "Valid hostname with port");
+        check_address_resolving(
+            "example.com:8333:8333",
+            false,
+            "Invalid hostname with multiple ports",
+        );
+
+        // Edge Cases
+        // This could fail on windows but doesn't since inside `resolve_connect_host` we specify empty addresses as localhost for all OS`s.
+        check_address_resolving("", true, "Empty string address");
+        check_address_resolving(
+            " 127.0.0.1:8333 ",
+            false,
+            "Address with leading/trailing spaces",
+        );
+        check_address_resolving("127.0.0.1:0", true, "Valid address with port 0");
+        check_address_resolving("127.0.0.1:65535", true, "Valid address with maximum port");
+        check_address_resolving(
+            "127.0.0.1:65536",
+            false,
+            "Valid address with out-of-range port",
+        );
+
+        // Cjdns tests, addresses taken from: https://github.com/cjdelisle/cjdns/blob/master/doc/network-services.md
+        check_address_resolving(
+            "[fcf7:75f0:82e3:327c:7112:b9ab:d1f9:bbbe]:0",
+            true,
+            "Valid address with port 0",
+        );
+        check_address_resolving(
+            "[fcf7:75f0:82e3:327c:7112:b9ab:d1f9:bbbe]",
+            true,
+            "Valid address without a port",
+        );
+        check_address_resolving(
+            "[fcde:c974:bde5:a226:b8a9:bd8:3e8:7df5]:0",
+            true,
+            "Valid address with port 0",
+        );
+        check_address_resolving(
+            "[fcde:c974a226:b8a9:bd8:3e8:7df5:0",
+            false,
+            "Invalid address with port 0",
+        );
+        check_address_resolving(
+            "[fcde:c9[74a226:b8a9:bd8:3e8:7df5:0",
+            false,
+            "Invalid address with port 0",
+        );
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -23,11 +23,11 @@ use std::io;
 use std::net::IpAddr;
 use std::str::FromStr;
 
+use bitcoin::Network;
 use bitcoin::hex::DisplayHex;
 use bitcoin::p2p::address::AddrV2;
-use bitcoin::Network;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::rng;
+use rand::seq::IndexedRandom;
 
 #[derive(Debug)]
 /// An error returned when trying to parse an address
@@ -45,7 +45,7 @@ pub enum InvalidAddressError {
     InvalidDNSName,
 
     /// The resolver returned no addresses
-    NoAssociatedName,
+    NoAssociatedAddress,
 
     /// No port were provided
     MissingPort,
@@ -339,9 +339,10 @@ impl BitcoinSocketAddr {
             .resolve(address)
             .map_err(|_e| InvalidAddressError::InvalidDNSName)?;
 
+        let mut rng = rng();
         let selected_addr = addresses
-            .choose(&mut thread_rng())
-            .ok_or(InvalidAddressError::NoAssociatedName)?;
+            .choose(&mut rng)
+            .ok_or(InvalidAddressError::NoAssociatedAddress)?;
 
         let address = match selected_addr {
             IpAddr::V4(v4) => AddrV2::Ipv4(*v4),

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A port of [`SocketAddr`](std::net::SocketAddr) that also supports non-ip based addresses, such as Onion and I2P.
+//!
+//! Inside floresta-wire, we rely heavily on passing addresses around, including several API-facing
+//! methods. Each address might be one of several different types, such as IP address, I2P, Onion
+//! or a domain that must be resolved. [`AddrV2`] wraps most of those — with the exception of
+//! Domain. However, we still need a port to connect with those addresses, and [`AddrV2`] is only
+//! the address part. To avoid passing ports as arguments every time, and remove duplicate address
+//! parsing logic, we have this [`BitcoinSocketAddr`] struct.
+//!
+//! It contains an inner [`AddrV2`] address and a [`u16`] port, a parsing logic for all supported
+//! addresses, including optional DNS resolving.
+//!
+//! The DNS part is handled by an implementation of the [`DnsResolver`] trait, by default we use
+//! the [`SystemResolver`] implementation, that uses the OS resolver. If you prefer, you can bring
+//! your own resolver.
+use core::error;
+use core::net::Ipv4Addr;
+use core::net::Ipv6Addr;
+use std::fmt::Display;
+use std::io;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use bitcoin::hex::DisplayHex;
+use bitcoin::p2p::address::AddrV2;
+use bitcoin::Network;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+#[derive(Debug)]
+/// An error returned when trying to parse an address
+pub enum InvalidAddressError {
+    /// The provided port is invalid
+    InvalidPort,
+
+    /// The provided address is invalid
+    InvalidAddress,
+
+    /// We've found an extra colon character after the address string
+    TrailingColon,
+
+    /// The provided hostname is either malformed or can't be resolved
+    InvalidDNSName,
+
+    /// The resolver returned no addresses
+    NoAssociatedName,
+
+    /// No port were provided
+    MissingPort,
+}
+
+impl Display for InvalidAddressError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidAddressError::MissingPort => {
+                write!(f, "No port were provided when one was needed")
+            }
+            InvalidAddressError::NoAssociatedAddress => write!(
+                f,
+                "No associated address could be found when fetching this name"
+            ),
+            InvalidAddressError::InvalidPort => write!(f, "The provided port is invalid"),
+            InvalidAddressError::TrailingColon => write!(
+                f,
+                "The provided address contains a trailing colon where it's not allowed"
+            ),
+            InvalidAddressError::InvalidDNSName => write!(f, "An invalid DNS name was provided"),
+            InvalidAddressError::InvalidAddress => write!(f, "The provided address is invalid"),
+        }
+    }
+}
+
+impl error::Error for InvalidAddressError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// A port of [`std::net::SocketAddr`] that supports all networks that we support.
+///
+/// It keeps an address and port, where the address can be anything that we can create a connection
+/// with another Bitcoin node, such as IP, I2P and onion.
+///
+/// It comes with a comprehensive parsing logic that can be used to parse addresses and use them
+/// internally and in interfaces.
+pub struct BitcoinSocketAddr {
+    /// The actual address.
+    address: AddrV2,
+
+    /// The port this address is listening to.
+    port: u16,
+}
+
+/// A resolver that will be used by [`BitcoinSocketAddr`] to resolve hostnames.
+pub trait DnsResolver {
+    /// The error type returned by this resolver
+    type Error: error::Error;
+
+    /// The main method for this trait. It resolves a hostname and returns a list of associated
+    /// addresses.
+    fn resolve(&self, name: &str) -> Result<Vec<IpAddr>, Self::Error>;
+}
+
+/// A simple resolver that uses the default OS resolver as implementation.
+pub struct SystemResolver;
+
+impl DnsResolver for SystemResolver {
+    type Error = io::Error;
+
+    fn resolve(&self, name: &str) -> Result<Vec<IpAddr>, Self::Error> {
+        dns_lookup::lookup_host(name)
+    }
+}
+
+impl BitcoinSocketAddr {
+    /// Returns that network's default port, if present
+    ///
+    /// Note: it takes an option because it makes the logic inside `parse_port_if_present` easier
+    fn get_default_port(network: Network) -> u16 {
+        match network {
+            Network::Signet => 38333,
+            Network::Bitcoin => 8333,
+            Network::Testnet => 18333,
+            Network::Regtest => 18444,
+            Network::Testnet4 => 48333,
+        }
+    }
+
+    /// Tries to parse a port, returns an error if nothing can be found.
+    ///
+    /// This will parsing a port in two ways:
+    ///  - Looking for the port field inside the URL, i.e.: `<host>:<port>`
+    ///  - Using the default port for a network
+    ///
+    ///  If neither are provided, this function returns an error. `network` is an [`Option`]
+    ///  because some trait implementations such as [`FromStr`] won't allow us to pass a network
+    ///  in, and we can't just hard-code mainnet. So you can still use those, but you are forced to
+    ///  always explicitly provide a port through the URL.
+    fn parse_port_if_present(
+        port_str: Option<&str>,
+        network: Option<Network>,
+    ) -> Result<u16, InvalidAddressError> {
+        port_str
+            .map(str::parse)
+            .transpose()
+            .map_err(|_| InvalidAddressError::InvalidPort)?
+            .or_else(|| network.map(Self::get_default_port))
+            .ok_or(InvalidAddressError::MissingPort)
+    }
+
+    /// Returns a reference to this node's address.
+    pub const fn as_addrv2(&self) -> &AddrV2 {
+        &self.address
+    }
+
+    /// Converts this [`BitcoinSocketAddr`] into an [`AddrV2`].
+    pub fn into_addrv2(self) -> AddrV2 {
+        self.address
+    }
+
+    /// Return the port for this address
+    pub fn get_port(&self) -> u16 {
+        self.port
+    }
+
+    /// Changes the port for this address
+    pub fn set_port(&mut self, port: u16) {
+        self.port = port;
+    }
+
+    /// Sets this node's address
+    pub fn set_address(&mut self, address: AddrV2) {
+        self.address = address;
+    }
+
+    /// Creates a new [`BitcoinSocketAddr`] giving an [`AddrV2`] and port.
+    pub fn new(address: AddrV2, port: u16) -> Self {
+        Self { address, port }
+    }
+
+    /// Creates a new [`BitcoinSocketAddr`] from an [`IpAddr`] and [`Network`].
+    pub fn from_ip_addr(address: IpAddr, network: Network) -> Self {
+        let address = match address {
+            IpAddr::V4(ipv4) => AddrV2::Ipv4(ipv4),
+            IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
+        };
+
+        let port = Self::get_default_port(network);
+
+        BitcoinSocketAddr { address, port }
+    }
+
+    #[inline]
+    /// DNS names may only use alphanumeric symbols and dots to represent subdomains.
+    /// Anything other than `<name1>...<nameN>.<tld>` or single names such as `localhost`
+    /// is forbidden.
+    fn check_dns_name(name: &str) -> bool {
+        /// Non-alphanumeric chars allowed in a domain name.
+        const SPECIAL_CHARS: [char; 3] = ['.', '-', '_'];
+
+        name.chars()
+            .all(|c| c.is_ascii_alphanumeric() || SPECIAL_CHARS.contains(&c))
+    }
+
+    #[inline]
+    /// Makes sure our address has exactly one `[` and one  `]`, and all the other chars are either
+    /// hexadecimal or `:`.
+    ///
+    /// We don't validate the actual address, because [`Ipv6Addr`]'s parsing already does that.
+    fn check_ipv6_chars(ip: &str) -> bool {
+        let brackets_count = ip.chars().filter(|&c| c == '[' || c == ']').count();
+        if !ip.contains("]") || brackets_count != 2 {
+            return false;
+        }
+
+        ip.chars()
+            .all(|c| c.is_ascii_hexdigit() || c == ':' || c == '[' || c == ']' || c == '.')
+    }
+
+    /// Parses an IPv6 address and build a [`BitcoinSocketAddr`] from it.
+    ///
+    /// The goal here is to avoid using regex or anything more complex. A lot of the heavy-lifting
+    /// is done by [`Ipv6Addr`], but it doesn't support ports, only addresses. We also require the
+    /// square brackets for both compatibility with other Bitcoin software that requires it, and
+    /// also because parsing ports is easier if we can search for a `]:` pattern — we don't need to
+    /// actually parse the IP address to find it.
+    ///
+    /// On our side, we just make sure the address follows the form `s/\[([A-Z] | [a - z] | (0 -
+    /// 9) | \:]+\](:)?([0-9]+)?". The actual parse is handled by Rust's standard library.
+    ///
+    /// This function also handles Cjdns addresses, since they are basically Ipv6 addresses that
+    /// are reserved by the Ipv6 standard.
+    fn parse_v6(address: &str, network: Option<Network>) -> Result<Self, InvalidAddressError> {
+        // make sure the address doesn't have any invalid chars
+        if !Self::check_ipv6_chars(address) {
+            return Err(InvalidAddressError::InvalidAddress);
+        }
+
+        // Tries to extract a port by splitting at ']:'. If no port were given, this will simply
+        // return back the whole address, and the default port will be used if `network` is Some.
+        let mut split = address.split_inclusive("]");
+        let address = split
+            .next()
+            .and_then(|address| {
+                // Denies anything after the `]`
+                let pos = address.find("]")?;
+                if (pos + 1) != address.len() {
+                    return None;
+                }
+
+                // remove the `[` and `]`
+                let address = address.replace("[", "");
+                let address = address.replace("]", "");
+
+                address.parse::<Ipv6Addr>().ok()
+            })
+            .ok_or(InvalidAddressError::InvalidAddress)?;
+
+        // Remove the colon if present
+        let port = split.next().map(|port| port.replace(":", ""));
+        let port = Self::parse_port_if_present(port.as_deref(), network)?;
+
+        // Shouldn't have something like <ip>:<port>]<something>
+        if split.next().is_some() {
+            return Err(InvalidAddressError::TrailingColon);
+        }
+
+        // CJDNS addresses use a special range for local addresses (FC00::/8)
+        // See: https://github.com/cjdelisle/cjdns/tree/master/doc#what-is-notable-about-cjdns-why-should-i-use-it
+        let octets = address.octets();
+        if octets[0] == 0xFC {
+            return Ok(Self {
+                address: AddrV2::Cjdns(address),
+                port,
+            });
+        }
+
+        // Regular IPv6 otherwise
+        Ok(Self {
+            address: AddrV2::Ipv6(address),
+            port,
+        })
+    }
+
+    /// Parses an Ipv4 and returns the corresponding [`BitcoinSocketAddr`].
+    ///
+    /// This function expects something like 255.255.255.255<:65535>. It will use [`Ipv4Addr`] for
+    /// the actual parsing. We don't allow anything after the port. All digits must either be a
+    /// period, a colon or a number. Everything else is denied.
+    fn parse_v4(address: &str, network: Option<Network>) -> Result<Self, InvalidAddressError> {
+        let mut split = address.split(":");
+        let address = split.next().ok_or(InvalidAddressError::InvalidAddress)?;
+
+        if let Ok(address) = address.parse::<Ipv4Addr>() {
+            let port = Self::parse_port_if_present(split.next(), network)?;
+
+            // Shouldn't have something like <ip>:<port>:<something>
+            if split.next().is_some() {
+                return Err(InvalidAddressError::TrailingColon);
+            }
+
+            return Ok(Self {
+                address: AddrV2::Ipv4(address),
+                port,
+            });
+        }
+
+        Err(InvalidAddressError::InvalidDNSName)
+    }
+
+    /// Parses and resolves a DNS address into a [`BitcoinSocketAddr`].
+    ///
+    /// This function uses the [`DnsResolver`] to lookup an address, and resolves it into the
+    /// appropriated IP address. If multiple names are returned, a random one will be selected. If no
+    /// names are returned, we return an error.
+    ///
+    /// Names MAY contain subnames, but they SHOULD NOT have non-alphanumeric characters. An MUST have AT
+    /// MOST one colon characters. URL schemes are not allowed.
+    fn parse_and_resolve_dns(
+        address: &str,
+        network: Option<Network>,
+        resolver: impl DnsResolver,
+    ) -> Result<Self, InvalidAddressError> {
+        let mut split = address.split(":");
+        let address = split.next().ok_or(InvalidAddressError::InvalidAddress)?;
+        let port = split.next();
+
+        // Shouldn't have something like <host>:<port>:<something>
+        if split.next().is_some() {
+            return Err(InvalidAddressError::TrailingColon);
+        }
+
+        let port = Self::parse_port_if_present(port, network)?;
+
+        if !Self::check_dns_name(address) {
+            return Err(InvalidAddressError::InvalidDNSName);
+        }
+
+        let addresses = resolver
+            .resolve(address)
+            .map_err(|_e| InvalidAddressError::InvalidDNSName)?;
+
+        let selected_addr = addresses
+            .choose(&mut thread_rng())
+            .ok_or(InvalidAddressError::NoAssociatedName)?;
+
+        let address = match selected_addr {
+            IpAddr::V4(v4) => AddrV2::Ipv4(*v4),
+            IpAddr::V6(v6) => AddrV2::Ipv6(*v6),
+        };
+
+        Ok(Self { address, port })
+    }
+
+    /// Parses and address from a [`str`] into a new [`BitcoinSocketAddr`].
+    ///
+    /// This method implements a very robust parser that can detect and parse any supported address
+    /// scheme, including hostnames. You can use it to parse any string that should be treated as a
+    /// Bitcoin node address.
+    ///
+    /// If you wish to parse hostnames, you should provide a [`DnsResolver`], such as
+    /// [`SystemResolver`]. Then you can give an string like `www.example.com:8333` and this will
+    /// be resolved into the appropriated IP address. If you don't want any resolver, you might
+    /// just implement a no-op, but note that if it always returns an empty list of addresses,
+    /// this method will always error out.
+    ///
+    /// The network parameter is used in case the string doesn't have a port, so we will use that
+    /// network's default port. It will only be used iff the address doesn't already contain a
+    /// port.
+    pub fn parse_address(
+        address: &str,
+        network: Option<Network>,
+        resolver: impl DnsResolver,
+    ) -> Result<Self, InvalidAddressError> {
+        if address.starts_with("[") {
+            // IpV6 is very distinct because it starts with a '[' character.
+            //
+            // Here we try to build one, return an error if we can't
+            return Self::parse_v6(address, network);
+        }
+
+        // This is an edge-case for some OS-specific behavior. Unix-systems define an empty host
+        // as localhost, but windows doesn't. This forces empty strings to be localhost
+        // independently for OS resolver.
+        if address.is_empty() {
+            let port = Self::parse_port_if_present(None, network)?;
+            return Ok(Self {
+                address: AddrV2::Ipv4(Ipv4Addr::LOCALHOST),
+                port,
+            });
+        }
+
+        // Try either V4 or DNS. It's a bit harder to distinguish between the two, so we try V4
+        // first and fallback to DNS on failure. If DNS fail, we return an error.
+        Self::parse_v4(address, network)
+            .or_else(|_| Self::parse_and_resolve_dns(address, network, resolver))
+    }
+}
+
+impl Display for BitcoinSocketAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let address = match self.address {
+            AddrV2::TorV3(address) => address.to_lower_hex_string(),
+            AddrV2::I2p(address) => address.to_lower_hex_string(),
+            AddrV2::Ipv4(address) => address.to_string(),
+            AddrV2::Ipv6(address) => format!("[{}]", address),
+            AddrV2::TorV2(address) => address.to_lower_hex_string(),
+            AddrV2::Cjdns(address) => format!("[{}]", address),
+            AddrV2::Unknown(_, _) => "unknown".to_string(),
+        };
+
+        write!(f, "{address}:{}", self.port)
+    }
+}
+
+impl FromStr for BitcoinSocketAddr {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse_address(s, None, SystemResolver)
+    }
+
+    type Err = InvalidAddressError;
+}
+
+impl From<BitcoinSocketAddr> for AddrV2 {
+    fn from(value: BitcoinSocketAddr) -> Self {
+        value.into_addrv2()
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -3,7 +3,6 @@
 use core::fmt;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::net::IpAddr;
 use std::io;
 
 use floresta_chain::BlockchainError;
@@ -13,6 +12,9 @@ use tokio::sync::mpsc::error::SendError;
 
 use super::peer::PeerError;
 use super::transport::TransportError;
+use crate::address_man::LocalAddress;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+use crate::bitcoin_socket_addr::InvalidAddressError;
 use crate::node::NodeRequest;
 
 #[derive(Debug)]
@@ -24,6 +26,9 @@ pub enum WireError {
 
     /// Error while writing into a channel
     ChannelSend(SendError<NodeRequest>),
+
+    /// Attempted to connect with a network we can' reach
+    UnreachableNetwork,
 
     /// Peer error
     PeerError(PeerError),
@@ -44,10 +49,10 @@ pub enum WireError {
     AnchorFileNotFound,
 
     /// Peer already exists in our peers list
-    PeerAlreadyExists(IpAddr, u16),
+    PeerAlreadyExists(LocalAddress),
 
     /// Peer not found with this given address and port, in our peer list
-    PeerNotFoundAtAddress(IpAddr, u16),
+    PeerNotFoundAtAddress(BitcoinSocketAddr),
 
     /// Generic io error
     Io(std::io::Error),
@@ -71,7 +76,7 @@ pub enum WireError {
     PoisonedLock,
 
     /// We couldn't parse the provided address
-    InvalidAddress(AddrParseError),
+    InvalidAddress(InvalidAddressError),
 
     /// Transport error
     Transport(TransportError),
@@ -95,6 +100,9 @@ pub enum WireError {
 impl Display for WireError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            WireError::UnreachableNetwork => {
+                write!(f, "The provided network is invalid or unreachable")
+            }
             WireError::Blockchain(err) => write!(f, "Blockchain error: {err:?}"),
             WireError::ChannelSend(err) => write!(f, "Error while writing into channel: {err:?}"),
             WireError::PeerError(err) => write!(f, "Peer error: {err:?}"),
@@ -106,8 +114,8 @@ impl Display for WireError {
                 f,
                 "Failed to init Utreexo peers: anchors.json does not exist yet"
             ),
-            WireError::PeerAlreadyExists(ip, port) => write!(f, "Peer {ip}:{port} already exists"),
-            WireError::PeerNotFoundAtAddress(ip, port) => write!(f, "Peer {ip}:{port} not found"),
+            WireError::PeerAlreadyExists(address) => write!(f, "Peer {address} already exists"),
+            WireError::PeerNotFoundAtAddress(address) => write!(f, "Peer {address} not found"),
             WireError::Io(err) => write!(f, "Generic IO error: {err:?}"),
             WireError::Serde(err) => write!(f, "Serde error: {err:?}"),
             WireError::NoUtreexoPeersAvailable => write!(
@@ -145,7 +153,7 @@ impl_error_from!(
     IterableFilterStoreError,
     CompactBlockFiltersError
 );
-impl_error_from!(WireError, AddrParseError, InvalidAddress);
+impl_error_from!(WireError, InvalidAddressError, InvalidAddress);
 impl_error_from!(WireError, SendError<NodeRequest>, ChannelSend);
 impl_error_from!(WireError, serde_json::Error, Serde);
 impl_error_from!(WireError, io::Error, Io);

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -89,6 +89,7 @@ impl Default for UtreexoNodeConfig {
 }
 
 pub mod address_man;
+pub mod bitcoin_socket_addr;
 pub mod block_proof;
 pub mod error;
 pub mod node;

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -186,7 +186,7 @@ where
 
                 let peer = self.peers.get(&peer).unwrap();
                 self.common.address_man.update_set_state(
-                    peer.address_id as usize,
+                    peer.address.id,
                     AddressState::Banned(ChainSelector::BAN_TIME),
                 );
             }
@@ -702,7 +702,7 @@ where
         for peer in self.common.peers.clone() {
             if self.context.tip_cache.get(&peer.0).copied().eq(&Some(tip)) {
                 self.address_man.update_set_state(
-                    peer.1.address_id as usize,
+                    peer.1.address.id,
                     AddressState::Banned(ChainSelector::BAN_TIME),
                 );
                 self.disconnect_and_ban(peer.0)?;

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -37,9 +37,6 @@ use crate::TransportProtocol;
 use crate::address_man::AddressMan;
 use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
-use crate::bitcoin_socket_addr::BitcoinSocketAddr;
-use crate::bitcoin_socket_addr::InvalidAddressError;
-use crate::bitcoin_socket_addr::SystemResolver;
 use crate::node_context::NodeContext;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::Peer;
@@ -362,21 +359,6 @@ where
 
     // === BOOTSTRAPPING ===
 
-    /// Resolves a string address into a LocalAddress
-    ///
-    /// This function should get an address in the format `<address>[<:port>]` and return a
-    /// usable [`LocalAddress`]. It can be an ipv4, ipv6 or a hostname. In case of hostnames,
-    /// we resolve them using the system's DNS resolver and return an ip address. Errors if
-    /// the provided address is invalid, or we can't resolve it.
-    ///
-    /// TODO: Allow for non-clearnet addresses like onion services and i2p.
-    pub(crate) fn resolve_connect_host(
-        address: &str,
-        network: Network,
-    ) -> Result<BitcoinSocketAddr, InvalidAddressError> {
-        BitcoinSocketAddr::parse_address(address, Some(network), SystemResolver)
-    }
-
     // TODO(@luisschwab): get rid of this once
     // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
     pub(crate) fn get_port(network: Network) -> u16 {
@@ -629,71 +611,5 @@ where
             }
         }
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use bitcoin::Network;
-    use floresta_chain::pruned_utreexo::partial_chain::PartialChainState;
-
-    use crate::node::UtreexoNode;
-    use crate::node::running_ctx::RunningNode;
-
-    fn check_address_resolving(address: &str, should_succeed: bool, description: &str) {
-        let result = UtreexoNode::<PartialChainState, RunningNode>::resolve_connect_host(
-            address,
-            Network::Bitcoin,
-        );
-        if should_succeed {
-            assert!(result.is_ok(), "Failed: {description}");
-        } else {
-            assert!(result.is_err(), "Unexpected success: {description}");
-        }
-    }
-
-    #[test]
-    fn test_parse_address() {
-        // IPv6 Tests
-        check_address_resolving("[::1]", true, "Valid IPv6 without port");
-        check_address_resolving("[::1", false, "Invalid IPv6 format");
-        check_address_resolving("[::1]:8333", true, "Valid IPv6 with port");
-        check_address_resolving("[::1]:8333:8333", false, "Invalid IPv6 with multiple ports");
-
-        // IPv4 Tests
-        check_address_resolving("127.0.0.1", true, "Valid IPv4 without port");
-        check_address_resolving("321.321.321.321", false, "Invalid IPv4 format");
-        check_address_resolving("127.0.0.1:8333", true, "Valid IPv4 with port");
-        check_address_resolving(
-            "127.0.0.1:8333:8333",
-            false,
-            "Invalid IPv4 with multiple ports",
-        );
-
-        // Hostname Tests
-        check_address_resolving("example.com", true, "Valid hostname without port");
-        check_address_resolving("example", false, "Invalid hostname");
-        check_address_resolving("example.com:8333", true, "Valid hostname with port");
-        check_address_resolving(
-            "example.com:8333:8333",
-            false,
-            "Invalid hostname with multiple ports",
-        );
-
-        // Edge Cases
-        // This could fail on windows but doesn't since inside `resolve_connect_host` we specify empty addresses as localhost for all OS`s.
-        check_address_resolving("", true, "Empty string address");
-        check_address_resolving(
-            " 127.0.0.1:8333 ",
-            false,
-            "Address with leading/trailing spaces",
-        );
-        check_address_resolving("127.0.0.1:0", true, "Valid address with port 0");
-        check_address_resolving("127.0.0.1:65535", true, "Valid address with maximum port");
-        check_address_resolving(
-            "127.0.0.1:65536",
-            false,
-            "Valid address with out-of-range port",
-        )
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use core::net::IpAddr;
 use core::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -10,7 +9,6 @@ use std::time::UNIX_EPOCH;
 
 use bitcoin::Network;
 use bitcoin::p2p::ServiceFlags;
-use bitcoin::p2p::address::AddrV2;
 use floresta_chain::ChainBackend;
 use floresta_common::Ema;
 use floresta_common::service_flags;
@@ -39,8 +37,10 @@ use crate::TransportProtocol;
 use crate::address_man::AddressMan;
 use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+use crate::bitcoin_socket_addr::InvalidAddressError;
+use crate::bitcoin_socket_addr::SystemResolver;
 use crate::node_context::NodeContext;
-use crate::p2p_wire::error::AddrParseError;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::Peer;
 use crate::p2p_wire::peer::create_actors;
@@ -95,9 +95,9 @@ where
             self.fixed_peers
                 .iter()
                 .find(|addr| {
-                    self.peers
-                        .values()
-                        .all(|p| p.address != addr.get_net_address() || p.port != addr.get_port())
+                    self.peers.values().all(|p| {
+                        p.address.as_bitcoin_socket_addr() != addr.as_bitcoin_socket_addr()
+                    })
                 })
                 .map(|addr| (0, addr.clone()))
         } else {
@@ -113,6 +113,7 @@ where
                 let net = self.network;
                 self.address_man.add_fixed_addresses(net);
             }
+
             return Err(WireError::NoAddressesAvailable);
         };
 
@@ -127,16 +128,14 @@ where
         self.address_man
             .update_set_state(peer_id, AddressState::Failed(now));
 
-        // Don't open duplicate connections to the same peer.
-        let is_peer_connected = |(_, old_peer): (_, &LocalPeerView)| {
-            peer_address.get_net_address() == old_peer.address
-                && peer_address.get_port() == old_peer.port
-        };
-        if self.peers.iter().any(is_peer_connected) {
-            return Err(WireError::PeerAlreadyExists(
-                peer_address.get_net_address(),
-                peer_address.get_port(),
-            ));
+        // Don't connect to the same peer twice
+        if self
+            .common
+            .peers
+            .values()
+            .any(|p| p.address == peer_address)
+        {
+            return Err(WireError::PeerAlreadyExists(peer_address));
         }
 
         // Only allow P2PV1 fallback if the peer's connection kind is manual,
@@ -145,7 +144,7 @@ where
             matches!(conn_kind, ConnectionKind::Manual) || self.config.allow_v1_fallback;
 
         // Open a connection to the peer.
-        self.open_connection(conn_kind, peer_id, peer_address, allow_v1_fallback)?;
+        self.open_connection(conn_kind, peer_address, allow_v1_fallback)?;
 
         Ok(())
     }
@@ -177,7 +176,6 @@ where
     pub(crate) fn open_connection(
         &mut self,
         kind: ConnectionKind,
-        peer_id: usize,
         peer_address: LocalAddress,
         allow_v1_fallback: bool,
     ) -> Result<(), WireError> {
@@ -234,15 +232,13 @@ where
             peer_count,
             LocalPeerView {
                 message_times: Ema::with_half_life_50(),
-                address: peer_address.get_net_address(),
-                port: peer_address.get_port(),
+                address: peer_address,
                 user_agent: "".to_string(),
                 state: PeerStatus::Awaiting,
                 channel: requests_tx,
                 services: ServiceFlags::NONE,
                 _last_message: Instant::now(),
                 kind,
-                address_id: peer_id as u32,
                 height: 0,
                 banscore: 0,
                 // Will be downgraded to V1 if the V2 handshake fails, and we allow fallback
@@ -283,12 +279,13 @@ where
         our_best_block: u32,
         allow_v1_fallback: bool,
     ) -> Result<(), WireError> {
-        let (transport_reader, transport_writer, transport_protocol) = transport::connect(
-            (peer_address.get_net_address(), peer_address.get_port()),
-            network,
-            allow_v1_fallback,
-        )
-        .await?;
+        let ip_addr = peer_address
+            .get_net_address()
+            .ok_or(WireError::UnreachableNetwork)?;
+        let address = (ip_addr, peer_address.get_port());
+
+        let (transport_reader, transport_writer, transport_protocol) =
+            transport::connect(address, network, allow_v1_fallback).await?;
 
         let (cancellation_sender, cancellation_receiver) = oneshot::channel();
         let (actor_receiver, actor) = create_actors(transport_reader);
@@ -375,109 +372,9 @@ where
     /// TODO: Allow for non-clearnet addresses like onion services and i2p.
     pub(crate) fn resolve_connect_host(
         address: &str,
-        default_port: u16,
-    ) -> Result<LocalAddress, AddrParseError> {
-        // ipv6
-        if address.starts_with('[') {
-            if !address.contains(']') {
-                return Err(AddrParseError::InvalidIpv6);
-            }
-
-            let mut split = address.trim_end().split(']');
-            let hostname = split.next().ok_or(AddrParseError::InvalidIpv6)?;
-            let port = split
-                .next()
-                .filter(|x| !x.is_empty())
-                .map(|port| {
-                    port.trim_start_matches(':')
-                        .parse()
-                        .map_err(|_e| AddrParseError::InvalidPort)
-                })
-                .transpose()?
-                .unwrap_or(default_port);
-
-            let hostname = hostname.trim_start_matches('[');
-            let ip = hostname.parse().map_err(|_e| AddrParseError::InvalidIpv6)?;
-            return Ok(LocalAddress::new(
-                AddrV2::Ipv6(ip),
-                0,
-                AddressState::NeverTried,
-                ServiceFlags::NONE,
-                port,
-                rand::random::<u64>() as usize,
-            ));
-        }
-
-        // ipv4 - it's hard to differentiate between ipv4 and hostname without an actual regex
-        // simply try to parse it as an ip address and if it fails, assume it's a hostname
-
-        // this breaks the necessity of feature gate on windows
-        let mut address = address;
-        if address.is_empty() {
-            address = "127.0.0.1"
-        }
-
-        let mut split = address.split(':');
-        let ip = split
-            .next()
-            .ok_or(AddrParseError::InvalidIpv4)?
-            .parse()
-            .map_err(|_e| AddrParseError::InvalidIpv4);
-
-        match ip {
-            Ok(ip) => {
-                let port = split
-                    .next()
-                    .map(|port| port.parse().map_err(|_e| AddrParseError::InvalidPort))
-                    .transpose()?
-                    .unwrap_or(default_port);
-
-                if split.next().is_some() {
-                    return Err(AddrParseError::Inconclusive);
-                }
-
-                let id = rand::random::<u64>() as usize;
-                Ok(LocalAddress::new(
-                    AddrV2::Ipv4(ip),
-                    0,
-                    AddressState::NeverTried,
-                    ServiceFlags::NONE,
-                    port,
-                    id,
-                ))
-            }
-
-            Err(_) => {
-                let mut split = address.split(':');
-                let hostname = split.next().ok_or(AddrParseError::InvalidHostname)?;
-                let port = split
-                    .next()
-                    .map(|port| port.parse().map_err(|_e| AddrParseError::InvalidPort))
-                    .transpose()?
-                    .unwrap_or(default_port);
-
-                if split.next().is_some() {
-                    return Err(AddrParseError::Inconclusive);
-                }
-
-                let ip = dns_lookup::lookup_host(hostname)
-                    .map_err(|_e| AddrParseError::InvalidHostname)?;
-                let id = rand::random::<u64>() as usize;
-                let ip = match ip[0] {
-                    IpAddr::V4(ip) => AddrV2::Ipv4(ip),
-                    IpAddr::V6(ip) => AddrV2::Ipv6(ip),
-                };
-
-                Ok(LocalAddress::new(
-                    ip,
-                    0,
-                    AddressState::NeverTried,
-                    ServiceFlags::NONE,
-                    port,
-                    id,
-                ))
-            }
-        }
+        network: Network,
+    ) -> Result<BitcoinSocketAddr, InvalidAddressError> {
+        BitcoinSocketAddr::parse_address(address, Some(network), SystemResolver)
     }
 
     // TODO(@luisschwab): get rid of this once
@@ -598,7 +495,6 @@ where
         for address in anchors {
             self.open_connection(
                 ConnectionKind::Regular(service_flags::UTREEXO.into()),
-                address.id,
                 address,
                 // Using V1 transport fallback as utreexo nodes have limited support
                 true,
@@ -709,9 +605,10 @@ where
         }
         let peers_count = self.peer_id_count;
         for added_peer in self.added_peers.clone() {
-            let matching_peer = self.peers.values().find(|peer| {
-                self.to_addr_v2(peer.address) == added_peer.address && peer.port == added_peer.port
-            });
+            let matching_peer = self
+                .peers
+                .values()
+                .find(|peer| *peer.address.as_bitcoin_socket_addr() == added_peer.address);
 
             if matching_peer.is_none() {
                 let address = LocalAddress::new(
@@ -724,17 +621,11 @@ where
                             .as_secs(),
                     ),
                     ServiceFlags::NONE,
-                    added_peer.port,
                     peers_count as usize,
                 );
 
                 // Finally, open the connection with the node
-                self.open_connection(
-                    ConnectionKind::Manual,
-                    peers_count as usize,
-                    address,
-                    added_peer.v1_fallback,
-                )?
+                self.open_connection(ConnectionKind::Manual, address, added_peer.v1_fallback)?
             }
         }
         Ok(())
@@ -743,14 +634,17 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::Network;
     use floresta_chain::pruned_utreexo::partial_chain::PartialChainState;
 
     use crate::node::UtreexoNode;
     use crate::node::running_ctx::RunningNode;
 
-    fn check_address_resolving(address: &str, port: u16, should_succeed: bool, description: &str) {
-        let result =
-            UtreexoNode::<PartialChainState, RunningNode>::resolve_connect_host(address, port);
+    fn check_address_resolving(address: &str, should_succeed: bool, description: &str) {
+        let result = UtreexoNode::<PartialChainState, RunningNode>::resolve_connect_host(
+            address,
+            Network::Bitcoin,
+        );
         if should_succeed {
             assert!(result.is_ok(), "Failed: {description}");
         } else {
@@ -761,57 +655,43 @@ mod tests {
     #[test]
     fn test_parse_address() {
         // IPv6 Tests
-        check_address_resolving("[::1]", 8333, true, "Valid IPv6 without port");
-        check_address_resolving("[::1", 8333, false, "Invalid IPv6 format");
-        check_address_resolving("[::1]:8333", 8333, true, "Valid IPv6 with port");
-        check_address_resolving(
-            "[::1]:8333:8333",
-            8333,
-            false,
-            "Invalid IPv6 with multiple ports",
-        );
+        check_address_resolving("[::1]", true, "Valid IPv6 without port");
+        check_address_resolving("[::1", false, "Invalid IPv6 format");
+        check_address_resolving("[::1]:8333", true, "Valid IPv6 with port");
+        check_address_resolving("[::1]:8333:8333", false, "Invalid IPv6 with multiple ports");
 
         // IPv4 Tests
-        check_address_resolving("127.0.0.1", 8333, true, "Valid IPv4 without port");
-        check_address_resolving("321.321.321.321", 8333, false, "Invalid IPv4 format");
-        check_address_resolving("127.0.0.1:8333", 8333, true, "Valid IPv4 with port");
+        check_address_resolving("127.0.0.1", true, "Valid IPv4 without port");
+        check_address_resolving("321.321.321.321", false, "Invalid IPv4 format");
+        check_address_resolving("127.0.0.1:8333", true, "Valid IPv4 with port");
         check_address_resolving(
             "127.0.0.1:8333:8333",
-            8333,
             false,
             "Invalid IPv4 with multiple ports",
         );
 
         // Hostname Tests
-        check_address_resolving("example.com", 8333, true, "Valid hostname without port");
-        check_address_resolving("example", 8333, false, "Invalid hostname");
-        check_address_resolving("example.com:8333", 8333, true, "Valid hostname with port");
+        check_address_resolving("example.com", true, "Valid hostname without port");
+        check_address_resolving("example", false, "Invalid hostname");
+        check_address_resolving("example.com:8333", true, "Valid hostname with port");
         check_address_resolving(
             "example.com:8333:8333",
-            8333,
             false,
             "Invalid hostname with multiple ports",
         );
 
         // Edge Cases
-        // This could fail on windows but doesnt since inside `resolve_connect_host` we specificate empty addresses as localhost for all OS`s.
-        check_address_resolving("", 8333, true, "Empty string address");
+        // This could fail on windows but doesn't since inside `resolve_connect_host` we specify empty addresses as localhost for all OS`s.
+        check_address_resolving("", true, "Empty string address");
         check_address_resolving(
             " 127.0.0.1:8333 ",
-            8333,
             false,
             "Address with leading/trailing spaces",
         );
-        check_address_resolving("127.0.0.1:0", 0, true, "Valid address with port 0");
-        check_address_resolving(
-            "127.0.0.1:65535",
-            65535,
-            true,
-            "Valid address with maximum port",
-        );
+        check_address_resolving("127.0.0.1:0", true, "Valid address with port 0");
+        check_address_resolving("127.0.0.1:65535", true, "Valid address with maximum port");
         check_address_resolving(
             "127.0.0.1:65536",
-            65535,
             false,
             "Valid address with out-of-range port",
         )

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -56,6 +56,8 @@ use super::node_handle::UserRequest;
 use super::peer::PeerMessages;
 use super::socks::Socks5StreamBuilder;
 use super::transport::TransportProtocol;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+use crate::bitcoin_socket_addr::SystemResolver;
 use crate::node_context::PeerId;
 
 /// As per BIP 155, limit the number of addresses to 1,000
@@ -351,7 +353,8 @@ where
         let mut seen = HashSet::new();
         let mut fixed_peers = Vec::with_capacity(config.fixed_peers.len());
         for address in &config.fixed_peers {
-            let resolved = Self::resolve_connect_host(address, config.network)?;
+            let resolved =
+                BitcoinSocketAddr::parse_address(address, Some(config.network), SystemResolver)?;
             if seen.insert(resolved.clone()) {
                 fixed_peers.push(LocalAddress::from(resolved));
             }

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -13,7 +13,6 @@ pub mod sync_ctx;
 mod user_req;
 
 use core::fmt::Debug;
-use core::net::IpAddr;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -190,9 +189,6 @@ pub struct LocalPeerView {
     /// The state in which this peer is, e.g., awaiting handshake, ready, banned, etc.
     pub(crate) state: PeerStatus,
 
-    /// An id identifying this peer's address in our address manager
-    pub(crate) address_id: u32,
-
     /// A channel used to send requests to this peer
     pub(crate) channel: UnboundedSender<NodeRequest>,
 
@@ -203,10 +199,7 @@ pub struct LocalPeerView {
     pub(crate) user_agent: String,
 
     /// This peer's IP address
-    pub(crate) address: IpAddr,
-
-    /// The port we used to connect to this peer
-    pub(crate) port: u16,
+    pub(crate) address: LocalAddress,
 
     /// The last time we received a message from this peer
     pub(crate) _last_message: Instant,
@@ -358,9 +351,9 @@ where
         let mut seen = HashSet::new();
         let mut fixed_peers = Vec::with_capacity(config.fixed_peers.len());
         for address in &config.fixed_peers {
-            let resolved = Self::resolve_connect_host(address, Self::get_port(config.network))?;
-            if seen.insert((resolved.get_net_address(), resolved.get_port())) {
-                fixed_peers.push(resolved);
+            let resolved = Self::resolve_connect_host(address, config.network)?;
+            if seen.insert(resolved.clone()) {
+                fixed_peers.push(LocalAddress::from(resolved));
             }
         }
 

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use core::net::IpAddr;
-use core::net::SocketAddr;
 use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use bitcoin::Transaction;
 use bitcoin::p2p::ServiceFlags;
-use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::message_blockdata::Inventory;
 use floresta_chain::ChainBackend;
@@ -31,6 +28,7 @@ use super::PeerStatus;
 use super::UtreexoNode;
 use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::block_proof::Bitmap;
 use crate::node::running_ctx::RunningNode;
 use crate::node_context::NodeContext;
@@ -46,10 +44,7 @@ use crate::p2p_wire::peer::Version;
 /// A simple struct of added peers, used to track the ones we added manually by `addnode <ip:port> add` command.
 pub struct AddedPeerInfo {
     /// The address of the peer
-    pub(crate) address: AddrV2,
-
-    /// The port of the peer
-    pub(crate) port: u16,
+    pub(crate) address: BitcoinSocketAddr,
 
     /// Whether we should allow V1 fallback for this connection
     pub(crate) v1_fallback: bool,
@@ -844,7 +839,7 @@ where
         let peer = self.peers.get(peer_id)?;
         Some(PeerInfo {
             id: *peer_id,
-            address: SocketAddr::new(peer.address, peer.port),
+            address: peer.address.as_bitcoin_socket_addr().clone(),
             services: peer.services,
             user_agent: peer.user_agent.clone(),
             initial_height: peer.height,
@@ -856,49 +851,36 @@ where
 
     // === ADDNODE ===
 
-    // TODO: remove this after bitcoin-0.33.0
-    /// Helper function to resolve an IpAddr to AddrV2
-    /// This is a little bit of a hack while rust-bitcoin
-    /// do not have an `from` or `into` that do IpAddr <> AddrV2
-    pub(crate) fn to_addr_v2(&self, addr: IpAddr) -> AddrV2 {
-        match addr {
-            IpAddr::V4(addr) => AddrV2::Ipv4(addr),
-            IpAddr::V6(addr) => AddrV2::Ipv6(addr),
-        }
-    }
-
     /// Handles addnode-RPC `Add` requests, adding a new peer to the `added_peers` list. This means
     /// the peer is marked as a "manually added peer". We then try to connect to it, or retry later.
     pub fn handle_addnode_add_peer(
         &mut self,
-        addr: IpAddr,
-        port: u16,
+        peer_address: BitcoinSocketAddr,
         v2_transport: bool,
     ) -> Result<(), WireError> {
         // See https://github.com/bitcoin/bitcoin/blob/8309a9747a8df96517970841b3648937d05939a3/src/net.cpp#L3558
-        debug!("Adding node {addr}:{port}");
-        let address = self.to_addr_v2(addr);
+
+        // Add this address to our address manager for later
+        // assume it has the bare-minimum services, otherwise `push_addresses` will ignore it
+        let mut local_address = LocalAddress::from(peer_address.clone());
+        debug!("Adding node {}", local_address);
+
+        local_address.set_services(ServiceFlags::NETWORK_LIMITED | ServiceFlags::WITNESS);
 
         // Check if the peer already exists
         if self
             .added_peers
             .iter()
-            .any(|info| address == info.address && port == info.port)
+            .any(|peer_info| peer_address == peer_info.address)
         {
-            return Err(WireError::PeerAlreadyExists(addr, port));
+            return Err(WireError::PeerAlreadyExists(local_address));
         }
-
-        // Add this address to our address manager for later
-        // assume it has the bare-minimum services, otherwise `push_addresses` will ignore it
-        let mut local_address = LocalAddress::from(address.clone());
-        local_address.set_services(ServiceFlags::NETWORK_LIMITED | ServiceFlags::WITNESS);
 
         self.address_man.push_addresses(&[local_address]);
 
         // Add a simple reference to the peer
         self.added_peers.push(AddedPeerInfo {
-            address,
-            port,
+            address: peer_address,
             v1_fallback: !v2_transport,
         });
 
@@ -917,73 +899,60 @@ where
     ///
     /// If someone wants to remove a peer, it should be done using the
     /// `disconnectnode`.
-    pub fn handle_addnode_remove_peer(&mut self, addr: IpAddr, port: u16) -> Result<(), WireError> {
-        debug!("Trying to remove peer {addr}:{port}");
+    pub fn handle_addnode_remove_peer(&mut self, addr: BitcoinSocketAddr) -> Result<(), WireError> {
+        debug!("Trying to remove peer {addr}");
 
-        let address = self.to_addr_v2(addr);
         let index = self
             .added_peers
             .iter()
-            .position(|info| address == info.address && port == info.port);
+            .position(|info| addr == info.address)
+            .ok_or(WireError::PeerNotFoundAtAddress(addr))?;
 
-        match index {
-            Some(peer_id) => self.added_peers.remove(peer_id),
-            None => return Err(WireError::PeerNotFoundAtAddress(addr, port)),
-        };
+        self.added_peers.remove(index);
 
         Ok(())
     }
 
     /// Handles the node request for immediate disconnection from a peer.
-    pub fn handle_disconnect_peer(&mut self, addr: IpAddr, port: u16) -> Result<(), WireError> {
+    pub fn handle_disconnect_peer(&mut self, addr: BitcoinSocketAddr) -> Result<(), WireError> {
         // Get the peer's index in the [`AddressMan`]'s list, if it exists.
-        let index = self
+        let peer_id = self
             .peers
             .iter()
-            .find(|(_, peer)| addr == peer.address && port == peer.port)
-            .map(|(&peer_id, _)| peer_id);
+            .find_map(|(&id, peer)| (*peer.address.as_bitcoin_socket_addr() == addr).then_some(id))
+            .ok_or(WireError::PeerNotFoundAtAddress(addr))?;
 
-        match index {
-            Some(peer_id) => {
-                self.send_to_peer(peer_id, NodeRequest::Shutdown)?;
-                Ok(())
-            }
-            None => Err(WireError::PeerNotFoundAtAddress(addr, port)),
-        }
+        self.send_to_peer(peer_id, NodeRequest::Shutdown)
     }
 
     /// Handles addnode onetry requests, connecting to the node and this will try to connect to the given address and port.
     /// If it's successful, it will add the node to the peers list, but not to the added_peers list (e.g., it won't be reconnected if disconnected).
     pub fn handle_addnode_onetry_peer(
         &mut self,
-        addr: IpAddr,
-        port: u16,
+        peer_address: BitcoinSocketAddr,
         v2_transport: bool,
     ) -> Result<(), WireError> {
-        debug!("Creating an one-try connection with {addr}:{port}");
+        let kind = ConnectionKind::Manual;
+
+        // Add this address to our address manager for later
+        // assume it has the bare-minimum services, otherwise `push_addresses` will ignore it
+        let mut local_address = LocalAddress::from(peer_address.clone());
+        debug!("Creating an one-try connection with {local_address}");
 
         // Check if the peer already exists
         if self
             .peers
             .iter()
-            .any(|(_, peer)| addr == peer.address && port == peer.port)
+            .any(|(_, peer_info)| *peer_info.address.as_bitcoin_socket_addr() == peer_address)
         {
-            return Err(WireError::PeerAlreadyExists(addr, port));
+            return Err(WireError::PeerAlreadyExists(local_address));
         }
 
-        let kind = ConnectionKind::Manual;
-
-        // Add this address to our address manager for later
-        // assume it has the bare-minimum services, otherwise `push_addresses` will ignore it
-        let address_v2 = self.to_addr_v2(addr);
-        let mut local_address = LocalAddress::from(address_v2.clone());
-
-        local_address.set_port(port);
         local_address.set_services(ServiceFlags::NETWORK_LIMITED | ServiceFlags::WITNESS);
 
         self.address_man.push_addresses(&[local_address.clone()]);
         // Return true if exists or false if anything fails during connection
         // We allow V1 fallback iff the `v2` flag is not set
-        self.open_connection(kind, local_address.id, local_address, !v2_transport)
+        self.open_connection(kind, local_address, !v2_transport)
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -96,10 +96,10 @@ where
                 return;
             }
 
-            UserRequest::Add((addr, port, v2transport)) => {
-                let node_response = match self.handle_addnode_add_peer(addr, port, v2transport) {
+            UserRequest::Add((addr, v2transport)) => {
+                let node_response = match self.handle_addnode_add_peer(addr.clone(), v2transport) {
                     Ok(_) => {
-                        info!("Added peer {addr}:{port}");
+                        info!("Added peer {addr}");
                         NodeResponse::Add(true)
                     }
                     Err(err) => {
@@ -112,10 +112,10 @@ where
                 return;
             }
 
-            UserRequest::Remove((addr, port)) => {
-                let node_response = match self.handle_addnode_remove_peer(addr, port) {
+            UserRequest::Remove(addr) => {
+                let node_response = match self.handle_addnode_remove_peer(addr.clone()) {
                     Ok(_) => {
-                        info!("Removed peer {addr}:{port}");
+                        info!("Removed peer {addr}");
                         NodeResponse::Remove(true)
                     }
                     Err(err) => {
@@ -128,10 +128,11 @@ where
                 return;
             }
 
-            UserRequest::Onetry((addr, port, v2transport)) => {
-                let node_response = match self.handle_addnode_onetry_peer(addr, port, v2transport) {
+            UserRequest::Onetry((addr, v2transport)) => {
+                let node_response = match self.handle_addnode_onetry_peer(addr.clone(), v2transport)
+                {
                     Ok(_) => {
-                        info!("Connected to peer {addr}:{port}");
+                        info!("Connected to peer {addr}");
                         NodeResponse::Onetry(true)
                     }
                     Err(err) => {
@@ -144,14 +145,14 @@ where
                 return;
             }
 
-            UserRequest::Disconnect((addr, port)) => {
-                let node_response = match self.handle_disconnect_peer(addr, port) {
+            UserRequest::Disconnect(addr) => {
+                let node_response = match self.handle_disconnect_peer(addr.clone()) {
                     Ok(_) => {
-                        info!("Disconnected from peer {addr}:{port}");
+                        info!("Disconnected from peer {addr}");
                         NodeResponse::Disconnect(true)
                     }
                     Err(err) => {
-                        warn!("Failed to disconnect from peer {addr}:{port}: {err:?}");
+                        warn!("Failed to disconnect from peer {addr}: {err:?}");
                         NodeResponse::Disconnect(false)
                     }
                 };

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -14,7 +14,6 @@
 //! This module actually implement the [`crate::node_interface::NodeMethods`] trait, and
 //! contains the actual type you will use when interacting with a real node.
 
-use core::net::IpAddr;
 use std::time::Instant;
 
 use bitcoin::Block;
@@ -30,6 +29,7 @@ use tokio::sync::oneshot::error::RecvError;
 use super::UtreexoNodeConfig;
 use super::node::NodeNotification;
 use crate::address_man::ConnectionStats;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::node_interface::ChainMethods;
 use crate::node_interface::MempoolMethods;
 use crate::node_interface::NetworkMethods;
@@ -68,22 +68,22 @@ pub enum UserRequest {
     ///
     /// This function will add this peer to a special list of peers such that, if we lose the
     /// connection, we will keep trying to connect to it until we succeed.
-    Add((IpAddr, u16, bool)),
+    Add((BitcoinSocketAddr, bool)),
 
     /// Removes a node from the node's peer list.
     ///
     /// This function will remove a node that was added with [`UserRequest::Add`]. This will **not**
     /// disconnect the peer, but if it disconnects, it will not be reconnected again.
-    Remove((IpAddr, u16)),
+    Remove(BitcoinSocketAddr),
 
     /// Attempts to connect to a peer once.
     ///
     /// Different from [`UserRequest::Add`], this function will try to connect to the peer once, but
     /// will not add it to the node's added peers list.
-    Onetry((IpAddr, u16, bool)),
+    Onetry((BitcoinSocketAddr, bool)),
 
     /// Attempt to disconnect from a peer.
-    Disconnect((IpAddr, u16)),
+    Disconnect(BitcoinSocketAddr),
 
     /// Ping all connected peers to check if they are alive.
     Ping,
@@ -221,38 +221,34 @@ impl NetworkMethods for NodeHandle {
 
     async fn add_peer(
         &self,
-        addr: IpAddr,
-        port: u16,
+        addr: BitcoinSocketAddr,
         v2transport: bool,
     ) -> Result<bool, Self::Error> {
         let val = self
-            .send_request(UserRequest::Add((addr, port, v2transport)))
+            .send_request(UserRequest::Add((addr, v2transport)))
             .await?;
 
         extract_variant!(Add, val);
     }
 
-    async fn remove_peer(&self, addr: IpAddr, port: u16) -> Result<bool, Self::Error> {
-        let val = self.send_request(UserRequest::Remove((addr, port))).await?;
+    async fn remove_peer(&self, addr: BitcoinSocketAddr) -> Result<bool, Self::Error> {
+        let val = self.send_request(UserRequest::Remove(addr)).await?;
         extract_variant!(Remove, val);
     }
 
-    async fn disconnect_peer(&self, addr: IpAddr, port: u16) -> Result<bool, Self::Error> {
-        let val = self
-            .send_request(UserRequest::Disconnect((addr, port)))
-            .await?;
+    async fn disconnect_peer(&self, addr: BitcoinSocketAddr) -> Result<bool, Self::Error> {
+        let val = self.send_request(UserRequest::Disconnect(addr)).await?;
 
         extract_variant!(Disconnect, val);
     }
 
     async fn onetry_peer(
         &self,
-        addr: IpAddr,
-        port: u16,
+        addr: BitcoinSocketAddr,
         v2transport: bool,
     ) -> Result<bool, Self::Error> {
         let val = self
-            .send_request(UserRequest::Onetry((addr, port, v2transport)))
+            .send_request(UserRequest::Onetry((addr, v2transport)))
             .await?;
         extract_variant!(Onetry, val);
     }

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -17,15 +17,12 @@
 //! testing other modules, and to allow people to reuse other crates without wire: simply
 //! re-implement the relevant parts of node interface and you are fine!
 
-use core::net::IpAddr;
-use core::net::SocketAddr;
-use std::future::Future;
-
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
 use bitcoin::Txid;
 use bitcoin::p2p::ServiceFlags;
+use bitcoin::p2p::address::AddrV2;
 use floresta_mempool::mempool::MempoolError;
 use serde::Serialize;
 
@@ -34,6 +31,7 @@ use super::node::ConnectionKind;
 use super::node::PeerStatus;
 use super::transport::TransportProtocol;
 use crate::address_man::ConnectionStats;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// A request to addnode that can be made to the node.
@@ -44,13 +42,13 @@ use crate::address_man::ConnectionStats;
 /// [Bitcoin Core]: (https://bitcoincore.org/en/doc/29.0.0/rpc/network/addnode/)
 pub enum AddNode {
     /// The `Add` variant is used to add a peer to the node's peer list
-    Add((IpAddr, u16)),
+    Add((AddrV2, u16)),
 
     /// The `Remove` variant is used to remove a peer from the node's peer list
-    Remove((IpAddr, u16)),
+    Remove((AddrV2, u16)),
 
     /// The `Onetry` variant is used to try a connection to the peer once, but not add it to the peer list.
-    Onetry((IpAddr, u16)),
+    Onetry((AddrV2, u16)),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -85,22 +83,22 @@ pub enum UserRequest {
     ///
     /// This function will add this peer to a special list of peers such that, if we lose the
     /// connection, we will keep trying to connect to it until we succeed.
-    Add((IpAddr, u16, bool)),
+    Add((BitcoinSocketAddr, bool)),
 
     /// Removes a node from the node's peer list.
     ///
     /// This function will remove a node that was added with [`AddNode::Add`]. This will **not**
     /// disconnect the peer, but if it disconnects, it will not be reconnected again.
-    Remove((IpAddr, u16)),
+    Remove(BitcoinSocketAddr),
 
     /// Attempts to connect to a peer once.
     ///
     /// Different from [`AddNode::Add`], this function will try to connect to the peer once, but
     /// will not add it to the node's added peers list.
-    Onetry((IpAddr, u16, bool)),
+    Onetry((BitcoinSocketAddr, bool)),
 
     /// Attempt to disconnect from a peer.
-    Disconnect((IpAddr, u16)),
+    Disconnect(BitcoinSocketAddr),
 
     /// Ping all connected peers to check if they are alive.
     Ping,
@@ -120,7 +118,8 @@ pub enum UserRequest {
 /// at, its state and the kind of connection it has with the node.
 pub struct PeerInfo {
     pub id: u32,
-    pub address: SocketAddr,
+    #[serde(serialize_with = "serialize_addr")]
+    pub address: BitcoinSocketAddr,
     #[serde(serialize_with = "serialize_service_flags")]
     pub services: ServiceFlags,
     pub user_agent: String,
@@ -177,8 +176,7 @@ pub trait NetworkMethods {
     /// may be called multiple times, and may use hostnames or IP addresses.
     fn add_peer(
         &self,
-        addr: IpAddr,
-        port: u16,
+        addr: BitcoinSocketAddr,
         v2transport: bool,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
@@ -187,8 +185,7 @@ pub trait NetworkMethods {
     /// It may be called multiple times, and may use hostnames or IP addresses.
     fn remove_peer(
         &self,
-        addr: IpAddr,
-        port: u16,
+        addr: BitcoinSocketAddr,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
     /// Immediately disconnect from a peer.
@@ -196,8 +193,7 @@ pub trait NetworkMethods {
     /// Returns a bool indicating whether the disconnection was successful.
     fn disconnect_peer(
         &self,
-        addr: IpAddr,
-        port: u16,
+        addr: BitcoinSocketAddr,
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
     /// Attempts to connect to a peer once.
@@ -207,8 +203,7 @@ pub trait NetworkMethods {
     /// It may be called multiple times, and may use hostnames or IP addresses.
     fn onetry_peer(
         &self,
-        addr: IpAddr,
-        port: u16,
+        addr: BitcoinSocketAddr,
         v2transport: bool,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
@@ -245,6 +240,13 @@ pub trait NodeMethods:
 impl<T> NodeMethods for T where
     T: ChainMethods + MempoolMethods + NetworkMethods + NodeConfigMethods + Send + 'static
 {
+}
+
+fn serialize_addr<S>(local_addr: &BitcoinSocketAddr, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&local_addr.to_string())
 }
 
 fn serialize_service_flags<S>(flags: &ServiceFlags, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -780,10 +780,8 @@ pub(super) mod peer_utils {
         let sender_address = Address::new(&fake_socket, services);
 
         // The remote peer's `Address`.
-        let receiver_address = Address::new(
-            &peer_address.get_socket_address(),
-            peer_address.get_services(),
-        );
+        let peer_addr = peer_address.get_socket_addr().unwrap_or(fake_socket);
+        let receiver_address = Address::new(&peer_addr, peer_address.get_services());
 
         // Generate a per-message nonce.
         let mut prng = rng();
@@ -881,6 +879,7 @@ mod tests {
     use crate::TransportProtocol;
     use crate::address_man::AddressState;
     use crate::address_man::LocalAddress;
+    use crate::bitcoin_socket_addr::BitcoinSocketAddr;
     use crate::node::ConnectionKind;
     use crate::node::NodeNotification;
     use crate::node::NodeRequest;
@@ -916,11 +915,10 @@ mod tests {
         let (cancellation_sender, _) = oneshot::channel();
 
         let address = LocalAddress::new(
-            AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
+            BitcoinSocketAddr::new(AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1)), 8333),
             0,
             AddressState::NeverTried,
             ServiceFlags::NONE,
-            18444,
             0,
         );
 

--- a/crates/floresta-wire/src/p2p_wire/socks.rs
+++ b/crates/floresta-wire/src/p2p_wire/socks.rs
@@ -15,11 +15,15 @@ use core::fmt::Formatter;
 use core::net::Ipv4Addr;
 use core::net::Ipv6Addr;
 use core::net::SocketAddr;
+use std::net::IpAddr;
 
 use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
+
+use crate::address_man::LocalAddress;
+use crate::p2p_wire::transport::TransportError;
 
 #[derive(Clone, Debug)]
 pub struct Socks5StreamBuilder {
@@ -43,8 +47,9 @@ const SOCKS_ADDR_TYPE_IPV6: u8 = 4;
 pub enum Socks5Addr {
     Ipv4(Ipv4Addr),
     Ipv6(Ipv6Addr),
-    Domain(Box<[u8]>),
+    Domain(String),
 }
+
 impl From<Socks5Addr> for u8 {
     fn from(val: Socks5Addr) -> Self {
         match val {
@@ -54,10 +59,28 @@ impl From<Socks5Addr> for u8 {
         }
     }
 }
+
+impl TryFrom<&LocalAddress> for Socks5Addr {
+    type Error = TransportError;
+
+    fn try_from(address: &LocalAddress) -> Result<Self, Self::Error> {
+        address
+            .get_net_address()
+            .map(|ip| match ip {
+                // Try to parse as an IP address first
+                IpAddr::V4(ipv4) => Socks5Addr::Ipv4(ipv4),
+                IpAddr::V6(ipv6) => Socks5Addr::Ipv6(ipv6),
+            })
+            // TODO(davidson): Support Tor, I2P...
+            .ok_or(TransportError::InvalidAddress)
+    }
+}
+
 impl Socks5StreamBuilder {
     pub fn new(address: SocketAddr) -> Self {
         Self { address }
     }
+
     pub async fn connect<Stream: AsyncRead + AsyncWrite + Unpin>(
         mut socket: Stream,
         address: &Socks5Addr,
@@ -65,17 +88,18 @@ impl Socks5StreamBuilder {
     ) -> Result<Stream, Socks5Error> {
         socket
             .write_all(&[SOCKS_VERSION, 1, SOCKS_AUTH_METHOD_NONE])
-            .await
-            .unwrap();
+            .await?;
+
         let address = match address {
             Socks5Addr::Ipv4(addr) => addr.octets().to_vec(),
             Socks5Addr::Ipv6(addr) => addr.octets().to_vec(),
             Socks5Addr::Domain(domain) => {
                 let mut buf = vec![domain.len() as u8];
-                buf.extend_from_slice(domain);
+                buf.extend_from_slice(domain.as_bytes());
                 buf
             }
         };
+
         let mut buf = [0_u8; 2];
         socket.read_exact(&mut buf).await?;
 
@@ -90,6 +114,7 @@ impl Socks5StreamBuilder {
         socket
             .write_all(&[SOCKS_VERSION, SOCKS_CMD_CONNECT, 0, SOCKS_ADDR_TYPE_IPV4])
             .await?;
+
         socket.write_all(&address).await?;
         socket.write_all(&port.to_be_bytes()).await?;
 
@@ -99,6 +124,7 @@ impl Socks5StreamBuilder {
         if buf[0] != SOCKS_VERSION {
             return Err(Socks5Error::InvalidVersion);
         }
+
         if buf[1] != 0 {
             return Err(Socks5Error::ConnectionFailed);
         }
@@ -123,6 +149,7 @@ impl Socks5StreamBuilder {
         Ok(socket)
     }
 }
+
 #[derive(Debug)]
 pub enum Socks5Error {
     InvalidVersion,

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use core::net::IpAddr;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -16,7 +15,6 @@ use bitcoin::consensus::encode;
 use bitcoin::consensus::encode::deserialize_hex;
 use bitcoin::hex::FromHex;
 use bitcoin::p2p::ServiceFlags;
-use bitcoin::p2p::address::AddrV2;
 use derive_more::Constructor;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::ChainState;
@@ -177,16 +175,14 @@ pub fn create_peer(
 
     LocalPeerView {
         message_times: Ema::with_half_life_50(),
-        address: "127.0.0.1".parse().unwrap(),
+        address: "127.0.0.1:8333".parse().unwrap(),
         services: service_flags::UTREEXO.into(),
         user_agent: "/utreexo:0.1.0/".to_string(),
         height: 0,
         state: PeerStatus::Ready,
         channel: sender,
-        port: 8333,
         kind: ConnectionKind::Regular(service_flags::UTREEXO.into()),
         banscore: 0,
-        address_id: 0,
         _last_message: Instant::now(),
         transport_protocol: TransportProtocol::V2,
     }
@@ -345,7 +341,7 @@ pub async fn setup_node(
 
         // Add a fixed peer to avoid opening real P2P connections
         if i == 0 {
-            node.fixed_peers = vec![to_addr_v2(peer.address).into()];
+            node.fixed_peers = vec![peer.address.clone()];
         }
 
         node.peers.insert(peer_id, peer);
@@ -373,14 +369,6 @@ pub async fn setup_node(
         .unwrap();
 
     chain
-}
-
-// TODO: remove this after bitcoin-0.33.0
-fn to_addr_v2(addr: IpAddr) -> AddrV2 {
-    match addr {
-        IpAddr::V4(addr) => AddrV2::Ipv4(addr),
-        IpAddr::V6(addr) => AddrV2::Ipv6(addr),
-    }
 }
 
 #[cfg(test)]

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -27,7 +27,6 @@ use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256d;
 use bitcoin::hex::DisplayHex;
 use bitcoin::p2p::Magic;
-use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::message::MAX_MSG_SIZE;
 use bitcoin::p2p::message::NetworkMessage;
 use bitcoin::p2p::message::RawNetworkMessage;
@@ -125,6 +124,9 @@ pub enum TransportError {
 
     /// Peer sent us a message with invalid magic bits
     BadMagicBits { expected: Magic, provided: Magic },
+
+    /// Received address is invalid/unreachable
+    InvalidAddress,
 }
 
 impl Display for TransportError {
@@ -151,6 +153,9 @@ impl Display for TransportError {
                     f,
                     "Peer sent us a message with invalid magic bits: expected {expected}, got {provided}"
                 )
+            }
+            TransportError::InvalidAddress => {
+                write!(f, "provided address is either invalid or unreachable")
             }
         }
     }
@@ -331,17 +336,7 @@ pub async fn connect_proxy<A: ToSocketAddrs + Clone + Debug>(
     network: Network,
     allow_v1_fallback: bool,
 ) -> TransportResult {
-    let addr = match address.get_addrv2() {
-        AddrV2::Cjdns(addr) => Socks5Addr::Ipv6(addr),
-        AddrV2::I2p(addr) => Socks5Addr::Domain(addr.into()),
-        AddrV2::Ipv4(addr) => Socks5Addr::Ipv4(addr),
-        AddrV2::Ipv6(addr) => Socks5Addr::Ipv6(addr),
-        AddrV2::TorV2(addr) => Socks5Addr::Domain(addr.into()),
-        AddrV2::TorV3(addr) => Socks5Addr::Domain(addr.into()),
-        AddrV2::Unknown(_, _) => {
-            return Err(TransportError::Proxy(Socks5Error::InvalidAddress));
-        }
-    };
+    let addr = Socks5Addr::try_from(&address)?;
 
     match try_proxy_connection(&proxy_addr, &addr, address.get_port(), network, false).await {
         Ok(transport) => Ok(transport),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -76,5 +76,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "bitcoin_socket_addr"
+path = "fuzz_targets/bitcoin_socket_addr.rs"
+test = false
+doc = false
+bench = false
+
 [lints]
 workspace = true

--- a/fuzz/fuzz_targets/bitcoin_socket_addr.rs
+++ b/fuzz/fuzz_targets/bitcoin_socket_addr.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use std::io;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+
+use bitcoin::Network;
+use floresta_wire::bitcoin_socket_addr::BitcoinSocketAddr;
+use floresta_wire::bitcoin_socket_addr::DnsResolver;
+use libfuzzer_sys::fuzz_target;
+
+/// A no-op resolver to avoid costly name lookup operations inside the fuzz target
+///
+/// It simply returns localhost to any name
+struct FuzzResolver;
+
+impl DnsResolver for FuzzResolver {
+    type Error = io::Error;
+
+    fn resolve(&self, _name: &str) -> Result<Vec<IpAddr>, Self::Error> {
+        Ok(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(address) = String::from_utf8(data.to_vec()) else {
+        return;
+    };
+
+    let Ok(parsed_address) =
+        BitcoinSocketAddr::parse_address(&address, Some(Network::Bitcoin), FuzzResolver)
+    else {
+        return;
+    };
+
+    // Make sure the Display version matches what our parser expects.
+    let display_repr = parsed_address.to_string();
+    display_repr.parse::<BitcoinSocketAddr>().unwrap();
+});


### PR DESCRIPTION
### Description and Notes

Our code represents addresses in a scattered and messy way. Some places we use SocketAddr, some AddrV2 and some Strings. SocketAddr and Strings already wraps ports, while AddrV2 and IpAddr don't. Therefore some functions will ask for a `u16` and other won't. We also have parsing logic for addresses all over the code, repeating logic and creating inconsistecies. Finally, in some APIs we support names, and others don't, which is frustrating.

This type will encapsulate both addresses and ports, as AddrV2 it will work with non-ip addresses such as Tor and I2P. It also supports name resolution.

It exposes a few conversion primitives to make it into other types if this is required in specific scopes, but overall we should use this type to represent Bitcoin node addresses.

Note: This used to be part of another PR to implement Onion addresses (we currently can't connect to `.onion` addresses), but got too big and I decided to split it up. Without these changes, it would be impossible to have those as well.