### PR TITLE
[FIX] [RPC] Align getrawtransaction with Bitcoin Core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,9 +666,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-types"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6ea6101b2da248ff9c7e0ead02c6e0b8243db140d86c6190e1b043c306d97a"
+checksum = "f095534efdb8f2f43d48b9c3e9f35aefdf29ec6a5f1895064f575a67bc2a8dfe"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ readme = "README.md"
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
 bitcoin = { version = "=0.32.8", default-features = false }
 clap = { version = "=4.6.1", default-features = false, features = ["derive", "std"] }
-corepc-types = { version = "=0.11.0" }
+corepc-types = "=0.14.0"
 console-subscriber = { version = "=0.5.0", default-features = false }
 dns-lookup = { version = "=2.1.1" }
 hex = { version = "=0.4.3" }

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -230,7 +230,13 @@ pub enum Methods {
     },
 
     /// Returns the transaction, assuming it is cached by our watch only wallet
-    #[command(name = "getrawtransaction")]
+    #[doc = include_str!("../../../doc/rpc/getrawtransaction.md")]
+    #[command(
+        name = "getrawtransaction",
+        about = "Returns raw transaction data for a given txid from wallet cache (controlled by verbosity level)",
+        long_about = Some(include_str!("../../../doc/rpc/getrawtransaction.md")),
+        disable_help_subcommand = true
+    )]
     GetRawTransaction { txid: Txid, verbosity: Option<u8> },
 
     #[doc = include_str!("../../../doc/rpc/rescanblockchain.md")]

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -70,9 +70,10 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::GetTxOutProof { txids, blockhash } => {
             serde_json::to_string_pretty(&client.get_txout_proof(txids, blockhash))?
         }
-        Methods::GetTransaction { txid, .. } => {
-            serde_json::to_string_pretty(&client.get_transaction(txid, Some(true))?)?
-        }
+        Methods::GetRawTransaction {
+            txid,
+            verbosity: verbose,
+        } => serde_json::to_string_pretty(&client.get_raw_transaction(txid, verbose)?)?,
         Methods::RescanBlockchain {
             start_block,
             stop_block,
@@ -229,8 +230,8 @@ pub enum Methods {
     },
 
     /// Returns the transaction, assuming it is cached by our watch only wallet
-    #[command(name = "gettransaction")]
-    GetTransaction { txid: Txid, verbose: Option<bool> },
+    #[command(name = "getrawtransaction")]
+    GetRawTransaction { txid: Txid, verbosity: Option<u8> },
 
     #[doc = include_str!("../../../doc/rpc/rescanblockchain.md")]
     #[command(

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -17,7 +17,7 @@ use bitcoin::consensus::Encodable;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::constants::genesis_block;
 use bitcoin::hashes::Hash;
-use corepc_types::ScriptPubkey;
+use corepc_types::ScriptPubKey;
 use corepc_types::v29::GetTxOut;
 use corepc_types::v30::DeploymentInfo;
 use corepc_types::v30::GetBlockHeaderVerbose;
@@ -644,7 +644,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 };
 
                 let asm = Self::to_core_asm_string(&txout.script_pubkey)?;
-                let script_pubkey = ScriptPubkey {
+                let script_pubkey = ScriptPubKey {
                     asm,
                     hex: txout.script_pubkey.to_hex_string(),
                     descriptor,

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -41,6 +41,7 @@ use super::server::RpcImpl;
 use crate::json_rpc::res::GetBlockRes;
 use crate::json_rpc::res::RescanConfidence;
 use crate::json_rpc::server::SERIALIZATION_EXPECT_MSG;
+use crate::json_rpc::server::to_core_asm_string;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     async fn get_block_inner(&self, hash: BlockHash) -> Result<Block, JsonRpcError> {
@@ -471,7 +472,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
     /// Returns a label about the scriptPubKey type
     /// (pubkey, pubkeyhash, multisig, nulldata, scripthash, witness_v0_keyhash, witness_v0_scripthash, witness_v1_taproot, anchor, nonstandard)
-    fn get_script_type_label(script: &Script) -> &'static str {
+    pub(super) fn get_script_type_label(script: &Script) -> &'static str {
         if script.is_p2pk() {
             return "pubkey";
         }
@@ -511,20 +512,15 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         "nonstandard"
     }
 
-    fn get_script_type_descriptor(script: &Script, address: &Option<Address>) -> String {
-        let get_addr_str = || {
-            address
-                .as_ref()
-                .expect("address should be Some")
-                .to_string()
-        };
-
-        if script.is_p2pk() {
-            let addr = get_addr_str();
-            return format!("pk({addr}");
-        }
-
+    /// TODO: This function is not compliant with Bitcoin Core.
+    /// See: <https://github.com/getfloresta/Floresta/issues/987>
+    pub(super) fn get_script_type_descriptor(script: &Script, address: &Option<Address>) -> String {
+        // Try script from the address
         if let Some(addr) = address {
+            if script.is_p2pk() {
+                return format!("pk({addr})");
+            }
+
             return format!("addr({addr})");
         }
 
@@ -533,83 +529,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             return format!("raw({hex})");
         }
 
-        if Self::is_anchor_type(script) {
-            let addr = get_addr_str();
-            return format!("addr({addr})");
-        }
-
         let hex = script.to_hex_string();
         format!("raw({hex})")
-    }
-
-    /// Parses the serialized opcodes in a [ScriptBuf] as numbers and it's hashes.
-    /// This differs from `ScriptBuf::to_asm_string` in that, `rust-bitcoin` will
-    /// show the the human representation of the opcode. It does not omit the number representations of
-    /// `OP_PUSHDATA_<N>` and `OP_PUSHBYTE<N>`. This method do the opposite: it not show the human
-    /// representation and omit the last opcodes, so it can be compliant with bitcoin-core.
-    /// For reference see <https://en.bitcoin.it/wiki/Script#Opcodes>
-    fn to_core_asm_string(script: &ScriptBuf) -> Result<String, JsonRpcError> {
-        let mut asm = vec![];
-        let bytes = script.as_bytes();
-        let mut i = 0usize;
-
-        // little reused helper to hex string
-        let to_hex_string = |r: &[u8]| r.iter().map(|b| format!("{b:02x}")).collect::<String>();
-
-        while i < bytes.len() {
-            let byte = bytes[i];
-            i += 1;
-
-            match byte {
-                // OP_0
-                0x00 => asm.push(format!("{}", 0)),
-                // OP_PUSHDATA_<N>: The next N bytes is data to be pushed onto the stack
-                0x01..=0x4b => {
-                    let pushed_bytes = byte as usize;
-                    let hex = to_hex_string(&bytes[i..i + pushed_bytes]);
-                    asm.push(hex);
-                    i += pushed_bytes;
-                }
-                // OP_PUSHBYTE1: the next byte contains the number of bytes to be pushed onto the stack.
-                0x4c => {
-                    let pushed_bytes = bytes[i] as usize;
-                    i += 1;
-                    let hex = to_hex_string(&bytes[i..i + pushed_bytes]);
-                    asm.push(hex);
-                    i += pushed_bytes;
-                }
-                // OP_PUSHBYTE2: the next two bytes contain the number of bytes to be pushed onto the stack in little endian order.
-                0x4d => {
-                    let pushed_bytes = u16::from_le_bytes([bytes[i], bytes[i + 1]]) as usize;
-                    i += 2;
-                    let hex = to_hex_string(&bytes[i..i + pushed_bytes]);
-                    asm.push(hex);
-                    i += pushed_bytes;
-                }
-                // OP_PUSHBYTE4: the next four bytes contain the number of bytes to be pushed onto the stack in little endian order.
-                0x4e => {
-                    let pushed_bytes =
-                        u32::from_le_bytes([bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]])
-                            as usize;
-                    i += 4;
-                    let hex = to_hex_string(&bytes[i..i + pushed_bytes]);
-                    asm.push(hex);
-                    i += pushed_bytes;
-                }
-                // OP_1 to OP_16
-                0x51..=0x60 => {
-                    // 0x50 is OP_RESERVED
-                    let reserved = 0x50;
-                    asm.push(format!("{}", byte - reserved));
-                }
-                // Any other opcode that should  be pushed
-                another_one => {
-                    asm.push(format!("{another_one:02x}"));
-                }
-            }
-        }
-
-        Ok(asm.join(" "))
     }
 
     /// gettxout: returns details about an unspent transaction output.
@@ -643,7 +564,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                     Err(_) => None,
                 };
 
-                let asm = Self::to_core_asm_string(&txout.script_pubkey)?;
+                let asm = to_core_asm_string(&txout.script_pubkey, false);
                 let script_pubkey = ScriptPubKey {
                     asm,
                     hex: txout.script_pubkey.to_hex_string(),

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -25,6 +25,7 @@ use core::fmt::Debug;
 
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
+use corepc_types::v30::GetRawTransactionVerbose;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -552,56 +553,12 @@ impl RescanConfidence {
     }
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct RawTxJson {
-    pub in_active_chain: bool,
-    pub hex: String,
-    pub txid: String,
-    pub hash: String,
-    pub size: u32,
-    pub vsize: u32,
-    pub weight: u32,
-    pub version: u32,
-    pub locktime: u32,
-    pub vin: Vec<TxInJson>,
-    pub vout: Vec<TxOutJson>,
-    pub blockhash: String,
-    pub confirmations: u32,
-    pub blocktime: u32,
-    pub time: u32,
-}
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetRawTransactionRes {
+    Zero(String),
 
-#[derive(Deserialize, Serialize)]
-pub struct TxOutJson {
-    pub value: u64,
-    pub n: u32,
-    pub script_pub_key: ScriptPubKeyJson,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct ScriptPubKeyJson {
-    pub asm: String,
-    pub hex: String,
-    pub req_sigs: u32,
-    #[serde(rename = "type")]
-    pub type_: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<String>,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct TxInJson {
-    pub txid: String,
-    pub vout: u32,
-    pub script_sig: ScriptSigJson,
-    pub sequence: u32,
-    pub witness: Vec<String>,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct ScriptSigJson {
-    pub asm: String,
-    pub hex: String,
+    One(Box<GetRawTransactionVerbose>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -17,7 +17,6 @@ use axum::http::Response as HttpResponse;
 use axum::http::StatusCode;
 use axum::routing::post;
 use bitcoin::Address;
-use bitcoin::BlockHash;
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
@@ -26,9 +25,16 @@ use bitcoin::TxOut;
 use bitcoin::Txid;
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::encode::serialize_hex;
-use bitcoin::hashes::Hash;
+use bitcoin::ecdsa::Signature as EcdsaSignature;
 use bitcoin::hashes::hex::FromHex;
+use bitcoin::hex;
 use bitcoin::hex::DisplayHex;
+use bitcoin::taproot::Signature as TaprootSignature;
+use corepc_types::ScriptPubKey;
+use corepc_types::ScriptSig;
+use corepc_types::v30::GetRawTransactionVerbose;
+use corepc_types::v31::RawTransactionInput;
+use corepc_types::v31::RawTransactionOutput;
 use floresta_chain::ThreadSafeChain;
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
 use floresta_compact_filters::network_filters::NetworkFilters;
@@ -46,11 +52,7 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
-use super::res::RawTxJson;
-use super::res::ScriptPubKeyJson;
-use super::res::ScriptSigJson;
-use super::res::TxInJson;
-use super::res::TxOutJson;
+use super::res::GetRawTransactionRes;
 use super::res::jsonrpc_interface::JsonRpcError;
 use crate::json_rpc::request::RpcRequest;
 use crate::json_rpc::request::arg_parser::get_at;
@@ -96,19 +98,21 @@ pub struct RpcImpl<Blockchain: RpcChain> {
 type Result<T> = std::result::Result<T, JsonRpcError>;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
-    fn get_raw_transaction(&self, tx_id: Txid, verbosity: u8) -> Result<Value> {
+    fn get_raw_transaction(&self, tx_id: Txid, verbosity: u8) -> Result<GetRawTransactionRes> {
+        if verbosity > 1 {
+            return Err(JsonRpcError::InvalidVerbosityLevel);
+        }
+
         let tx = self
             .wallet
             .get_transaction(&tx_id)
             .ok_or(JsonRpcError::TxNotFound)?;
 
         match verbosity {
-            0 => serde_json::to_value(serialize_hex(&tx.tx))
-                .map_err(|e| JsonRpcError::Decode(e.to_string())),
-            1 => {
-                let raw_tx = self.make_raw_transaction(tx)?;
-                serde_json::to_value(raw_tx).map_err(|e| JsonRpcError::Decode(e.to_string()))
-            }
+            0 => Ok(GetRawTransactionRes::Zero(serialize_hex(&tx.tx))),
+            1 => Ok(GetRawTransactionRes::One(Box::new(
+                self.make_raw_transaction(tx)?,
+            ))),
             _ => Err(JsonRpcError::InvalidVerbosityLevel),
         }
     }
@@ -530,113 +534,125 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         Ok(())
     }
 
-    fn make_vin(&self, input: TxIn) -> TxInJson {
-        let txid = serialize_hex(&input.previous_output.txid);
-        let vout = input.previous_output.vout;
+    fn make_vin(&self, input: TxIn, is_coinbase: bool) -> RawTransactionInput {
         let sequence = input.sequence.0;
-        TxInJson {
-            txid,
-            vout,
-            script_sig: ScriptSigJson {
-                asm: input.script_sig.to_asm_string(),
-                hex: input.script_sig.to_hex_string(),
-            },
-            witness: input
+        let txin_witness = (!input.witness.is_empty()).then_some(
+            input
                 .witness
                 .iter()
-                .map(|w| w.to_hex_string(bitcoin::hex::Case::Upper))
+                .map(|w| w.to_hex_string(hex::Case::Lower))
                 .collect(),
+        );
+
+        if is_coinbase {
+            return RawTransactionInput {
+                coinbase: Some(input.script_sig.to_hex_string()),
+                sequence,
+                txin_witness,
+                script_sig: None,
+                txid: None,
+                vout: None,
+            };
+        }
+
+        let txid = Some(input.previous_output.txid.to_string());
+        let vout = Some(input.previous_output.vout);
+        let script_sig = ScriptSig {
+            asm: to_core_asm_string(&input.script_sig, true),
+            hex: input.script_sig.to_hex_string(),
+        };
+
+        RawTransactionInput {
+            coinbase: None,
+            txid,
+            vout,
+            script_sig: Some(script_sig),
+            txin_witness,
             sequence,
         }
     }
 
-    fn get_script_type(script: ScriptBuf) -> Option<&'static str> {
-        if script.is_p2pkh() {
-            return Some("p2pkh");
-        }
-        if script.is_p2sh() {
-            return Some("p2sh");
-        }
-        if script.is_p2wpkh() {
-            return Some("v0_p2wpkh");
-        }
-        if script.is_p2wsh() {
-            return Some("v0_p2wsh");
-        }
-        None
-    }
-
-    fn make_vout(&self, output: TxOut, n: u32) -> TxOutJson {
+    fn make_vout(&self, output: TxOut, index: u64) -> RawTransactionOutput {
         let value = output.value;
-        TxOutJson {
-            value: value.to_sat(),
-            n,
-            script_pub_key: ScriptPubKeyJson {
-                asm: output.script_pubkey.to_asm_string(),
+        RawTransactionOutput {
+            value: value.to_btc(),
+            index,
+            script_pubkey: ScriptPubKey {
+                asm: to_core_asm_string(&output.script_pubkey, false),
                 hex: output.script_pubkey.to_hex_string(),
-                req_sigs: 0, // This field is deprecated
                 // `Address::from_script` can fail for nonstandard scripts. Bitcoin Core
                 // omits the `address` field entirely when `ExtractDestination` fails:
                 // https://github.com/bitcoin/bitcoin/blob/f50d53c84736f8ada8419346c4d1734d5a6686d4/src/core_io.cpp#L424
                 address: Address::from_script(&output.script_pubkey, self.network)
-                    .ok()
-                    .map(|a| a.to_string()),
-                type_: Self::get_script_type(output.script_pubkey)
-                    .unwrap_or("nonstandard")
-                    .to_string(),
+                    .map(|a| a.to_string())
+                    .ok(),
+                type_: Self::get_script_type_label(&output.script_pubkey).to_string(),
+                descriptor: Some(Self::get_script_type_descriptor(
+                    &output.script_pubkey,
+                    &Address::from_script(&output.script_pubkey, self.network).ok(),
+                )),
+                required_signatures: None, // This field is deprecated in Core v22
+                addresses: None,           // This field is deprecated in Core v22
             },
         }
     }
 
-    fn make_raw_transaction(&self, tx: CachedTransaction) -> Result<RawTxJson> {
+    fn make_raw_transaction(&self, tx: CachedTransaction) -> Result<GetRawTransactionVerbose> {
         let raw_tx = tx.tx;
         let in_active_chain = tx.height != 0;
         let hex = serialize_hex(&raw_tx);
-        let txid = serialize_hex(&raw_tx.compute_txid());
-        let block_hash = self
-            .chain
-            .get_block_hash(tx.height)
-            .unwrap_or(BlockHash::all_zeros());
-        let tip = self.chain.get_height().map_err(|_| JsonRpcError::Chain)?;
-        let confirmations = if in_active_chain {
-            tip - tx.height + 1
-        } else {
-            0
-        };
+        let txid = raw_tx.compute_txid().to_string();
 
-        Ok(RawTxJson {
-            in_active_chain,
+        let mut block_hash = None;
+        let mut block_time = None;
+        let mut transaction_time = None;
+        let mut confirmations = Some(0);
+        if in_active_chain {
+            confirmations = self.chain.get_height().ok().and_then(|tip| {
+                if tip >= tx.height {
+                    Some((tip - tx.height + 1).into())
+                } else {
+                    None
+                }
+            });
+
+            if let Ok(hash) = self.chain.get_block_hash(tx.height) {
+                if let Ok(header) = self.chain.get_block_header(&hash) {
+                    block_hash = Some(header.block_hash().to_string());
+                    block_time = Some(header.time.into());
+                    transaction_time = Some(header.time.into());
+                }
+            }
+        }
+
+        Ok(GetRawTransactionVerbose {
+            in_active_chain: Some(in_active_chain),
             hex,
             txid,
-            hash: serialize_hex(&raw_tx.compute_wtxid()),
-            size: raw_tx.total_size() as u32,
-            vsize: raw_tx.vsize() as u32,
-            weight: raw_tx.weight().to_wu() as u32,
-            version: raw_tx.version.0 as u32,
-            locktime: raw_tx.lock_time.to_consensus_u32(),
-            vin: raw_tx
+            hash: raw_tx.compute_wtxid().to_string(),
+            size: raw_tx.total_size().try_into()?,
+            vsize: raw_tx.vsize().try_into()?,
+            weight: raw_tx.weight().to_wu(),
+            version: raw_tx.version.0,
+            lock_time: raw_tx.lock_time.to_consensus_u32(),
+            inputs: raw_tx
                 .input
                 .iter()
-                .map(|input| self.make_vin(input.clone()))
+                .map(|input| self.make_vin(input.clone(), raw_tx.is_coinbase()))
                 .collect(),
-            vout: raw_tx
+            outputs: raw_tx
                 .output
                 .into_iter()
                 .enumerate()
-                .map(|(i, output)| self.make_vout(output, i as u32))
-                .collect(),
-            blockhash: serialize_hex(&block_hash),
+                .map(|(i, output)| -> Result<RawTransactionOutput> {
+                    let index = i.try_into()?;
+                    Ok(self.make_vout(output, index))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            block_hash,
             confirmations,
-            blocktime: self
-                .chain
-                .get_block_header(&block_hash)
-                .map(|h| h.time)
-                .unwrap_or(0),
-            time: self
-                .chain
-                .get_block_header(&block_hash)
-                .map(|h| h.time)
-                .unwrap_or(0),
+            block_time,
+            transaction_time,
         })
     }
 
@@ -711,5 +727,168 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         axum::serve(listener, router)
             .await
             .expect("failed to start rpc server");
+    }
+}
+
+/// Converts a script to ASM (assembly) format, displaying the script's operations
+/// in a format similar to Bitcoin Core.
+///
+/// This function performs the following transformations:
+/// 1. Removes OP_PUSHBYTES and OP_PUSHDATA opcodes (these are unnecessary in ASM output)
+/// 2. Converts leading OP_0 to "0" and OP_PUSHNUM_1 to "1" (these represent witness versions)
+/// 3. If `attempt_sighash_decode` is true, attempts to decode hexadecimal data as signatures
+///    and appends their sighash type (useful for analyzing scripts in scriptSig)
+///
+/// # Arguments
+/// * `script` - The script buffer to convert
+/// * `attempt_sighash_decode` - If true, tries to parse data elements as signatures and format them
+pub(super) fn to_core_asm_string(script: &ScriptBuf, attempt_sighash_decode: bool) -> String {
+    let mut script_asm = script.to_asm_string();
+    if !script_asm.contains(' ') {
+        return script_asm;
+    }
+
+    // Remove OP_PUSHBYTES_X opcodes (these are only metadata for script serialization)
+    for i in 0..=75 {
+        script_asm = script_asm.replace(&format!("OP_PUSHBYTES_{} ", i), "");
+    }
+
+    // Remove OP_PUSHDATA1/2/4 opcodes (these are only metadata for script serialization)
+    for i in 1..=4 {
+        script_asm = script_asm.replace(&format!("OP_PUSHDATA{} ", i), "");
+    }
+
+    let mut array_script_asm: Vec<String> = script_asm.split(' ').map(String::from).collect();
+
+    // Convert leading OP_0 to "0" - represents witness version 0
+    if array_script_asm[0] == "OP_0" {
+        array_script_asm[0] = "0".to_string();
+    }
+
+    // Convert leading OP_PUSHNUM_1 to "1" - represents witness version 1 (Taproot)
+    if array_script_asm[0] == "OP_PUSHNUM_1" {
+        array_script_asm[0] = "1".to_string();
+    }
+
+    // If enabled, attempt to decode data elements as signatures and format them
+    // This is particularly useful for scriptSig analysis, where signatures are wrapped with their sighash type
+    if attempt_sighash_decode {
+        for word in array_script_asm.iter_mut() {
+            // Skip OP codes and small words that are unlikely to be signatures
+            if word.contains("OP") || word.len() <= 8 {
+                continue;
+            }
+
+            if let Some(decoded) =
+                try_parse_and_format_signature(&Vec::from_hex(word).unwrap_or_default())
+            {
+                *word = decoded;
+            }
+        }
+    }
+
+    array_script_asm.join(" ")
+}
+
+/// Attempts to decode a byte slice as a valid signature (ECDSA or Taproot).
+/// If the bytes represent a valid signature, returns the signature with the sighash type appended.
+fn try_parse_and_format_signature(signature_bytes: &[u8]) -> Option<String> {
+    macro_rules! try_decode_signature {
+        ($sig_type:ty) => {
+            if let Ok(signature) = <$sig_type>::from_slice(signature_bytes) {
+                // Extract the sighash type and remove the "SIGHASH_" prefix
+                // The rust-bitcoin library prefixes "SIGHASH_" to the type name, but Bitcoin Core
+                // does not include this prefix in the output
+                let label = signature.sighash_type.to_string().replace("SIGHASH_", "");
+                return Some(format!("{}[{}]", signature.signature, label));
+            }
+        };
+    }
+
+    // Attempt to parse as ECDSA signature
+    try_decode_signature!(EcdsaSignature);
+
+    // Attempt to parse as Taproot signature
+    try_decode_signature!(TaprootSignature);
+
+    // If the bytes don't match any known signature format, return None
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_converter_script_into_asm_not_attempt_sighash_decode() {
+        let test_cases = [
+            // P2WPKH
+            (
+                "0014aabc2cd363103811113b040c541afe3759489c96",
+                "0 aabc2cd363103811113b040c541afe3759489c96",
+            ),
+            // BECH32
+            (
+                "0014251619c32f6500664e71a6d0393ec4b5f6da549c",
+                "0 251619c32f6500664e71a6d0393ec4b5f6da549c",
+            ),
+            (
+                "0014aa138477d24cb7b7a84160ef55af14b7bfb98143",
+                "0 aa138477d24cb7b7a84160ef55af14b7bfb98143",
+            ),
+            // P2PKH
+            (
+                "76a914e7d68c17e6275b2e5c1da053ef648c676c38962488ac",
+                "OP_DUP OP_HASH160 e7d68c17e6275b2e5c1da053ef648c676c389624 OP_EQUALVERIFY OP_CHECKSIG",
+            ),
+            (
+                "76a9144eb2df72d9befff81b6dd985044d2d1b3ed4de4188ac",
+                "OP_DUP OP_HASH160 4eb2df72d9befff81b6dd985044d2d1b3ed4de41 OP_EQUALVERIFY OP_CHECKSIG",
+            ),
+            // P2SH
+            (
+                "a914fae946075d1f629d35ed4067eca928c1632f4fef87",
+                "OP_HASH160 fae946075d1f629d35ed4067eca928c1632f4fef OP_EQUAL",
+            ),
+            // P2TR (Taproot)
+            (
+                "51209ec7be23a1ec17cd9c4b621d899eec02bacde1d754ab080f9e1ac8445820014e",
+                "1 9ec7be23a1ec17cd9c4b621d899eec02bacde1d754ab080f9e1ac8445820014e",
+            ),
+        ];
+
+        for (script_hex, expected_asm) in test_cases.iter() {
+            let script = ScriptBuf::from_hex(script_hex).unwrap();
+            let asm = to_core_asm_string(&script, false);
+
+            assert_eq!(asm, *expected_asm);
+        }
+    }
+
+    #[test]
+    fn test_converter_script_into_asm_attempt_sighash_decode() {
+        let test_cases = [
+            // scriptSig with ECDSA signature and pubkey
+            (
+                "47304402205a9b7c4432f9d895cbf4ac78519ae4e9776d47776078521b93e06beda560dd9a02202b1afbda3c917c2698b38f78203e03d2743069939e3ce2b6a3a153e148502f19012103fde976887234670c672e33a4707356997df737f3e7ac6de809164b5a606b8bad",
+                "304402205a9b7c4432f9d895cbf4ac78519ae4e9776d47776078521b93e06beda560dd9a02202b1afbda3c917c2698b38f78203e03d2743069939e3ce2b6a3a153e148502f19[ALL] 03fde976887234670c672e33a4707356997df737f3e7ac6de809164b5a606b8bad",
+            ),
+            (
+                "47304402204ab6753b249205b01d938826189cefaa4176e32ca5aa64fc6fd51891fb78fed2022065b7ba08d8739884ba232f5f7bf6efbb36b2cf98917630c64343cad2fe9db3a2012102ecf8dfb67cae8fe66d700cb13c458e5cc59be2a1c5f3ca3c5a54745259cbe45c",
+                "304402204ab6753b249205b01d938826189cefaa4176e32ca5aa64fc6fd51891fb78fed2022065b7ba08d8739884ba232f5f7bf6efbb36b2cf98917630c64343cad2fe9db3a2[ALL] 02ecf8dfb67cae8fe66d700cb13c458e5cc59be2a1c5f3ca3c5a54745259cbe45c",
+            ),
+            // P2WPKH
+            (
+                "160014bb180b7bf33f066f7b557c09a0bd3b6accc84fcf",
+                "0014bb180b7bf33f066f7b557c09a0bd3b6accc84fcf",
+            ),
+        ];
+
+        for (script_hex, expected_asm) in test_cases.iter() {
+            let script = ScriptBuf::from_hex(script_hex).unwrap();
+            let asm = to_core_asm_string(&script, true);
+
+            assert_eq!(asm, *expected_asm);
+        }
     }
 }

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -96,24 +96,21 @@ pub struct RpcImpl<Blockchain: RpcChain> {
 type Result<T> = std::result::Result<T, JsonRpcError>;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
-    fn get_transaction(&self, tx_id: Txid, verbosity: bool) -> Result<Value> {
-        if verbosity {
-            let tx = self
-                .wallet
-                .get_transaction(&tx_id)
-                .ok_or(JsonRpcError::TxNotFound)?;
-            let raw = self.make_raw_transaction(tx)?;
-            return Ok(serde_json::to_value(raw).expect(SERIALIZATION_EXPECT_MSG));
-        }
-
-        self.wallet
+    fn get_raw_transaction(&self, tx_id: Txid, verbosity: u8) -> Result<Value> {
+        let tx = self
+            .wallet
             .get_transaction(&tx_id)
-            .and_then(|tx| {
-                self.make_raw_transaction(tx)
-                    .ok()
-                    .and_then(|v| serde_json::to_value(v).ok())
-            })
-            .ok_or(JsonRpcError::TxNotFound)
+            .ok_or(JsonRpcError::TxNotFound)?;
+
+        match verbosity {
+            0 => serde_json::to_value(serialize_hex(&tx.tx))
+                .map_err(|e| JsonRpcError::Decode(e.to_string())),
+            1 => {
+                let raw_tx = self.make_raw_transaction(tx)?;
+                serde_json::to_value(raw_tx).map_err(|e| JsonRpcError::Decode(e.to_string()))
+            }
+            _ => Err(JsonRpcError::InvalidVerbosityLevel),
+        }
     }
 
     fn load_descriptor(&self, descriptor: String) -> Result<bool> {
@@ -379,10 +376,10 @@ async fn handle_json_rpc_request(
 
         "getrawtransaction" => {
             let txid = get_at(&params, 0, "txid")?;
-            let verbosity = get_with_default(&params, 1, "verbosity", false)?;
+            let verbosity = get_with_default(&params, 1, "verbosity", 0)?;
 
             state
-                .get_transaction(txid, verbosity)
+                .get_raw_transaction(txid, verbosity)
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }
 

--- a/crates/floresta-node/src/lib.rs
+++ b/crates/floresta-node/src/lib.rs
@@ -11,7 +11,7 @@ mod config_file;
 mod error;
 mod florestad;
 #[cfg(feature = "json-rpc")]
-#[deny(clippy::unwrap_used)]
+#[cfg_attr(not(test), deny(clippy::unwrap_used))]
 mod json_rpc;
 #[cfg(feature = "zmq-server")]
 mod zmq;

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -60,7 +60,11 @@ pub trait FlorestaRPC {
     /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
     /// set to 0, the transaction is returned as a hexadecimal string. If the verbosity
     /// flag is set to 1, the transaction is returned as a json object.
-    fn get_raw_transaction(&self, tx_id: Txid, verbosity: Option<u8>) -> Result<Value>;
+    fn get_raw_transaction(
+        &self,
+        tx_id: Txid,
+        verbosity: Option<u8>,
+    ) -> Result<GetRawTransactionRes>;
     /// Returns the proof that one or more transactions were included in a block
     ///
     /// This method returns the Merkle proof, showing that a transaction was included in a block.
@@ -333,7 +337,11 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockhash", &[Value::Number(Number::from(height))])
     }
 
-    fn get_raw_transaction(&self, tx_id: Txid, verbosity: Option<u8>) -> Result<Value> {
+    fn get_raw_transaction(
+        &self,
+        tx_id: Txid,
+        verbosity: Option<u8>,
+    ) -> Result<GetRawTransactionRes> {
         let mut params = vec![Value::String(tx_id.to_string())];
 
         if let Some(verbosity) = verbosity {

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -58,9 +58,9 @@ pub trait FlorestaRPC {
     /// Gets a transaction from the blockchain
     ///
     /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
-    /// set to false, the transaction is returned as a hexadecimal string. If the verbosity
-    /// flag is set to true, the transaction is returned as a json object.
-    fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value>;
+    /// set to 0, the transaction is returned as a hexadecimal string. If the verbosity
+    /// flag is set to 1, the transaction is returned as a json object.
+    fn get_raw_transaction(&self, tx_id: Txid, verbosity: Option<u8>) -> Result<Value>;
     /// Returns the proof that one or more transactions were included in a block
     ///
     /// This method returns the Merkle proof, showing that a transaction was included in a block.
@@ -333,12 +333,14 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockhash", &[Value::Number(Number::from(height))])
     }
 
-    fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value> {
-        let verbosity = verbosity.unwrap_or(false);
-        self.call(
-            "gettransaction",
-            &[Value::String(tx_id.to_string()), Value::Bool(verbosity)],
-        )
+    fn get_raw_transaction(&self, tx_id: Txid, verbosity: Option<u8>) -> Result<Value> {
+        let mut params = vec![Value::String(tx_id.to_string())];
+
+        if let Some(verbosity) = verbosity {
+            params.push(Value::Number(Number::from(verbosity)));
+        }
+
+        self.call("getrawtransaction", &params)
     }
 
     fn load_descriptor(&self, descriptor: String) -> Result<bool> {

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
 pub use corepc_types::v30::GetNetworkInfo;
+use corepc_types::v31::GetRawTransactionVerbose;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -18,107 +19,12 @@ use serde::Serialize;
 /// by btc core.
 pub struct GetTxOutProof(pub Vec<u8>);
 
-/// The information returned by a get_raw_tx
-#[derive(Deserialize, Serialize)]
-pub struct RawTx {
-    /// Whether this tx is in our best known chain
-    pub in_active_chain: bool,
-    /// The hex-encoded tx
-    pub hex: String,
-    /// The sha256d of the serialized transaction without witness
-    pub txid: String,
-    /// The sha256d of the serialized transaction including witness
-    pub hash: String,
-    /// The size this transaction occupies on disk
-    pub size: u32,
-    /// The virtual size of this transaction, as define by the segwit soft-fork
-    pub vsize: u32,
-    /// The weight of this transaction, as defined by the segwit soft-fork
-    pub weight: u32,
-    /// This transaction's version. The current bigger version is 2
-    pub version: u32,
-    /// This transaction's locktime
-    pub locktime: u32,
-    /// A list of inputs being spent by this transaction
-    ///
-    /// See [TxIn] for more information about the contents of this
-    pub vin: Vec<TxIn>,
-    /// A list of outputs being created by this tx
-    ///
-    /// Se [TxOut] for more information
-    pub vout: Vec<TxOut>,
-    /// The hash of the block that included this tx, if any
-    pub blockhash: String,
-    /// How many blocks have been mined after this transaction's confirmation
-    /// including the block that confirms it. A zero value means this tx is unconfirmed
-    pub confirmations: u32,
-    /// The timestamp for the block confirming this tx, if confirmed
-    pub blocktime: u32,
-    /// Same as blocktime
-    pub time: u32,
-}
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetRawTransactionRes {
+    Zero(String),
 
-/// A transaction output returned by some RPCs like gettransaction and getblock
-#[derive(Deserialize, Serialize)]
-pub struct TxOut {
-    /// The amount in sats locked in this UTXO
-    pub value: u64,
-    /// This utxo's index inside the transaction
-    pub n: u32,
-    /// The locking script of this utxo
-    pub script_pub_key: ScriptPubKey,
-}
-
-/// The locking script inside a txout
-#[derive(Deserialize, Serialize)]
-pub struct ScriptPubKey {
-    /// A ASM representation for this script
-    ///
-    /// Assembly is a high-level representation of a lower level code. Instructions
-    /// are turned into OP_XXXXX and data is hex-encoded.
-    /// E.g: OP_DUP OP_HASH160 <0000000000000000000000000000000000000000> OP_EQUALVERIFY OP_CHECKSIG
-    pub asm: String,
-    /// The hex-encoded raw script
-    pub hex: String,
-    /// How many signatures are required to spend this UTXO.
-    ///
-    /// This field is deprecated and is here for compatibility with Core
-    pub req_sigs: u32,
-    #[serde(rename = "type")]
-    /// The type of this spk. E.g: PKH, SH, WSH, WPKH, TR, non-standard...
-    pub type_: String,
-    /// Encode this script using one of the standard address types, if possible
-    pub address: String,
-}
-
-/// A transaction input returned by some rpcs, like gettransaction and getblock
-#[derive(Deserialize, Serialize)]
-pub struct TxIn {
-    /// The txid that created this UTXO
-    pub txid: String,
-    /// The index of this UTXO inside the tx that created it
-    pub vout: u32,
-    /// Unlocking script that should solve the challenge and prove ownership over
-    /// that UTXO
-    pub script_sig: ScriptSigJson,
-    /// The nSequence field, used in relative and absolute lock-times
-    pub sequence: u32,
-    /// A vector of witness elements for this input
-    pub witness: Vec<String>,
-}
-
-/// A representation for the transaction ScriptSig, returned by some rpcs
-/// like gettransaction and getblock
-#[derive(Deserialize, Serialize)]
-pub struct ScriptSigJson {
-    /// A ASM representation for this scriptSig
-    ///
-    /// Assembly is a high-level representation of a lower level code. Instructions
-    /// are turned into OP_XXXXX and data is hex-encoded.
-    /// E.g: OP_PUSHBYTES32 <000000000000000000000000000000000000000000000000000000000000000000>
-    pub asm: String,
-    /// The hex-encoded script sig
-    pub hex: String,
+    One(Box<GetRawTransactionVerbose>),
 }
 
 /// General information about our peers. Returned by get_peer_info

--- a/doc/rpc/getrawtransaction.md
+++ b/doc/rpc/getrawtransaction.md
@@ -1,0 +1,85 @@
+# `getrawtransaction`
+
+Returns a transaction that is cached in the wallet. This method retrieves transactions
+that have been tracked and indexed by the wallet during blockchain synchronization or
+through explicit tracking. The response format can be controlled via the verbosity parameter.
+
+## Usage
+
+### Synopsis
+
+```
+floresta-cli getrawtransaction <txid> [<verbosity>]
+```
+
+### Examples
+
+```bash
+# Get transaction as serialized hex string
+floresta-cli getrawtransaction "d7d7558342e3aff8fc4ae0a84bc7d19c0add4dfa1a3c0fa56cf66dc4f2400145"
+
+# Get transaction as detailed JSON object
+floresta-cli getrawtransaction "d7d7558342e3aff8fc4ae0a84bc7d19c0add4dfa1a3c0fa56cf66dc4f2400145" 1
+
+# Default behavior (hex format)
+floresta-cli getrawtransaction "d7d7558342e3aff8fc4ae0a84bc7d19c0add4dfa1a3c0fa56cf66dc4f2400145" 0
+```
+
+## Arguments
+
+-`txid` - (string, required) The transaction ID to retrieve.
+- `verbosity` - (numeric, optional, default=1)
+  * `0`: Returns transaction as a raw serialized hexadecimal string.
+  * `1`: Returns transaction as a detailed JSON object with decoded fields.
+
+## Returns
+
+### Ok Response (verbosity = 0)
+
+- `"hex"` - (string) A serialized, hex-encoded string of the transaction data.
+
+### Ok Response (verbosity = 1)
+
+- `in_active_chain` - (boolean) Whether the transaction is in the active blockchain
+- `blockhash` - (string, optional) The block hash containing this transaction
+- `confirmations` - (numeric, optional) Number of confirmations (0 if in mempool)
+- `blocktime` - (numeric, optional) Block creation time as Unix timestamp
+- `time` - (numeric, optional) Transaction time as Unix timestamp
+- `hex` - (string) The serialized, hex-encoded data for 'txid'
+- `txid` - (string) The transaction id (same as provided)
+- `hash` - (string) The transaction hash (differs from txid for witness transactions)
+- `size` - (numeric) The transaction size in bytes
+- `vsize` - (numeric) The virtual transaction size (differs from size for witness transactions)
+- `weight` - (numeric) The transaction's weight (between vsize*4-3 and vsize*4)
+- `version` - (numeric) The transaction version
+- `locktime` - (numeric) The block height or timestamp at which transaction is final
+- `vin` - (array) Array of transaction inputs
+  * `coinbase` - (string) The hex-encoded coinbase script data. **Only if coinbase transaction**
+  * `txid` - (string) The previous transaction ID. **Only if non-coinbase transaction**
+  * `vout` - (numeric) The output index in the previous transaction. **Only if non-coinbase transaction**
+  * `script_sig` - (object) Contains the scriptSig. **Only if non-coinbase transaction**
+    - `hex` - (string) The script hex
+  * `sequence` - (numeric) The sequence number
+  * `txinwitness` - (array, optional) Witness stack
+    - `hex` - (string) hex-encoded witness data (if any)
+- `vout` - (array) Array of transaction outputs
+  * `value` - (numeric) Amount in btc
+  * `n` - (numeric) The output index
+  * `script_pub_key` - (object) Contains the scriptPubKey
+    - `asm` - (string) Disassembly of the output script
+    - `hex` - (string) The raw output script bytes, hex-encoded
+    - `type` - (string) The type of script (pubkey, pubkeyhash, multisig, etc.)
+    - `address` - (string, optional) The Bitcoin address (if applicable)
+
+### Error Enum `JsonRpcError`
+
+- `TxNotFound` - The requested transaction is not found in the wallet cache
+- `InvalidVerbosityLevel` - Verbosity parameter is not 0 or 1
+- `MissingParameter` - The txid parameter was not provided
+- `InvalidParameterType` - The txid is not a valid hex string
+- `Decode` - Error during transaction decoding or serialization
+
+## Notes
+
+- It only returns transactions belonging to the wallet, so to use it, descriptors must have been provided
+to the node beforehand.

--- a/tests/floresta-cli/getblock.py
+++ b/tests/floresta-cli/getblock.py
@@ -10,6 +10,7 @@ import time
 import random
 from typing import Any
 import pytest
+from test_framework.util import compare_fields
 
 
 class TestGetBlock:
@@ -71,12 +72,7 @@ class TestGetBlock:
         floresta_block = self.florestad.rpc.get_block(block_hash, 1)
         bitcoind_block = self.bitcoind.rpc.get_block(block_hash, 1)
 
-        for key, bval in bitcoind_block.items():
-            fval = floresta_block[key]
-
-            self.log.info(f"Comparing {key} field: floresta={fval} bitcoind={bval}")
-            if key == "difficulty":
-                # Allow small differences in floating point representation
-                assert round(fval, 3) == round(bval, 3)
-            else:
-                assert fval == bval
+        compare_fields(
+            floresta_block,
+            bitcoind_block,
+        )

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -11,7 +11,7 @@ failures rather than silent drift.
 
 import pytest
 
-from test_framework.util import wait_until
+from test_framework.util import wait_until, compare_fields
 
 MINE_BLOCKS = 10
 EXTRA_BLOCKS = 5
@@ -35,15 +35,11 @@ def test_get_blockchain_info(node_manager, florestad_bitcoind_utreexod_with_chai
     floresta_info = florestad.rpc.get_blockchain_info()
     bitcoind_info = bitcoind.rpc.get_blockchain_info()
 
-    for key, bval in bitcoind_info.items():
-        if key in FLORESTA_SPECIFIC_FIELDS:
-            continue
-        fval = floresta_info[key]
-        if key == "difficulty":
-            # Allow float rounding noise.
-            assert round(fval, 3) == round(bval, 3)
-        else:
-            assert fval == bval, f"{key}: floresta={fval} bitcoind={bval}"
+    compare_fields(
+        floresta_info,
+        bitcoind_info,
+        ignore_fields=FLORESTA_SPECIFIC_FIELDS,
+    )
 
     # size_on_disk: well-formed, grows after mining.
     size_before = floresta_info["size_on_disk"]

--- a/tests/floresta-cli/getblockheader.py
+++ b/tests/floresta-cli/getblockheader.py
@@ -11,6 +11,7 @@ import random
 from typing import Any
 import pytest
 from requests.exceptions import HTTPError
+from test_framework.util import compare_fields
 
 TIMEOUT_SECONDS = 20
 
@@ -94,7 +95,7 @@ class TestGetBlockheader:
         self.log.info("Fetching request without verbosity")
         florestad_header = self.florestad.rpc.get_blockheader(block_hash)
         bitcoind_header = self.bitcoind.rpc.get_blockheader(block_hash)
-        self.validate_headers_match(florestad_header, bitcoind_header)
+        compare_fields(florestad_header, bitcoind_header)
 
         verbosity = False
         self.log.info(f"Fetching request with verbosity {verbosity}")
@@ -107,18 +108,4 @@ class TestGetBlockheader:
         florestad_header = self.florestad.rpc.get_blockheader(block_hash, verbosity)
         bitcoind_header = self.bitcoind.rpc.get_blockheader(block_hash, verbosity)
 
-        self.validate_headers_match(florestad_header, bitcoind_header)
-
-    def validate_headers_match(self, florestad_header: dict, bitcoind_header: dict):
-        """
-        Compare two block headers and assert that they match.
-        """
-        for key, bval in bitcoind_header.items():
-            fval = florestad_header[key]
-
-            self.log.info(f"Comparing {key} field: florestad={fval} bitcoind={bval}")
-            if key == "difficulty":
-                # Allow small differences in floating point representation
-                assert round(fval, 3) == round(bval, 3)
-            else:
-                assert fval == bval
+        compare_fields(florestad_header, bitcoind_header)

--- a/tests/floresta-cli/getrawtransaction.py
+++ b/tests/floresta-cli/getrawtransaction.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getrawtransaction.py
+
+Integrate test for the CLI utility that interacts with a Floresta node
+using the `getrawtransaction` RPC method.
+"""
+
+import time
+import os
+import pytest
+from test_framework.node import NodeType
+from test_framework.util import compare_fields
+
+ADDRESS_COINBASE = "bcrt1q4gfcga7jfjmm02zpvrh4ttc5k7lmnq2re52z2y"
+ADDRESS_LEGACY = "n2eoQNSGg7ZWjnbXzdnGDMHZShn3MjaEfR"
+ADDRESS_P2PKH = "mnh5HKWqsYdRo8ChUc2rN9bDcMRj4HopFw"
+ADDRESS_P2PWH = "2NG7vNNXVRMihLD14WBbxhMxEQ1qKBkepq1"
+ADDRESS_BECH32 = "bcrt1q427ze5mrzqupzyfmqsx9gxh7xav538yk2j4cft"
+ADDRESS_BECH32M = "bcrt1p929uxzkp0lnh3smkkcvdqerj7ejhhac6vsc2lr0gqc4l092w8yjq64dhfy"
+ADDRESS_TAPROOT = "bcrt1pnmrmugapastum8ztvgwcn8hvq2avmcwh2j4ssru7rtyygkpqq98q4wyd6s"
+
+WALLET_CONFIG = "\n".join(
+    [
+        "[wallet]",
+        (
+            f'addresses = [ "{ADDRESS_COINBASE}", '
+            f'"{ADDRESS_LEGACY}", "{ADDRESS_P2PKH}", '
+            f'"{ADDRESS_P2PWH}", "{ADDRESS_BECH32}", '
+            f'"{ADDRESS_BECH32M}", "{ADDRESS_TAPROOT}" ]'
+        ),
+    ]
+)
+
+MINED_BLOCKS = 101
+COINBASE_BLOCKS = 6
+
+SPECIAL_FIELDS = ["vin", "vout", "scriptSig", "scriptPubKey"]
+IGNORE_FIELDS = ["desc"]
+
+
+class TestGetRawTransaction:
+    """
+    Test `getrawtransaction` RPC method of Floresta node by comparing
+    its response with Bitcoin Core's response for the same transaction.
+    """
+
+    log = None
+    node_manager = None
+    florestad = None
+    bitcoind = None
+
+    # pylint: disable=too-many-statements,too-many-locals
+    @pytest.mark.rpc
+    def test_get_raw_transaction(
+        self, setup_logging, node_manager, add_node_with_extra_args, utreexod_node
+    ):
+        """
+        Run the test by sending transactions, mining blocks, and
+        comparing `getrawtransaction` responses between Floresta
+        and Bitcoin Core.
+        """
+        self.log = setup_logging
+        self.node_manager = node_manager
+
+        self.florestad = node_manager.add_node_default_args(variant=NodeType.FLORESTAD)
+        config_dir = os.path.join(self.florestad.daemon.data_dir, "config.toml")
+        with open(config_dir, "w", encoding="utf-8") as f:
+            f.write(WALLET_CONFIG)
+            self.florestad.set_extra_args([f"--config-file={config_dir}"])
+
+        node_manager.run_node(self.florestad)
+
+        self.log.info("Test getrawtransaction with a non existing txid")
+
+        self.florestad.rpc.ensure_rpc_call_error(
+            method="getrawtransaction",
+            params=["nonexistingtxid"],
+        )
+
+        self.florestad.rpc.ensure_rpc_call_error(
+            method="getrawtransaction",
+            params=["nonexistingtxid", 0],
+        )
+
+        self.florestad.rpc.ensure_rpc_call_error(
+            method="getrawtransaction",
+            params=["nonexistingtxid", 1],
+        )
+
+        self.log.info("Creating and funding transactions in Bitcoin Core")
+        self.bitcoind = add_node_with_extra_args(
+            variant=NodeType.BITCOIND,
+            extra_args=["-txindex", "-fallbackfee=0.00000001"],
+        )
+        self.bitcoind.rpc.create_wallet("testwallet")
+
+        self.bitcoind.rpc.generate_block_to_wallet(MINED_BLOCKS)
+
+        txids = []
+        value = 6.4242521
+        for address in [
+            ADDRESS_BECH32,
+            ADDRESS_LEGACY,
+            ADDRESS_BECH32M,
+            ADDRESS_P2PWH,
+            ADDRESS_P2PKH,
+            ADDRESS_TAPROOT,
+        ]:
+            txid = self.bitcoind.rpc.send_to_address(address, value)
+            self.log.info(
+                f"Sent transaction to {address} and value {value} " f"with txid: {txid}"
+            )
+            txids.append(txid)
+
+        txids.append(self.bitcoind.rpc.send_to_address(ADDRESS_BECH32, 5.5))
+        self.log.info(f"Sent transaction with txid: {txid}")
+
+        self.bitcoind.rpc.generate_block_to_address(COINBASE_BLOCKS, ADDRESS_COINBASE)
+
+        self.node_manager.connect_nodes(self.bitcoind, utreexod_node)
+        time.sleep(5)
+
+        self.node_manager.connect_nodes(self.florestad, utreexod_node)
+        time.sleep(5)
+
+        self.node_manager.connect_nodes(self.florestad, self.bitcoind)
+
+        self.log.info("Waiting for Florestad to sync with Bitcoin Core")
+        self.node_manager.wait_for_sync_nodes()
+
+        self.log.info(
+            "Test getrawtransaction with a non existing txid and "
+            "invalid verbose level"
+        )
+        self.florestad.rpc.ensure_rpc_call_error(
+            method="getrawtransaction",
+            params=[txids[0], 2],
+        )
+
+        for txid in txids:
+            self.compare_getrawtransaction(txid)
+
+        initial_block_coinbase_wallet = self.bitcoind.rpc.get_block_count() - (
+            COINBASE_BLOCKS - 1
+        )
+        best_block_height = self.bitcoind.rpc.get_block_count()
+        block_range = (
+            f"Testing getrawtransaction for coinbase transactions "
+            f"in the block range {initial_block_coinbase_wallet} to {best_block_height}"
+        )
+        self.log.info(block_range)
+        for height in range(initial_block_coinbase_wallet, best_block_height):
+            block_hash = self.bitcoind.rpc.get_blockhash(height)
+
+            block = self.bitcoind.rpc.get_block(block_hash, verbosity=1)
+            coinbase_tx = block["tx"][0]  # Get the coinbase transaction txid
+
+            self.compare_getrawtransaction(coinbase_tx)
+
+    def compare_getrawtransaction(self, txid):
+        """Compare getrawtransaction output between Floresta and Bitcoin Core."""
+        self.log.info(
+            f"Comparing getrawtransaction for txid: {txid} with verbose default (verbose=0)"
+        )
+        get_raw_tx = self.florestad.rpc.get_raw_transaction(txid)
+        get_raw_tx_bitcoind = self.bitcoind.rpc.get_raw_transaction(txid)
+        assert get_raw_tx == get_raw_tx_bitcoind
+
+        self.log.info(
+            f"Comparing getrawtransaction for txid: {txid} with verbose level 0"
+        )
+        get_raw_tx = self.florestad.rpc.get_raw_transaction(txid, verbose=0)
+        get_raw_tx_bitcoind = self.bitcoind.rpc.get_raw_transaction(txid, verbose=0)
+        assert get_raw_tx == get_raw_tx_bitcoind
+
+        self.log.info(
+            f"Comparing getrawtransaction for txid: {txid} with verbose level 1"
+        )
+        get_raw_tx = self.florestad.rpc.get_raw_transaction(txid, verbose=1)
+        get_raw_tx_bitcoind = self.bitcoind.rpc.get_raw_transaction(txid, verbose=1)
+
+        compare_fields(get_raw_tx, get_raw_tx_bitcoind, ignore_fields=IGNORE_FIELDS)

--- a/tests/floresta-cli/gettxout.py
+++ b/tests/floresta-cli/gettxout.py
@@ -7,6 +7,9 @@ This functional test cli utility to interact with a Floresta node with `gettxout
 """
 
 import pytest
+from test_framework.util import compare_fields
+
+IGNORE_FIELDS = ["bestblock", "confirmations"]
 
 
 # pylint: disable=too-many-locals
@@ -36,17 +39,4 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain, node_m
             txout_bitcoind = bitcoind.rpc.get_txout(tx, vout=0, include_mempool=False)
             assert txout_bitcoind is not None, f"Txout for tx {tx} is None in Bitcoind."
 
-            for key in txout_bitcoind.keys():
-                if key in ["bestblock", "confirmations"]:
-                    continue
-
-                if key == "scriptPubKey":
-                    for subkey in txout_bitcoind["scriptPubKey"].keys():
-                        log.debug(f"Comparing scriptPubKey[{subkey}] for tx {tx}...")
-                        assert (
-                            txout_floresta["scriptPubKey"][subkey]
-                            == txout_bitcoind["scriptPubKey"][subkey]
-                        )
-                else:
-                    log.debug(f"Comparing {key} for tx {tx}...")
-                    assert txout_floresta[key] == txout_bitcoind[key]
+            compare_fields(txout_floresta, txout_bitcoind, ignore_fields=IGNORE_FIELDS)

--- a/tests/florestad/rpcserver_request_parsing.py
+++ b/tests/florestad/rpcserver_request_parsing.py
@@ -26,13 +26,6 @@ from test_framework.constants import (
     METHODS_REQUIRING_PARAMS,
     NO_PARAM_METHODS,
 )
-from test_framework.rpc.base import (
-    assert_rpc_error,
-    assert_rpc_success,
-    make_raw_data_request,
-    make_raw_request,
-    make_request,
-)
 
 
 class TestRpcServerRequestParsing:
@@ -44,83 +37,78 @@ class TestRpcServerRequestParsing:
     def test_noparammethods_omittedparams_succeeds(self, shared_florestad_node):
         """Verify all no-param methods succeed when the params field is omitted."""
         for method in NO_PARAM_METHODS:
-            resp = make_request(shared_florestad_node, method)
-            assert_rpc_success(resp)
+            shared_florestad_node.rpc.ensure_rpc_call_success(method=method)
 
     def test_noparammethods_nullparams_succeeds(self, shared_florestad_node):
         """Verify all no-param methods succeed when params is explicitly null."""
         for method in NO_PARAM_METHODS:
-            resp = make_request(shared_florestad_node, method, params=None)
-            assert_rpc_success(resp)
+            shared_florestad_node.rpc.ensure_rpc_call_success(
+                method=method, params=None
+            )
 
     def test_noparammethods_emptyarray_succeeds(self, shared_florestad_node):
         """Verify all no-param methods succeed when params is an empty array."""
         for method in NO_PARAM_METHODS:
-            resp = make_request(shared_florestad_node, method, params=[])
-            assert_rpc_success(resp)
+            shared_florestad_node.rpc.ensure_rpc_call_success(method=method, params=[])
 
     def test_positionalparams_validargs_succeeds(self, shared_florestad_node):
         """Verify methods accept valid positional (array) parameters."""
-        resp = make_request(shared_florestad_node, "getblockhash", params=[0])
-        assert_rpc_success(resp)
-        genesis_hash = resp["body"]["result"]
-        resp = make_request(
-            shared_florestad_node, "getblockheader", params=[genesis_hash]
+        resp = shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblockhash", params=[0]
         )
-        assert_rpc_success(resp)
-        resp = make_request(shared_florestad_node, "getblock", params=[genesis_hash, 1])
-        assert_rpc_success(resp)
+        genesis_hash = resp["body"]["result"]
+
+        shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblockheader", params=[genesis_hash]
+        )
+
+        shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblock", params=[genesis_hash, 1]
+        )
 
     def test_namedparams_validargs_succeeds(self, shared_florestad_node):
         """Verify methods accept valid named (object) parameters."""
-        resp = make_request(
-            shared_florestad_node, "getblockhash", params={"block_height": 0}
+        resp = shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblockhash", params={"block_height": 0}
         )
-        assert_rpc_success(resp)
         genesis_hash = resp["body"]["result"]
-        resp = make_request(
-            shared_florestad_node,
-            "getblockheader",
-            params={"block_hash": genesis_hash},
+
+        shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblockheader", params={"block_hash": genesis_hash}
         )
-        assert_rpc_success(resp)
-        resp = make_request(
-            shared_florestad_node,
-            "getblock",
-            params={"block_hash": genesis_hash, "verbosity": 0},
+
+        shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblock", params={"block_hash": genesis_hash, "verbosity": 0}
         )
-        assert_rpc_success(resp)
 
     def test_optionalparams_omitted_usesdefaults(self, shared_florestad_node):
         """Verify omitted optional parameters fall back to their defaults."""
         genesis_hash = shared_florestad_node.rpc.get_bestblockhash()
-        resp_default = make_request(
-            shared_florestad_node, "getblock", params=[genesis_hash]
+
+        resp_default = shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblock", params=[genesis_hash]
         )
-        assert_rpc_success(resp_default)
         result = resp_default["body"]["result"]
         # Check that the default verbosity was enabled.
         assert "hash" in result
         assert "tx" in result
 
-        resp_explicit = make_request(
-            shared_florestad_node, "getblock", params=[genesis_hash, 1]
+        resp_explicit = shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblock", params=[genesis_hash, 1]
         )
-        assert_rpc_success(resp_explicit)
         assert resp_default["body"]["result"] == resp_explicit["body"]["result"]
 
-        resp = make_request(
-            shared_florestad_node, "getblock", params={"block_hash": genesis_hash}
+        resp = shared_florestad_node.rpc.ensure_rpc_call_success(
+            method="getblock", params={"block_hash": genesis_hash}
         )
-        assert_rpc_success(resp)
         assert resp_default["body"]["result"] == resp_explicit["body"]["result"]
         assert "hash" in resp["body"]["result"]
 
     def test_unknownmethod_anyparams_returnsmethodnotfound(self, shared_florestad_node):
         """Verify unknown methods return METHOD_NOT_FOUND (-32601)."""
-        resp = make_request(shared_florestad_node, "nonexistent_method", params=[])
-        assert_rpc_error(
-            resp,
+        shared_florestad_node.rpc.ensure_rpc_call_error(
+            method="nonexistent_method",
+            params=[],
             expected_status_code=404,
             expected_rpcerror_code=JSONRPC_ERRCODE_METHOD_NOT_FOUND,
             expected_message=JSONRPC_ERRMSG_METHOD_NOT_FOUND,
@@ -128,9 +116,9 @@ class TestRpcServerRequestParsing:
 
     def test_requiredparams_missing_returnsinvalidparams(self, shared_florestad_node):
         """Verify missing required parameters return INVALID_PARAMS (-32602)."""
-        resp = make_request(shared_florestad_node, "getblockhash", params=[])
-        assert_rpc_error(
-            resp,
+        shared_florestad_node.rpc.ensure_rpc_call_error(
+            method="getblockhash",
+            params=[],
             expected_status_code=400,
             expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
             expected_message=JSONRPC_ERRMSG_MISSING_PARAMS,
@@ -138,9 +126,9 @@ class TestRpcServerRequestParsing:
 
         # {} is an empty object, so it should be accepted as an object
         # but raise that is missing the fields
-        resp = make_request(shared_florestad_node, "getblockhash", params={})
-        assert_rpc_error(
-            resp,
+        shared_florestad_node.rpc.ensure_rpc_call_error(
+            method="getblockhash",
+            params={},
             expected_status_code=400,
             expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
             expected_message=JSONRPC_ERRMSG_MISSING_PARAMS,
@@ -150,34 +138,27 @@ class TestRpcServerRequestParsing:
         """Verify wrong parameter types return INVALID_PARAMS (-32602)."""
 
         # getblockhash expects a number, but "not_a_number" is a string - params must be array
-        resp = make_request(
-            shared_florestad_node, "getblockhash", params=["not_a_number"]
-        )
-        assert_rpc_error(
-            resp,
+        shared_florestad_node.rpc.ensure_rpc_call_error(
+            method="getblockhash",
+            params=["not_a_number"],
             expected_status_code=400,
             expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
             expected_message=JSONRPC_ERRMSG_WRONG_PARAM_TYPE,
         )
 
         # getblock hash expects a string, but 12345 is a number - params must be array
-        resp = make_request(shared_florestad_node, "getblock", params=[12345])
-        assert_rpc_error(
-            resp,
+        shared_florestad_node.rpc.ensure_rpc_call_error(
+            method="getblock",
+            params=[12345],
             expected_status_code=400,
             expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
             expected_message=JSONRPC_ERRMSG_WRONG_PARAM_TYPE,
         )
 
         genesis_hash = shared_florestad_node.rpc.get_bestblockhash()
-        resp = make_request(
-            shared_florestad_node,
-            "getblock",
+        shared_florestad_node.rpc.ensure_rpc_call_error(
+            method="getblock",
             params=[genesis_hash, "invalid_verbosity"],
-        )
-
-        assert_rpc_error(
-            resp,
             expected_status_code=400,
             expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
             expected_message=JSONRPC_ERRMSG_WRONG_PARAM_TYPE,
@@ -185,21 +166,15 @@ class TestRpcServerRequestParsing:
 
     def test_jsonrpcversion_invalid_returnsrejection(self, shared_florestad_node):
         """Verify invalid jsonrpc versions are rejected and valid ones accepted."""
-        resp = make_raw_request(
-            shared_florestad_node,
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_error(
             {"jsonrpc": "3.0", "id": "test", "method": "getblockcount", "params": []},
-        )
-
-        assert_rpc_error(
-            resp,
             expected_status_code=400,
             expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_REQUEST,
             expected_message=JSONRPC_ERRMSG_INVALID_VERSION,
         )
 
         for version in ["1.0", "2.0"]:
-            resp = make_raw_request(
-                shared_florestad_node,
+            shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
                 {
                     "jsonrpc": version,
                     "id": "test",
@@ -207,19 +182,16 @@ class TestRpcServerRequestParsing:
                     "params": [],
                 },
             )
-            assert_rpc_success(resp)
 
-        resp = make_raw_request(
-            shared_florestad_node, {"id": "test", "method": "getblockcount"}
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
+            {"id": "test", "method": "getblockcount"}
         )
-        assert_rpc_success(resp)
 
     def test_parammethods_omittedparams_returnserror(self, shared_florestad_node):
         """Verify methods that require params fail when params are omitted."""
         for method in METHODS_REQUIRING_PARAMS:
-            resp = make_request(shared_florestad_node, method)
-            assert_rpc_error(
-                resp,
+            shared_florestad_node.rpc.ensure_rpc_call_error(
+                method=method,
                 expected_status_code=400,
                 expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
                 expected_message=JSONRPC_ERRMSG_MISSING_PARAMS,
@@ -227,8 +199,7 @@ class TestRpcServerRequestParsing:
 
     def test_responsestructure_success_matchesjsonrpcspec(self, shared_florestad_node):
         """Verify successful responses match the JSON-RPC spec structure."""
-        resp = make_raw_request(
-            shared_florestad_node,
+        resp = shared_florestad_node.rpc.noraise_raw_request(
             {"jsonrpc": "2.0", "id": "struct_test", "method": "getblockcount"},
         )
         body = resp["body"]
@@ -239,8 +210,7 @@ class TestRpcServerRequestParsing:
 
     def test_responsestructure_error_matchesjsonrpcspec(self, shared_florestad_node):
         """Verify error responses match the JSON-RPC spec structure."""
-        resp = make_raw_request(
-            shared_florestad_node,
+        resp = shared_florestad_node.rpc.noraise_raw_request(
             {
                 "jsonrpc": "2.0",
                 "id": "struct_err",
@@ -259,43 +229,34 @@ class TestRpcServerRequestParsing:
 
     def test_jsonrpc_v1_explicit_version_succeeds(self, shared_florestad_node):
         """Verify requests with explicit jsonrpc 1.0 version succeed."""
-        resp = make_raw_request(
-            shared_florestad_node,
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
             {"jsonrpc": "1.0", "id": "test", "method": "getblockcount", "params": []},
         )
-        assert_rpc_success(resp)
 
     def test_jsonrpc_v1_omitted_version_succeeds(self, shared_florestad_node):
         """Verify requests without jsonrpc field succeed (JSON-RPC 1.0 style)."""
-        resp = make_raw_request(
-            shared_florestad_node,
-            {"id": "test", "method": "getblockcount"},
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
+            {"id": "test", "method": "getblockcount"}
         )
-        assert_rpc_success(resp)
 
     def test_contenttype_applicationjson_succeeds(self, shared_florestad_node):
         """Verify requests with application/json content-type succeed."""
-        resp = make_raw_request(
-            shared_florestad_node,
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
             {"jsonrpc": "2.0", "id": "test", "method": "getblockcount"},
             content_type="application/json",
         )
-        assert_rpc_success(resp)
 
     def test_contenttype_textplain_succeeds(self, shared_florestad_node):
         """Verify requests with text/plain content-type succeed."""
-        resp = make_raw_request(
-            shared_florestad_node,
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
             {"jsonrpc": "2.0", "id": "test", "method": "getblockcount"},
             content_type="text/plain",
         )
-        assert_rpc_success(resp)
 
     def test_contenttype_nonjson_body_rejected(self, shared_florestad_node):
         """Verify non-JSON body is rejected regardless of content-type."""
-        resp = make_raw_data_request(
-            shared_florestad_node,
-            data="this is not json",
+        shared_florestad_node.rpc.ensure_rpc_raw_request_call_error(
+            payload="this is not json",
             content_type="text/plain",
+            expected_status_code=400,
         )
-        assert_rpc_error(resp, expected_status_code=400)

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -148,26 +148,20 @@ class BaseRPC(ABC):
         return self._send_request(request)
 
     def noraise_raw_request(
-        self, payload: Dict[str, Any], content_type: str = "application/json"
+        self,
+        data: Any,
+        content_type: str = "application/json",
     ) -> Dict[str, Any]:
         """
-        Send an arbitrary dict as a JSON-RPC request body and return the raw
+        Send raw data or a dict as a JSON-RPC request body and return the raw
         parsed response WITHOUT raising.
         """
         request_kwargs = self._build_request_kwargs()
         request_kwargs["headers"]["content-type"] = content_type
-        request_kwargs["data"] = json.dumps(payload)
-        return self._send_request(request_kwargs)
 
-    def noraise_raw_data_request(
-        self, data, content_type: str = "application/json"
-    ) -> Dict[str, Any]:
-        """
-        Send raw data (string/bytes) to the RPC endpoint and return the raw
-        parsed response WITHOUT raising.
-        """
-        request_kwargs = self._build_request_kwargs()
-        request_kwargs["headers"]["content-type"] = content_type
+        if isinstance(data, dict):
+            data = json.dumps(data)
+
         request_kwargs["data"] = data
         return self._send_request(request_kwargs)
 
@@ -416,52 +410,81 @@ class BaseRPC(ABC):
         """
         return self.perform_request("getaddrmaninfo")
 
+    def ensure_rpc_raw_request_call_success(
+        self, payload, content_type="application/json"
+    ):
+        """Assert that a raw JSON-RPC request indicates success (HTTP 200, no error)."""
+        resp = self.noraise_raw_request(payload, content_type)
+        self.assert_rpc_success(resp)
 
-def make_raw_request(node, payload, content_type="application/json"):
-    """
-    Send a raw JSON-RPC request and return the parsed response without raising on non-200.
-    """
-    return node.rpc.noraise_raw_request(payload, content_type)
+        return resp
 
+    def ensure_rpc_call_success(self, method, params=None, request_id="test"):
+        """Assert that a JSON-RPC response indicates success (HTTP 200, no error)."""
+        resp = self.noraise_request(method, params, request_id)
+        self.assert_rpc_success(resp)
 
-def make_raw_data_request(node, data, content_type="application/json"):
-    """
-    Send raw data to the JSON-RPC endpoint and return the parsed response.
+        return resp
 
-    Unlike ``make_raw_request`` this accepts a raw string/bytes body instead of
-    a dict, allowing tests to send malformed or non-JSON payloads.
-    """
-    return node.rpc.noraise_raw_data_request(data, content_type)
+    def assert_rpc_success(self, resp):
+        """Assert that a JSON-RPC response indicates success (HTTP 200, no error)."""
+        assert resp["status_code"] == 200
+        assert resp["body"].get("error") is None
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def ensure_rpc_raw_request_call_error(
+        self,
+        payload,
+        expected_status_code=None,
+        expected_rpcerror_code=None,
+        expected_message=None,
+        content_type="application/json",
+    ):
+        """Assert that a raw JSON-RPC request indicates an error (non-200, error present)."""
+        resp = self.noraise_raw_request(payload, content_type)
+        self.assert_rpc_error(
+            resp, expected_status_code, expected_rpcerror_code, expected_message
+        )
 
-def make_request(node, method, params=None, request_id="test"):
-    """
-    Send a JSON-RPC request and return the parsed response without raising on non-200.
-    """
-    return node.rpc.noraise_request(method, params, request_id)
+        return resp
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def ensure_rpc_call_error(
+        self,
+        method,
+        params=None,
+        request_id="test",
+        expected_status_code=None,
+        expected_rpcerror_code=None,
+        expected_message=None,
+    ):
+        """Assert that a JSON-RPC response indicates an error (non-200, error present)."""
+        resp = self.noraise_request(method, params, request_id)
+        self.assert_rpc_error(
+            resp, expected_status_code, expected_rpcerror_code, expected_message
+        )
 
-def assert_rpc_success(resp):
-    """Assert that a JSON-RPC response indicates success (HTTP 200, no error)."""
-    assert resp["status_code"] == 200
-    assert resp["body"].get("error") is None
+        return resp
 
+    def assert_rpc_error(
+        self,
+        resp,
+        expected_status_code=None,
+        expected_rpcerror_code=None,
+        expected_message=None,
+    ):
+        """
+        Assert that a JSON-RPC response indicates an error (non-200, error present).
+        """
+        assert resp["body"].get("error") is not None
 
-def assert_rpc_error(
-    resp, expected_status_code=None, expected_rpcerror_code=None, expected_message=None
-):
-    """
-    Assert that a JSON-RPC response indicates an error (non-200, error present).
-    """
-    assert resp["body"].get("error") is not None
+        if expected_status_code is None:
+            assert resp["status_code"] != 200
+        else:
+            assert resp["status_code"] == expected_status_code
 
-    if expected_status_code is None:
-        assert resp["status_code"] != 200
-    else:
-        assert resp["status_code"] == expected_status_code
+        if expected_rpcerror_code is not None:
+            assert resp["body"]["error"]["code"] == expected_rpcerror_code
 
-    if expected_rpcerror_code is not None:
-        assert resp["body"]["error"]["code"] == expected_rpcerror_code
-
-    if expected_message is not None:
-        assert resp["body"]["error"]["message"] == expected_message
+        if expected_message is not None:
+            assert resp["body"]["error"]["message"] == expected_message

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -188,6 +188,9 @@ class BaseRPC(ABC):
         resp = self.noraise_request(method, params)
 
         if resp["status_code"] != 200:
+            self.log.error(
+                f"RPC request failed with status code {resp['status_code']}: {resp['body']}"
+            )
             raise HTTPError
 
         result = resp["body"]
@@ -409,6 +412,16 @@ class BaseRPC(ABC):
         Get address manager statistics broken down by network
         """
         return self.perform_request("getaddrmaninfo")
+
+    def get_raw_transaction(self, txid: str, verbose: int | None = None):
+        """
+        Returns the raw transaction data for a given transaction ID.
+        """
+        params = [txid]
+        if verbose is not None:
+            params.append(int(verbose))
+
+        return self.perform_request("getrawtransaction", params=params)
 
     def ensure_rpc_raw_request_call_success(
         self, payload, content_type="application/json"

--- a/tests/test_framework/rpc/bitcoin.py
+++ b/tests/test_framework/rpc/bitcoin.py
@@ -46,3 +46,28 @@ class BitcoinRPC(BaseRPC):
         """
         address = "bcrt1q3ml87jemlfvk7lq8gfs7pthvj5678ndnxnw9ch"
         return self.generate_block_to_address(nblocks, address)
+
+    def get_new_address(self) -> str:
+        """
+        Get a new address from the wallet.
+        """
+        return self.perform_request("getnewaddress", params=[])
+
+    def generate_block_to_wallet(self, nblocks: int) -> list:
+        """
+        Mine blocks immediately, with coinbase reward sent to a new wallet address
+        """
+        address = self.get_new_address()
+        return self.generate_block_to_address(nblocks, address)
+
+    def create_wallet(self, wallet_name: str):
+        """
+        Create a new wallet with the given name.
+        """
+        return self.perform_request("createwallet", params=[wallet_name])
+
+    def send_to_address(self, address: str, amount: float) -> str:
+        """
+        Send a specified amount to a given address.
+        """
+        return self.perform_request("sendtoaddress", params=[address, amount])

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -8,6 +8,7 @@ import inspect
 import random
 import socket
 import subprocess
+import math
 
 from test_framework.crypto.pkcs8 import (
     create_pkcs8_private_key,
@@ -134,3 +135,49 @@ def wait_until(predicate, timeout=30, interval=0.5, error_msg="Condition not met
         time.sleep(interval)
 
     raise TimeoutError(f"{error_msg} after {timeout} seconds")
+
+
+def compare_fields(candidate, reference, ignore_fields=None, float_tol=1e-8):
+    """
+    Recursively compare two data structures (dicts, lists, or scalars),
+    ignoring specified fields.
+
+    Note:
+        The comparison is asymmetric. `reference` defines the required fields.
+        For Floresta RPC tests, use Floresta as `candidate` and the reference
+        node as `reference`.
+    """
+    if ignore_fields is None:
+        ignore_fields = set()
+    elif isinstance(ignore_fields, list):
+        ignore_fields = set(ignore_fields)
+
+    # float tolerance
+    if isinstance(candidate, float) or isinstance(reference, float):
+        assert math.isclose(candidate, reference, rel_tol=0.0, abs_tol=float_tol), (
+            f"Float mismatch: candidate={candidate}, reference={reference}, "
+            f"tolerance={float_tol}"
+        )
+        return
+
+    # dict
+    if isinstance(candidate, dict) and isinstance(reference, dict):
+        for key, ref_value in reference.items():
+            if key in ignore_fields:
+                continue
+            assert key in candidate, f"Missing key in candidate: {key}"
+            compare_fields(candidate[key], ref_value, ignore_fields=ignore_fields)
+
+        return
+
+    # list
+    if isinstance(candidate, list) and isinstance(reference, list):
+        assert len(candidate) == len(
+            reference
+        ), f"List length mismatch: expected {len(candidate)}, got {len(reference)}"
+        for cand_item, ref_item in zip(candidate, reference):
+            compare_fields(cand_item, ref_item, ignore_fields=ignore_fields)
+        return
+
+    # scalar
+    assert candidate == reference


### PR DESCRIPTION

## Description and Notes

Brings Floresta’s `getrawtransaction` RPC closer to Bitcoin Core compatibility.

Fixes the RPC method call so the client correctly uses `getrawtransaction` instead of the incorrect `gettransaction`, and standardizes `verbosity` handling to match Bitcoin Core’s numeric behavior.

*The response format was aligned with Bitcoin Core as well:*
- *`RawTx` fields such as `blockhash`, `confirmations`, `blocktime`, and `time` are now optional and only serialized when present.*
- *`txid` encoding was corrected.*
- *`TxOut.value` now uses `f64` in BTC instead of `u64` in sats, matching Bitcoin Core’s denomination.*
- *`TxOut.address` is now optional and only included when the script can be converted into a valid address.*
- *`TxIn` now handles coinbase inputs properly, including the `coinbase` field only when applicable.*
- *ASM formatting was improved to follow Bitcoin Core’s rules more strictly.*
- *`TxOut` script types were expanded to cover the script types supported by Bitcoin Core.*

*Note:* the `desc` field was intentionally left out, since matching Bitcoin Core’s descriptor logic requires additional investigation and a more complex implementation. That can be handled in a future PR.

## How to verify the changes you have done?

Compare the output of `getrawtransaction` between Floresta and Bitcoin Core for both `verbosity = 0` and `verbosity = 1`.

*The integration test added here already covers this behavior and is the best reference for validation.*
- *Check regular transactions across multiple script types, including `P2PKH`, `P2WPKH`, `P2SH`, and `P2TR`.*
- *Check coinbase transactions and confirm the special input/output fields are handled correctly.*
- *Review the optional field behavior to ensure fields are only present when they should be.*
- *Inspect the integration test to confirm field-by-field validation against Bitcoin Core.*