### PR TITLE
Centralize server-side defaults and align `addnode` behavior with Bitcoin Core

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -116,14 +116,8 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             vout,
             script,
             height_hint,
-        } => serde_json::to_string_pretty(&client.find_tx_out(
-            txid,
-            vout,
-            script,
-            height_hint.unwrap_or(0),
-        )?)?,
+        } => serde_json::to_string_pretty(&client.find_tx_out(txid, vout, script, height_hint)?)?,
         Methods::GetMemoryInfo { mode } => {
-            let mode = mode.unwrap_or("stats".to_string());
             serde_json::to_string_pretty(&client.get_memory_info(mode)?)?
         }
         Methods::GetRpcInfo => serde_json::to_string_pretty(&client.get_rpc_info()?)?,
@@ -394,7 +388,7 @@ pub enum Methods {
     )]
     DisconnectNode {
         node_address: String,
-        node_id: Option<usize>,
+        node_id: Option<u32>,
     },
 
     #[command(name = "findtxout")]

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -106,10 +106,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             node,
             command,
             v2transport,
-        } => {
-            let transport = v2transport.unwrap_or(false);
-            serde_json::to_string_pretty(&client.add_node(node, command, transport)?)?
-        }
+        } => serde_json::to_string_pretty(&client.add_node(node, command, v2transport)?)?,
         Methods::DisconnectNode {
             node_address,
             node_id,

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -108,14 +108,8 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             vout,
             script,
             height_hint,
-        } => serde_json::to_string_pretty(&client.find_tx_out(
-            txid,
-            vout,
-            script,
-            height_hint.unwrap_or(0),
-        )?)?,
+        } => serde_json::to_string_pretty(&client.find_tx_out(txid, vout, script, height_hint)?)?,
         Methods::GetMemoryInfo { mode } => {
-            let mode = mode.unwrap_or("stats".to_string());
             serde_json::to_string_pretty(&client.get_memory_info(mode)?)?
         }
         Methods::GetRpcInfo => serde_json::to_string_pretty(&client.get_rpc_info()?)?,
@@ -389,7 +383,7 @@ pub enum Methods {
     )]
     DisconnectNode {
         node_address: String,
-        node_id: Option<usize>,
+        node_id: Option<u32>,
     },
 
     #[command(name = "findtxout")]

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -98,10 +98,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             node,
             command,
             v2transport,
-        } => {
-            let transport = v2transport.unwrap_or(false);
-            serde_json::to_string_pretty(&client.add_node(node, command, transport)?)?
-        }
+        } => serde_json::to_string_pretty(&client.add_node(node, command, v2transport)?)?,
         Methods::DisconnectNode {
             node_address,
             node_id,

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -475,6 +475,7 @@ impl Florestad {
                 datadir.join("debug.log"),
                 self.config.user_agent.clone(),
                 proxy,
+                !self.config.allow_v1_fallback,
             ));
 
             if self.json_rpc.set(server).is_err() {

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -492,6 +492,7 @@ impl Florestad {
                 datadir.join("debug.log"),
                 self.config.user_agent.clone(),
                 proxy,
+                !self.config.allow_v1_fallback,
             ));
 
             if self.json_rpc.set(server).is_err() {

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -58,10 +58,12 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         &self,
         address: String,
         command: String,
-        v2transport: bool,
+        v2transport: Option<bool>,
     ) -> Result<Value> {
         let address =
             BitcoinSocketAddr::parse_address(&address, Some(self.network), SystemResolver)?;
+
+        let v2transport = v2transport.unwrap_or(self.default_connection_is_v2);
 
         let _ = match command.as_str() {
             "add" => self.node.add_peer(address, v2transport).await,

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -58,11 +58,11 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         &self,
         address: String,
         command: String,
-        v2transport: bool,
+        v2transport: Option<bool>,
     ) -> Result<Value> {
         let address =
             BitcoinSocketAddr::parse_address(&address, Some(self.network), SystemResolver)?;
-
+        let v2transport = v2transport.unwrap_or(self.default_connection_is_v2);
         let succeeded = match command.as_str() {
             "add" => self.node.add_peer(address.clone(), v2transport).await,
             "remove" => self.node.remove_peer(address.clone()).await,

--- a/crates/floresta-node/src/json_rpc/request.rs
+++ b/crates/floresta-node/src/json_rpc/request.rs
@@ -37,60 +37,52 @@ pub mod arg_parser {
 
     use crate::json_rpc::res::jsonrpc_interface::JsonRpcError;
 
-    /// Extracts a parameter from the request parameters at the specified index.
+    /// Extracts an optional parameter from the request by position (array params) or name (object params).
     ///
-    /// This function can extract any type that implements `FromStr`, such as `BlockHash` or
-    /// `Txid`. It checks if the parameter exists and is a valid string representation of the type.
-    /// Returns an error otherwise.
+    /// Returns `Ok(None)` if the field is absent or `null`.
+    /// Returns an error if `params` itself is `null` or has an unexpected structure.
+    pub fn get_optional<'de, T: Deserialize<'de>>(
+        params: &'de Value,
+        index: usize,
+        field_name: &str,
+    ) -> Result<Option<T>, JsonRpcError> {
+        let value = match params {
+            Value::Null => {
+                return Err(JsonRpcError::MissingParameter(field_name.to_string()));
+            }
+            Value::Array(values) => values.get(index),
+            Value::Object(map) => map.get(field_name),
+            _ => {
+                return Err(JsonRpcError::InvalidParameterStructure(params.to_string()));
+            }
+        }
+        .filter(|v| !v.is_null());
+
+        value
+            .map(|value| {
+                T::deserialize(value)
+                    .map_err(|e| JsonRpcError::InvalidParameterType(format!("{field_name}: {e}")))
+            })
+            .transpose()
+    }
+
+    /// Extracts a required parameter, returning [`JsonRpcError::MissingParameter`] if absent.
     pub fn get_at<'de, T: Deserialize<'de>>(
         params: &'de Value,
         index: usize,
         field_name: &str,
     ) -> Result<T, JsonRpcError> {
-        if params.is_null() {
-            return Err(JsonRpcError::MissingParameter(field_name.to_string()));
-        }
-
-        let v = match (params.is_array(), params.is_object()) {
-            (true, false) => params.get(index),
-            (false, true) => params.get(field_name),
-            _ => {
-                return Err(JsonRpcError::InvalidParameterStructure(
-                    (*params).to_string(),
-                ));
-            }
-        };
-
-        let value = v.ok_or(JsonRpcError::MissingParameter(field_name.to_string()))?;
-
-        T::deserialize(value)
-            .map_err(|e| JsonRpcError::InvalidParameterType(format!("{field_name}: {e}")))
+        get_optional(params, index, field_name)?
+            .ok_or_else(|| JsonRpcError::MissingParameter(field_name.to_string()))
     }
 
-    /// Wraps a parameter extraction result so that a missing parameter yields `Ok(None)`
-    /// instead of an error. Other errors are propagated unchanged.
-    pub fn try_into_optional<T>(
-        result: Result<T, JsonRpcError>,
-    ) -> Result<Option<T>, JsonRpcError> {
-        match result {
-            Ok(t) => Ok(Some(t)),
-            Err(JsonRpcError::MissingParameter(_)) => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Like [`get_at`], but returns `default` when the parameter is missing instead of
-    /// an error. Type mismatches are still propagated as errors.
+    /// Like [`get_optional`], but substitutes `default` instead of returning `None`.
     pub fn get_with_default<'de, T: Deserialize<'de>>(
         v: &'de Value,
         index: usize,
         field_name: &str,
         default: T,
     ) -> Result<T, JsonRpcError> {
-        match get_at(v, index, field_name) {
-            Ok(t) => Ok(t),
-            Err(JsonRpcError::MissingParameter(_)) => Ok(default),
-            Err(e) => Err(e),
-        }
+        Ok(get_optional(v, index, field_name)?.unwrap_or(default))
     }
 }

--- a/crates/floresta-node/src/json_rpc/request.rs
+++ b/crates/floresta-node/src/json_rpc/request.rs
@@ -37,60 +37,51 @@ pub mod arg_parser {
 
     use crate::json_rpc::res::jsonrpc_interface::JsonRpcError;
 
-    /// Extracts a parameter from the request parameters at the specified index.
+    /// Extracts an optional parameter from the request by position (array params) or name (object params).
     ///
-    /// This function can extract any type that implements `FromStr`, such as `BlockHash` or
-    /// `Txid`. It checks if the parameter exists and is a valid string representation of the type.
-    /// Returns an error otherwise.
+    /// Returns `Ok(None)` if the field is absent or `null`, or if `params` itself was
+    /// omitted from the request (i.e. is `null`), meaning no arguments were given.
+    /// Returns an error if `params` has an unexpected structure.
+    pub fn get_optional<'de, T: Deserialize<'de>>(
+        params: &'de Value,
+        index: usize,
+        field_name: &str,
+    ) -> Result<Option<T>, JsonRpcError> {
+        let value = match params {
+            Value::Null => None,
+            Value::Array(values) => values.get(index),
+            Value::Object(map) => map.get(field_name),
+            _ => {
+                return Err(JsonRpcError::InvalidParameterStructure(params.to_string()));
+            }
+        }
+        .filter(|v| !v.is_null());
+
+        value
+            .map(|value| {
+                T::deserialize(value)
+                    .map_err(|e| JsonRpcError::InvalidParameterType(format!("{field_name}: {e}")))
+            })
+            .transpose()
+    }
+
+    /// Extracts a required parameter, returning [`JsonRpcError::MissingParameter`] if absent.
     pub fn get_at<'de, T: Deserialize<'de>>(
         params: &'de Value,
         index: usize,
         field_name: &str,
     ) -> Result<T, JsonRpcError> {
-        if params.is_null() {
-            return Err(JsonRpcError::MissingParameter(field_name.to_string()));
-        }
-
-        let v = match (params.is_array(), params.is_object()) {
-            (true, false) => params.get(index),
-            (false, true) => params.get(field_name),
-            _ => {
-                return Err(JsonRpcError::InvalidParameterStructure(
-                    (*params).to_string(),
-                ));
-            }
-        };
-
-        let value = v.ok_or(JsonRpcError::MissingParameter(field_name.to_string()))?;
-
-        T::deserialize(value)
-            .map_err(|e| JsonRpcError::InvalidParameterType(format!("{field_name}: {e}")))
+        get_optional(params, index, field_name)?
+            .ok_or_else(|| JsonRpcError::MissingParameter(field_name.to_string()))
     }
 
-    /// Wraps a parameter extraction result so that a missing parameter yields `Ok(None)`
-    /// instead of an error. Other errors are propagated unchanged.
-    pub fn try_into_optional<T>(
-        result: Result<T, JsonRpcError>,
-    ) -> Result<Option<T>, JsonRpcError> {
-        match result {
-            Ok(t) => Ok(Some(t)),
-            Err(JsonRpcError::MissingParameter(_)) => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Like [`get_at`], but returns `default` when the parameter is missing instead of
-    /// an error. Type mismatches are still propagated as errors.
+    /// Like [`get_optional`], but substitutes `default` instead of returning `None`.
     pub fn get_with_default<'de, T: Deserialize<'de>>(
         v: &'de Value,
         index: usize,
         field_name: &str,
         default: T,
     ) -> Result<T, JsonRpcError> {
-        match get_at(v, index, field_name) {
-            Ok(t) => Ok(t),
-            Err(JsonRpcError::MissingParameter(_)) => Ok(default),
-            Err(e) => Err(e),
-        }
+        Ok(get_optional(v, index, field_name)?.unwrap_or(default))
     }
 }

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -93,6 +93,7 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) start_time: Instant,
     pub(super) user_agent: String,
     pub(super) proxy: Option<SocketAddr>,
+    pub(super) default_connection_is_v2: bool,
 }
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
@@ -307,7 +308,7 @@ async fn handle_json_rpc_request(
         "addnode" => {
             let node = get_at(&params, 0, "node")?;
             let command = get_at(&params, 1, "command")?;
-            let v2transport = get_with_default(&params, 2, "V2transport", false)?;
+            let v2transport = try_into_optional(get_at(&params, 2, "v2transport"))?;
 
             state
                 .add_node(node, command, v2transport)
@@ -680,6 +681,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         log_path: impl AsRef<Path>,
         user_agent: String,
         proxy: Option<SocketAddr>,
+        default_connection_is_v2: bool,
     ) {
         let address = address.unwrap_or_else(|| {
             format!("127.0.0.1:{}", Self::get_port(&network))
@@ -722,6 +724,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 start_time: Instant::now(),
                 user_agent,
                 proxy,
+                default_connection_is_v2,
             }));
 
         axum::serve(listener, router)

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -56,8 +56,8 @@ use super::res::GetRawTransactionRes;
 use super::res::jsonrpc_interface::JsonRpcError;
 use crate::json_rpc::request::RpcRequest;
 use crate::json_rpc::request::arg_parser::get_at;
+use crate::json_rpc::request::arg_parser::get_optional;
 use crate::json_rpc::request::arg_parser::get_with_default;
-use crate::json_rpc::request::arg_parser::try_into_optional;
 use crate::json_rpc::res::RescanConfidence;
 use crate::json_rpc::res::jsonrpc_interface::Response;
 
@@ -308,7 +308,7 @@ async fn handle_json_rpc_request(
         "addnode" => {
             let node = get_at(&params, 0, "node")?;
             let command = get_at(&params, 1, "command")?;
-            let v2transport = try_into_optional(get_at(&params, 2, "v2transport"))?;
+            let v2transport = get_optional(&params, 2, "v2transport")?;
 
             state
                 .add_node(node, command, v2transport)
@@ -318,7 +318,7 @@ async fn handle_json_rpc_request(
 
         "disconnectnode" => {
             let node_address = get_at(&params, 0, "node_address")?;
-            let node_id = try_into_optional(get_at(&params, 1, "node_id"))?;
+            let node_id = get_optional(&params, 1, "node_id")?;
 
             state
                 .disconnect_node(node_address, node_id)
@@ -331,7 +331,7 @@ async fn handle_json_rpc_request(
             let vout = get_at(&params, 1, "vout")?;
             let script: String = get_at(&params, 2, "script")?;
             let script = ScriptBuf::from_hex(&script).map_err(|_| JsonRpcError::InvalidScript)?;
-            let height = get_at(&params, 3, "height")?;
+            let height = get_with_default(&params, 3, "height", 0)?;
 
             state.clone().find_tx_out(txid, vout, script, height).await
         }
@@ -389,7 +389,7 @@ async fn handle_json_rpc_request(
         }
 
         "getdeploymentinfo" => {
-            let blockhash = try_into_optional(get_at(&params, 0, "blockhash"))?;
+            let blockhash = get_optional(&params, 0, "blockhash")?;
 
             state
                 .get_deployment_info(blockhash)
@@ -416,7 +416,7 @@ async fn handle_json_rpc_request(
 
         "gettxoutproof" => {
             let txids: Vec<Txid> = get_at(&params, 0, "txids")?;
-            let block_hash = try_into_optional(get_at(&params, 1, "block_hash"))?;
+            let block_hash = get_optional(&params, 1, "block_hash")?;
 
             state
                 .get_txout_proof(&txids, block_hash)

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -94,6 +94,7 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) start_time: Instant,
     pub(super) user_agent: String,
     pub(super) proxy: Option<SocketAddr>,
+    pub(super) default_connection_is_v2: bool,
 }
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
@@ -308,7 +309,7 @@ async fn handle_json_rpc_request(
         "addnode" => {
             let node = get_at(&params, 0, "node")?;
             let command = get_at(&params, 1, "command")?;
-            let v2transport = get_with_default(&params, 2, "V2transport", false)?;
+            let v2transport = try_into_optional(get_at(&params, 2, "v2transport"))?;
 
             state
                 .add_node(node, command, v2transport)
@@ -669,6 +670,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         log_path: impl AsRef<Path>,
         user_agent: String,
         proxy: Option<SocketAddr>,
+        default_connection_is_v2: bool,
     ) {
         let address = address.unwrap_or_else(|| {
             format!("127.0.0.1:{}", network.default_rpc_port())
@@ -711,6 +713,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 start_time: Instant::now(),
                 user_agent,
                 proxy,
+                default_connection_is_v2,
             }));
 
         axum::serve(listener, router)

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -57,8 +57,8 @@ use super::res::GetRawTransactionRes;
 use super::res::jsonrpc_interface::JsonRpcError;
 use crate::json_rpc::request::RpcRequest;
 use crate::json_rpc::request::arg_parser::get_at;
+use crate::json_rpc::request::arg_parser::get_optional;
 use crate::json_rpc::request::arg_parser::get_with_default;
-use crate::json_rpc::request::arg_parser::try_into_optional;
 use crate::json_rpc::res::RescanConfidence;
 use crate::json_rpc::res::jsonrpc_interface::Response;
 
@@ -309,7 +309,7 @@ async fn handle_json_rpc_request(
         "addnode" => {
             let node = get_at(&params, 0, "node")?;
             let command = get_at(&params, 1, "command")?;
-            let v2transport = try_into_optional(get_at(&params, 2, "v2transport"))?;
+            let v2transport = get_optional(&params, 2, "v2transport")?;
 
             state
                 .add_node(node, command, v2transport)
@@ -319,7 +319,7 @@ async fn handle_json_rpc_request(
 
         "disconnectnode" => {
             let node_address = get_at(&params, 0, "node_address")?;
-            let node_id = try_into_optional(get_at(&params, 1, "node_id"))?;
+            let node_id = get_optional(&params, 1, "node_id")?;
 
             state
                 .disconnect_node(node_address, node_id)
@@ -332,7 +332,7 @@ async fn handle_json_rpc_request(
             let vout = get_at(&params, 1, "vout")?;
             let script: String = get_at(&params, 2, "script")?;
             let script = ScriptBuf::from_hex(&script).map_err(|_| JsonRpcError::InvalidScript)?;
-            let height = get_at(&params, 3, "height")?;
+            let height = get_with_default(&params, 3, "height", 0)?;
 
             state.clone().find_tx_out(txid, vout, script, height).await
         }
@@ -390,7 +390,7 @@ async fn handle_json_rpc_request(
         }
 
         "getdeploymentinfo" => {
-            let blockhash = try_into_optional(get_at(&params, 0, "blockhash"))?;
+            let blockhash = get_optional(&params, 0, "blockhash")?;
 
             state
                 .get_deployment_info(blockhash)
@@ -417,7 +417,7 @@ async fn handle_json_rpc_request(
 
         "gettxoutproof" => {
             let txids: Vec<Txid> = get_at(&params, 0, "txids")?;
-            let block_hash = try_into_optional(get_at(&params, 1, "block_hash"))?;
+            let block_hash = get_optional(&params, 1, "block_hash")?;
 
             state
                 .get_txout_proof(&txids, block_hash)

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -9,6 +9,8 @@ use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
 use serde::Serialize;
+use serde::de::Deserialize;
+use serde::de::DeserializeOwned;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -174,7 +176,7 @@ pub trait JsonRPCClient: Sized {
     /// This should call the appropriated rpc method and return a parsed response or error.
     fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
     where
-        T: for<'a> serde::de::Deserialize<'a> + serde::de::DeserializeOwned + Debug;
+        T: for<'a> Deserialize<'a> + DeserializeOwned + Debug;
 }
 
 impl<T: JsonRPCClient> FlorestaRPC for T {
@@ -434,7 +436,650 @@ fn rpc_params(args: impl IntoIterator<Item = RpcArg>) -> Vec<Value> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::vec;
+
+    use bitcoin::hashes::Hash;
+
     use super::*;
+
+    struct MockRpcClient {
+        method: RefCell<String>,
+        params: RefCell<Vec<Value>>,
+        result: RefCell<Option<Value>>,
+    }
+
+    impl MockRpcClient {
+        fn set_result(&self, result: Value) {
+            *self.result.borrow_mut() = Some(result);
+        }
+    }
+
+    impl MockRpcClient {
+        fn new() -> Self {
+            Self {
+                method: RefCell::new(String::new()),
+                params: RefCell::new(Vec::new()),
+                result: RefCell::new(None),
+            }
+        }
+    }
+
+    impl JsonRPCClient for MockRpcClient {
+        fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
+        where
+            T: for<'a> Deserialize<'a> + DeserializeOwned + Debug,
+        {
+            *self.method.borrow_mut() = method.to_string();
+            *self.params.borrow_mut() = params.to_vec();
+
+            let result = self
+                .result
+                .borrow()
+                .clone()
+                .unwrap_or(serde_json::json!(null));
+
+            serde_json::from_value(result)
+                .map_err(|_| Error::Api(Value::String("Result parsing error".to_string())))
+        }
+    }
+
+    #[test]
+    fn test_get_block_filter_params() {
+        let client = MockRpcClient::new();
+        let expected_result = "abcdef1234567890".to_string();
+        client.set_result(Value::String(expected_result.clone()));
+
+        let height = 500u32;
+
+        let result = client.get_block_filter(height).unwrap();
+        assert_eq!(result, expected_result);
+
+        let expected_params = rpc_params([height.into()]);
+
+        assert_eq!(*client.method.borrow(), "getblockfilter");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_blockchain_info() {
+        let client = MockRpcClient::new();
+        let get_blockchain_info_res = GetBlockchainInfo {
+            chain: "main".to_string(),
+            blocks: 1000,
+            headers: 1000,
+            best_block_hash: "".to_string(),
+            difficulty: 1.0,
+            automatic_pruning: None,
+            bits: "1d00ffff".to_string(),
+            chain_work: "".to_string(),
+            initial_block_download: false,
+            median_time: 0,
+            prune_height: None,
+            prune_target_size: None,
+            pruned: false,
+            signet_challenge: None,
+            size_on_disk: 0,
+            target: "1d00ffff".to_string(),
+            time: 0,
+            verification_progress: 1.0,
+            warnings: vec![],
+        };
+        let expected_result = serde_json::to_value(get_blockchain_info_res).unwrap();
+        client.set_result(expected_result.clone());
+
+        let result = client.get_blockchain_info().unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(result_serialized, expected_result);
+
+        assert_eq!(*client.method.borrow(), "getblockchaininfo");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_best_block_hash() {
+        let client = MockRpcClient::new();
+        let expected_result = BlockHash::all_zeros();
+        client.set_result(Value::String(expected_result.to_string()));
+
+        let result = client.get_best_block_hash().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getbestblockhash");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_block_hash() {
+        let client = MockRpcClient::new();
+        let expected_result = BlockHash::all_zeros();
+        client.set_result(Value::String(expected_result.to_string()));
+
+        let height = 100u32;
+
+        let result = client.get_block_hash(height).unwrap();
+
+        let expected_params = rpc_params([height.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockhash");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_block_header() {
+        let client: MockRpcClient = MockRpcClient::new();
+        let block_header = GetBlockHeaderRes::Raw("Header".to_string());
+        let expected_result = serde_json::to_value(block_header).unwrap();
+        client.set_result(expected_result.clone());
+
+        let block_hash = BlockHash::all_zeros();
+
+        let result = client.get_block_header(block_hash, None).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([block_hash.into(), None::<bool>.into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockheader");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        let result = client.get_block_header(block_hash, Some(true)).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([block_hash.into(), Some(true).into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockheader");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_transaction() {
+        let client = MockRpcClient::new();
+        let expected_result: GetRawTransactionRes =
+            GetRawTransactionRes::Zero("transactionhex".to_string());
+        let expected_result_serialize = serde_json::to_value(expected_result).unwrap();
+        client.set_result(expected_result_serialize.clone());
+
+        let tx_id = Txid::all_zeros();
+        let mut verbosity = Some(1);
+
+        let result = client.get_raw_transaction(tx_id, verbosity).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([tx_id.into(), verbosity.into()]); // verbosity is always passed
+
+        assert_eq!(result_serialized, expected_result_serialize);
+        assert_eq!(*client.method.borrow(), "getrawtransaction");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        verbosity = None;
+        let _ = client.get_raw_transaction(tx_id, None);
+
+        let expected_params = rpc_params([tx_id.into(), verbosity.into()]);
+
+        assert_eq!(*client.method.borrow(), "getrawtransaction");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_txout_proof() {
+        let client = MockRpcClient::new();
+        let expected_result = "proof".to_string();
+        client.set_result(Value::String(expected_result.clone()));
+
+        let txids = vec![Txid::all_zeros()];
+        let blockhash = Some(BlockHash::all_zeros());
+
+        let result = client.get_txout_proof(txids.clone(), blockhash).unwrap();
+
+        let expected_params = rpc_params([txids.clone().into(), blockhash.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "gettxoutproof");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without blockhash parameter
+        let _ = client.get_txout_proof(txids.clone(), None);
+
+        let expected_params = rpc_params([txids.clone().into(), None::<BlockHash>.into()]);
+
+        assert_eq!(*client.method.borrow(), "gettxoutproof");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_load_descriptor() {
+        let client = MockRpcClient::new();
+        let expected_result = true;
+        client.set_result(Value::Bool(expected_result));
+
+        let descriptor = "wpkh([aabbccdd/84'/0'/0']xpub6CatD...)".to_string();
+
+        let result = client.load_descriptor(descriptor.clone()).unwrap();
+
+        let expected_params = rpc_params([descriptor.clone().into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "loaddescriptor");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_rescanblockchain() {
+        let client = MockRpcClient::new();
+        let expected_result = true;
+        client.set_result(Value::Bool(expected_result));
+
+        let start_height = 100u32;
+        let stop_height = 200u32;
+        let use_timestamp = true;
+        let confidence = RescanConfidence::High;
+
+        let result = client
+            .rescanblockchain(
+                Some(start_height),
+                Some(stop_height),
+                use_timestamp,
+                confidence.clone(),
+            )
+            .unwrap();
+
+        let expected_params = [
+            Value::Number(Number::from(start_height)),
+            Value::Number(Number::from(stop_height)),
+            Value::Bool(use_timestamp),
+            serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
+        ];
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "rescanblockchain");
+        assert_eq!(client.params.borrow().len(), 4);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test with None parameters
+        let _ = client.rescanblockchain(None, None, use_timestamp, confidence.clone());
+
+        let expected_params = [
+            Value::Null,
+            Value::Null,
+            Value::Bool(use_timestamp),
+            serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
+        ];
+
+        assert_eq!(*client.method.borrow(), "rescanblockchain");
+        assert_eq!(client.params.borrow().len(), 4); // All parameters are passed, but start/stop heights are defaulted
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_block_count() {
+        let client = MockRpcClient::new();
+        let expected_result = 1000u32;
+        client.set_result(Value::Number(Number::from(expected_result)));
+
+        let result = client.get_block_count().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockcount");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_send_raw_transaction() {
+        let client = MockRpcClient::new();
+        let expected_result = Txid::all_zeros();
+        client.set_result(Value::String(expected_result.to_string()));
+
+        let tx = "02000000010123456789abcdef...".to_string();
+
+        let result = client.send_raw_transaction(tx.clone()).unwrap();
+
+        let expected_params = rpc_params([tx.clone().into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "sendrawtransaction");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_roots() {
+        let client = MockRpcClient::new();
+        let expected_result = vec!["root1".to_string(), "root2".to_string()];
+        client.set_result(Value::Array(
+            expected_result
+                .iter()
+                .map(|root| Value::String(root.clone()))
+                .collect(),
+        ));
+
+        let result = client.get_roots().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getroots");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_peer_info() {
+        let client = MockRpcClient::new();
+        let peer_info = vec![PeerInfo {
+            address: "address".to_string(),
+            id: 1,
+            initial_height: 100,
+            kind: "kind".to_string(),
+            services: "services".to_string(),
+            state: "state".to_string(),
+            transport_protocol: "transport_protocol".to_string(),
+            user_agent: "user_agent".to_string(),
+        }];
+        let expected_result = serde_json::to_value(&peer_info).unwrap();
+        client.set_result(expected_result.clone());
+
+        let result = client.get_peer_info().unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getpeerinfo");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_connection_count() {
+        let client = MockRpcClient::new();
+        let expected_result = 8usize;
+        client.set_result(Value::Number(Number::from(expected_result)));
+
+        let result = client.get_connection_count().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getconnectioncount");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_block() {
+        let client = MockRpcClient::new();
+        let get_block = GetBlockRes::Zero("block".to_string());
+        let expected_result = serde_json::to_value(&get_block).unwrap();
+        client.set_result(expected_result.clone());
+
+        let block_hash = BlockHash::all_zeros();
+        let verbosity = Some(1u32);
+
+        let result = client.get_block(block_hash, verbosity).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([block_hash.into(), verbosity.into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getblock");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without verbosity parameter
+        let _ = client.get_block(block_hash, None);
+
+        let expected_params = rpc_params([block_hash.into(), None::<u32>.into()]);
+
+        assert_eq!(*client.method.borrow(), "getblock");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_tx_out() {
+        let client = MockRpcClient::new();
+        let expected_result = GetTxOut {
+            best_block: "best_block".to_string(),
+            confirmations: 10,
+            value: 0.1,
+            coinbase: false,
+            script_pubkey: corepc_types::ScriptPubKey {
+                address: Some("address".to_string()),
+                asm: "asm".to_string(),
+                hex: "hex".to_string(),
+                type_: "type".to_string(),
+                addresses: None,
+                descriptor: None,
+                required_signatures: None,
+            },
+        };
+        client.set_result(serde_json::to_value(&expected_result).unwrap());
+
+        let tx_id = Txid::all_zeros();
+        let outpoint = 0u32;
+
+        let result = client.get_tx_out(tx_id, outpoint).unwrap();
+
+        let expected_params = rpc_params([tx_id.into(), outpoint.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "gettxout");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_stop() {
+        let client = MockRpcClient::new();
+        let _ = client.stop();
+
+        assert_eq!(*client.method.borrow(), "stop");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_add_node() {
+        let client = MockRpcClient::new();
+        let expected_result = serde_json::json!({"success": true});
+        client.set_result(expected_result.clone());
+
+        let node = "192.168.1.1:8333".to_string();
+        let command = AddNodeCommand::Add;
+        let v2transport = Some(true);
+
+        let result = client
+            .add_node(node.clone(), command.clone(), v2transport)
+            .unwrap();
+
+        let expected_params = rpc_params([
+            node.clone().into(),
+            command.clone().to_string().into(),
+            v2transport.into(),
+        ]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "addnode");
+        assert_eq!(client.params.borrow().len(), 3);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without v2transport parameter
+        let _ = client.add_node(node.clone(), command.clone(), None);
+
+        let expected_params = rpc_params([
+            node.clone().into(),
+            command.to_string().into(),
+            None::<bool>.into(),
+        ]);
+
+        assert_eq!(*client.method.borrow(), "addnode");
+        assert_eq!(client.params.borrow().len(), 3);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_disconnect_node() {
+        let client = MockRpcClient::new();
+        let expected_result = serde_json::json!({"success": true});
+        client.set_result(expected_result.clone());
+
+        let node_address = "192.168.1.1".to_string();
+        let node_id = Some(1u32);
+
+        let result = client
+            .disconnect_node(node_address.clone(), node_id)
+            .unwrap();
+
+        let expected_params = rpc_params([node_address.clone().into(), node_id.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "disconnectnode");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test with None node_id
+        let _ = client.disconnect_node(node_address.clone(), None);
+
+        let expected_params = rpc_params([node_address.clone().into(), None::<u32>.into()]);
+
+        assert_eq!(*client.method.borrow(), "disconnectnode");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_find_tx_out() {
+        let client = MockRpcClient::new();
+        let expected_result = serde_json::json!({"success": true});
+        client.set_result(expected_result.clone());
+
+        let txid = Txid::all_zeros();
+        let outpoint = 0;
+        let script = "76a91488ac".to_string();
+        let mut height_hint = Some(100);
+
+        let result = client
+            .find_tx_out(txid, outpoint, script.clone(), height_hint)
+            .unwrap();
+
+        let expetecd_params = rpc_params([
+            txid.into(),
+            outpoint.into(),
+            script.clone().into(),
+            height_hint.into(),
+        ]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "findtxout");
+        assert_eq!(client.params.borrow().len(), 4);
+        assert_eq!(*client.params.borrow(), expetecd_params);
+
+        // Test that None height hint is filtered out
+        height_hint = None;
+
+        let _ = client.find_tx_out(txid, outpoint, script.clone(), height_hint);
+
+        let expetecd_params = rpc_params([
+            txid.into(),
+            outpoint.into(),
+            script.clone().into(),
+            height_hint.into(),
+        ]);
+
+        assert_eq!(*client.method.borrow(), "findtxout");
+        assert_eq!(client.params.borrow().len(), 4);
+        assert_eq!(*client.params.borrow(), expetecd_params);
+    }
+
+    #[test]
+    fn test_get_memory_info() {
+        let client = MockRpcClient::new();
+        let memory_info = GetMemInfoRes::MallocInfo("Malloc".to_string());
+        let expected_result = serde_json::to_value(&memory_info).unwrap();
+        client.set_result(expected_result.clone());
+
+        let mode = Some("all".to_string());
+
+        let result = client.get_memory_info(mode.clone()).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([mode.clone().into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getmemoryinfo");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without mode parameter
+        let _ = client.get_memory_info(None);
+
+        let expected_params = rpc_params([None::<String>.into()]);
+
+        assert_eq!(*client.method.borrow(), "getmemoryinfo");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_rpc_info() {
+        let client = MockRpcClient::new();
+        let rpc_info = GetRpcInfoRes {
+            logpath: "logpath".to_string().into(),
+            active_commands: Vec::new(),
+        };
+        let expected_result = serde_json::to_value(&rpc_info).unwrap();
+        client.set_result(expected_result.clone());
+
+        let result = client.get_rpc_info().unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getrpcinfo");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_uptime() {
+        let client = MockRpcClient::new();
+        let expected_result = 3600u32;
+        client.set_result(Value::Number(Number::from(expected_result)));
+
+        let result = client.uptime().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "uptime");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_list_descriptors() {
+        let client = MockRpcClient::new();
+        let expect_ed_result = vec!["desc1".to_string(), "desc2".to_string()];
+        client.set_result(Value::Array(
+            expect_ed_result
+                .iter()
+                .map(|desc| Value::String(desc.clone()))
+                .collect(),
+        ));
+
+        let result = client.list_descriptors().unwrap();
+
+        assert_eq!(result, expect_ed_result);
+        assert_eq!(*client.method.borrow(), "listdescriptors");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_ping() {
+        let client = MockRpcClient::new();
+        client.ping().unwrap();
+
+        assert_eq!(*client.method.borrow(), "ping");
+        assert!(client.params.borrow().is_empty());
+    }
 
     #[test]
     fn test_rpc_arg_from_string() {
@@ -492,11 +1137,11 @@ mod tests {
         assert_eq!(params.len(), 7);
         assert!(matches!(params[0], Value::String(ref s) if s == "node1"));
         assert!(matches!(params[1], Value::Bool(true)));
-        assert!(matches!(params[2], Value::Number(_)));
+        assert!(matches!(&params[2], Value::Number(n) if n.as_u64() == Some(123)));
         assert!(matches!(params[3], Value::Null));
         assert!(matches!(params[4], Value::Null));
         assert!(matches!(params[5], Value::String(ref s) if s == "node2"));
-        assert!(matches!(params[6], Value::Number(_)));
+        assert!(matches!(&params[6], Value::Number(n) if n.as_u64() == Some(321)));
     }
 
     #[test]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -128,7 +128,12 @@ pub trait FlorestaRPC {
     /// If the `v2transport` option is set, we won't retry connecting using the old, unencrypted
     /// P2P protocol.
     #[doc = include_str!("../../../doc/rpc/addnode.md")]
-    fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value>;
+    fn add_node(
+        &self,
+        node: String,
+        command: AddNodeCommand,
+        v2transport: Option<bool>,
+    ) -> Result<Value>;
     /// Immediately disconnect from a peer.
     ///
     /// The peer can be referenced either by node_address or node_id.
@@ -203,15 +208,19 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getrpcinfo", &[])
     }
 
-    fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value> {
-        self.call(
-            "addnode",
-            &[
-                Value::String(node),
-                Value::String(command.to_string()),
-                Value::Bool(v2transport),
-            ],
-        )
+    fn add_node(
+        &self,
+        node: String,
+        command: AddNodeCommand,
+        v2transport: Option<bool>,
+    ) -> Result<Value> {
+        let mut params = vec![Value::String(node), Value::String(command.to_string())];
+
+        if let Some(v2transport) = v2transport {
+            params.push(Value::Bool(v2transport));
+        }
+
+        self.call("addnode", &params)
     }
 
     fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value> {

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::fmt::Debug;
-use std::vec;
 
 use bitcoin::BlockHash;
 use bitcoin::Txid;
@@ -9,6 +8,7 @@ use corepc_types::v29::GetTxOut;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
+use serde::Serialize;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -138,7 +138,7 @@ pub trait FlorestaRPC {
     ///
     /// The peer can be referenced either by node_address or node_id.
     /// If referencing by node_id, an empty string must be passed as the node_address.
-    fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value>;
+    fn disconnect_node(&self, node_address: String, node_id: Option<u32>) -> Result<Value>;
     /// Finds an specific utxo in the chain
     ///
     /// You can use this to look for a utxo. If it exists, it will return the amount and
@@ -149,10 +149,10 @@ pub trait FlorestaRPC {
         tx_id: Txid,
         outpoint: u32,
         script: String,
-        height_hint: u32,
+        height_hint: Option<u32>,
     ) -> Result<Value>;
     #[doc = include_str!("../../../doc/rpc/getmemoryinfo.md")]
-    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
+    fn get_memory_info(&self, mode: Option<String>) -> Result<GetMemInfoRes>;
     #[doc = include_str!("../../../doc/rpc/getrpcinfo.md")]
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
     #[doc = include_str!("../../../doc/rpc/uptime.md")]
@@ -183,25 +183,25 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         tx_id: Txid,
         outpoint: u32,
         script: String,
-        height_hint: u32,
+        height_hint: Option<u32>,
     ) -> Result<Value> {
-        self.call(
-            "findtxout",
-            &[
-                Value::String(tx_id.to_string()),
-                Value::Number(Number::from(outpoint)),
-                Value::String(script),
-                Value::Number(Number::from(height_hint)),
-            ],
-        )
+        let params = rpc_params([
+            tx_id.into(),
+            outpoint.into(),
+            script.into(),
+            height_hint.into(),
+        ]);
+
+        self.call("findtxout", &params)
     }
 
     fn uptime(&self) -> Result<u32> {
         self.call("uptime", &[])
     }
 
-    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes> {
-        self.call("getmemoryinfo", &[Value::String(mode)])
+    fn get_memory_info(&self, mode: Option<String>) -> Result<GetMemInfoRes> {
+        let params = rpc_params([mode.into()]);
+        self.call("getmemoryinfo", &params)
     }
 
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes> {
@@ -214,26 +214,15 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         command: AddNodeCommand,
         v2transport: Option<bool>,
     ) -> Result<Value> {
-        let mut params = vec![Value::String(node), Value::String(command.to_string())];
-
-        if let Some(v2transport) = v2transport {
-            params.push(Value::Bool(v2transport));
-        }
+        let params = rpc_params([node.into(), command.to_string().into(), v2transport.into()]);
 
         self.call("addnode", &params)
     }
 
-    fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value> {
-        match node_id {
-            Some(node_id) => self.call(
-                "disconnectnode",
-                &[
-                    Value::String(node_address),
-                    Value::Number(Number::from(node_id)),
-                ],
-            ),
-            None => self.call("disconnectnode", &[Value::String(node_address)]),
-        }
+    fn disconnect_node(&self, node_address: String, node_id: Option<u32>) -> Result<Value> {
+        let params = rpc_params([node_address.into(), node_id.into()]);
+
+        self.call("disconnectnode", &params)
     }
 
     fn stop(&self) -> Result<String> {
@@ -247,19 +236,16 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         use_timestamp: bool,
         confidence: RescanConfidence,
     ) -> Result<bool> {
-        let start_height = start_height.unwrap_or(0u32);
+        let params = rpc_params([
+            start_height.into(),
+            stop_height.into(),
+            use_timestamp.into(),
+            serde_json::to_value(&confidence)
+                .expect("RescanConfidence implements Ser/De")
+                .into(),
+        ]);
 
-        let stop_height = stop_height.unwrap_or(0u32);
-
-        self.call(
-            "rescanblockchain",
-            &[
-                Value::Number(Number::from(start_height)),
-                Value::Number(Number::from(stop_height)),
-                Value::Bool(use_timestamp),
-                serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
-            ],
-        )
+        self.call("rescanblockchain", &params)
     }
 
     fn get_roots(&self) -> Result<Vec<String>> {
@@ -267,15 +253,9 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes> {
-        let verbosity = verbosity.unwrap_or(1);
+        let params = rpc_params([hash.into(), verbosity.into()]);
 
-        self.call(
-            "getblock",
-            &[
-                Value::String(hash.to_string()),
-                Value::Number(Number::from(verbosity)),
-            ],
-        )
+        self.call("getblock", &params)
     }
 
     fn get_block_count(&self) -> Result<u32> {
@@ -283,10 +263,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_deployment_info(&self, blockhash: Option<BlockHash>) -> Result<GetDeploymentInfo> {
-        let params = match blockhash {
-            Some(h) => vec![Value::String(h.to_string())],
-            None => vec![],
-        };
+        let params = rpc_params([blockhash.into()]);
         self.call("getdeploymentinfo", &params)
     }
 
@@ -295,32 +272,18 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut> {
-        let result: serde_json::Value = self.call(
-            "gettxout",
-            &[
-                Value::String(tx_id.to_string()),
-                Value::Number(Number::from(outpoint)),
-            ],
-        )?;
+        let params = rpc_params([tx_id.into(), outpoint.into()]);
+
+        let result: serde_json::Value = self.call("gettxout", &params)?;
         if result.is_null() {
             return Err(Error::TxOutNotFound);
         }
+
         serde_json::from_value(result).map_err(Error::Serde)
     }
 
     fn get_txout_proof(&self, txids: Vec<Txid>, blockhash: Option<BlockHash>) -> Result<String> {
-        let params: Vec<Value> = match blockhash {
-            Some(blockhash) => vec![
-                serde_json::to_value(txids)
-                    .expect("Unreachable, Vec<Txid> can be parsed into a json value"),
-                Value::String(blockhash.to_string()),
-            ],
-            None => {
-                let txids = serde_json::to_value(txids)
-                    .expect("Unreachable, Vec<Txid> can be parsed into a json value");
-                vec![txids]
-            }
-        };
+        let params = rpc_params([txids.into(), blockhash.into()]);
         self.call("gettxoutproof", &params)
     }
 
@@ -341,7 +304,8 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_block_hash(&self, height: u32) -> Result<BlockHash> {
-        self.call("getblockhash", &[Value::Number(Number::from(height))])
+        let params = rpc_params([height.into()]);
+        self.call("getblockhash", &params)
     }
 
     fn get_raw_transaction(
@@ -349,21 +313,19 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         tx_id: Txid,
         verbosity: Option<u8>,
     ) -> Result<GetRawTransactionRes> {
-        let mut params = vec![Value::String(tx_id.to_string())];
-
-        if let Some(verbosity) = verbosity {
-            params.push(Value::Number(Number::from(verbosity)));
-        }
+        let params = rpc_params([tx_id.into(), verbosity.into()]);
 
         self.call("getrawtransaction", &params)
     }
 
     fn load_descriptor(&self, descriptor: String) -> Result<bool> {
-        self.call("loaddescriptor", &[Value::String(descriptor)])
+        let params = rpc_params([descriptor.into()]);
+        self.call("loaddescriptor", &params)
     }
 
     fn get_block_filter(&self, height: u32) -> Result<String> {
-        self.call("getblockfilter", &[Value::Number(Number::from(height))])
+        let params = rpc_params([height.into()]);
+        self.call("getblockfilter", &params)
     }
 
     fn get_block_header(
@@ -371,10 +333,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         hash: BlockHash,
         verbosity: Option<bool>,
     ) -> Result<GetBlockHeaderRes> {
-        let mut params = vec![Value::String(hash.to_string())];
-        if let Some(verbosity) = verbosity {
-            params.push(Value::Bool(verbosity));
-        }
+        let params = rpc_params([hash.into(), verbosity.into()]);
         self.call("getblockheader", &params)
     }
 
@@ -383,7 +342,8 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn send_raw_transaction(&self, tx: String) -> Result<Txid> {
-        self.call("sendrawtransaction", &[Value::String(tx)])
+        let params = rpc_params([tx.into()]);
+        self.call("sendrawtransaction", &params)
     }
 
     fn list_descriptors(&self) -> Result<Vec<String>> {
@@ -396,5 +356,155 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+}
+
+enum RpcArg {
+    Value(Value),
+    Optional(Option<Value>),
+}
+
+impl From<String> for RpcArg {
+    fn from(v: String) -> Self {
+        Self::Value(Value::String(v))
+    }
+}
+
+impl From<&str> for RpcArg {
+    fn from(v: &str) -> Self {
+        Self::Value(Value::String(v.to_owned()))
+    }
+}
+
+impl From<bool> for RpcArg {
+    fn from(v: bool) -> Self {
+        Self::Value(Value::Bool(v))
+    }
+}
+
+impl From<u32> for RpcArg {
+    fn from(v: u32) -> Self {
+        Self::Value(Value::Number(Number::from(v)))
+    }
+}
+
+impl From<Txid> for RpcArg {
+    fn from(value: Txid) -> Self {
+        Self::Value(Value::String(value.to_string()))
+    }
+}
+
+impl From<BlockHash> for RpcArg {
+    fn from(value: BlockHash) -> Self {
+        Self::Value(Value::String(value.to_string()))
+    }
+}
+
+impl<T: Serialize> From<Vec<T>> for RpcArg {
+    fn from(v: Vec<T>) -> Self {
+        let values: Vec<Value> = v
+            .into_iter()
+            .filter_map(|item| serde_json::to_value(item).ok())
+            .collect();
+        Self::Value(Value::Array(values))
+    }
+}
+
+impl<T: Serialize> From<Option<T>> for RpcArg {
+    fn from(v: Option<T>) -> Self {
+        Self::Optional(v.and_then(|x| serde_json::to_value(x).ok()))
+    }
+}
+
+impl From<Value> for RpcArg {
+    fn from(v: Value) -> Self {
+        Self::Value(v)
+    }
+}
+
+fn rpc_params(args: impl IntoIterator<Item = RpcArg>) -> Vec<Value> {
+    args.into_iter()
+        .map(|arg| match arg {
+            RpcArg::Value(v) => v,
+            RpcArg::Optional(Some(v)) => v,
+            RpcArg::Optional(None) => Value::Null,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rpc_arg_from_string() {
+        let arg = RpcArg::from("test".to_string());
+        match arg {
+            RpcArg::Value(Value::String(s)) => assert_eq!(s, "test"),
+            _ => panic!("Expected RpcArg::Value"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_arg_from_bool() {
+        let arg = RpcArg::from(true);
+        match arg {
+            RpcArg::Value(Value::Bool(b)) => assert!(b),
+            _ => panic!("Expected RpcArg::Value with bool"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_arg_from_option_some() {
+        let opt: Option<u32> = Some(42);
+        let arg = RpcArg::from(opt);
+        match arg {
+            RpcArg::Optional(Some(Value::Number(n))) => {
+                assert_eq!(n.as_u64(), Some(42));
+            }
+            _ => panic!("Expected RpcArg::Optional(Some(...))"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_arg_from_option_none() {
+        let opt: Option<u32> = None;
+        let arg = RpcArg::from(opt);
+        match arg {
+            RpcArg::Optional(None) => {}
+            _ => panic!("Expected RpcArg::Optional(None)"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_params_preserves_null_for_none() {
+        let params = rpc_params([
+            "node1".into(),
+            true.into(),
+            Some(123u32).into(),
+            None::<u32>.into(),
+            None::<String>.into(),
+            "node2".into(),
+            Some(321u32).into(),
+        ]);
+
+        // Should have only 3 elements (None was filtered)
+        assert_eq!(params.len(), 7);
+        assert!(matches!(params[0], Value::String(ref s) if s == "node1"));
+        assert!(matches!(params[1], Value::Bool(true)));
+        assert!(matches!(params[2], Value::Number(_)));
+        assert!(matches!(params[3], Value::Null));
+        assert!(matches!(params[4], Value::Null));
+        assert!(matches!(params[5], Value::String(ref s) if s == "node2"));
+        assert!(matches!(params[6], Value::Number(_)));
+    }
+
+    #[test]
+    fn test_rpc_params_all_none() {
+        let params = rpc_params([None::<u32>.into(), None::<String>.into()]);
+
+        assert_eq!(params.len(), 2);
+        assert!(matches!(params[0], Value::Null));
+        assert!(matches!(params[1], Value::Null));
     }
 }

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -124,7 +124,12 @@ pub trait FlorestaRPC {
     /// If the `v2transport` option is set, we won't retry connecting using the old, unencrypted
     /// P2P protocol.
     #[doc = include_str!("../../../doc/rpc/addnode.md")]
-    fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value>;
+    fn add_node(
+        &self,
+        node: String,
+        command: AddNodeCommand,
+        v2transport: Option<bool>,
+    ) -> Result<Value>;
     /// Immediately disconnect from a peer.
     ///
     /// The peer can be referenced either by node_address or node_id.
@@ -199,15 +204,19 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getrpcinfo", &[])
     }
 
-    fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value> {
-        self.call(
-            "addnode",
-            &[
-                Value::String(node),
-                Value::String(command.to_string()),
-                Value::Bool(v2transport),
-            ],
-        )
+    fn add_node(
+        &self,
+        node: String,
+        command: AddNodeCommand,
+        v2transport: Option<bool>,
+    ) -> Result<Value> {
+        let mut params = vec![Value::String(node), Value::String(command.to_string())];
+
+        if let Some(v2transport) = v2transport {
+            params.push(Value::Bool(v2transport));
+        }
+
+        self.call("addnode", &params)
     }
 
     fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value> {

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -9,6 +9,8 @@ use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
 use serde::Serialize;
+use serde::de::Deserialize;
+use serde::de::DeserializeOwned;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -170,7 +172,7 @@ pub trait JsonRPCClient: Sized {
     /// This should call the appropriated rpc method and return a parsed response or error.
     fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
     where
-        T: for<'a> serde::de::Deserialize<'a> + serde::de::DeserializeOwned + Debug;
+        T: for<'a> Deserialize<'a> + DeserializeOwned + Debug;
 }
 
 impl<T: JsonRPCClient> FlorestaRPC for T {
@@ -430,7 +432,657 @@ fn rpc_params(args: impl IntoIterator<Item = RpcArg>) -> Vec<Value> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::vec;
+
+    use bitcoin::hashes::Hash;
+
     use super::*;
+
+    struct MockRpcClient {
+        method: RefCell<String>,
+        params: RefCell<Vec<Value>>,
+        result: RefCell<Option<Value>>,
+    }
+
+    impl MockRpcClient {
+        fn set_result(&self, result: Value) {
+            *self.result.borrow_mut() = Some(result);
+        }
+    }
+
+    impl MockRpcClient {
+        fn new() -> Self {
+            Self {
+                method: RefCell::new(String::new()),
+                params: RefCell::new(Vec::new()),
+                result: RefCell::new(None),
+            }
+        }
+    }
+
+    impl JsonRPCClient for MockRpcClient {
+        fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
+        where
+            T: for<'a> Deserialize<'a> + DeserializeOwned + Debug,
+        {
+            *self.method.borrow_mut() = method.to_string();
+            *self.params.borrow_mut() = params.to_vec();
+
+            let result = self
+                .result
+                .borrow()
+                .clone()
+                .unwrap_or(serde_json::json!(null));
+
+            serde_json::from_value(result)
+                .map_err(|_| Error::Api(Value::String("Result parsing error".to_string())))
+        }
+    }
+
+    #[test]
+    fn test_get_block_filter_params() {
+        let client = MockRpcClient::new();
+        let expected_result = "abcdef1234567890".to_string();
+        client.set_result(Value::String(expected_result.clone()));
+
+        let height = 500u32;
+
+        let result = client.get_block_filter(height).unwrap();
+        assert_eq!(result, expected_result);
+
+        let expected_params = rpc_params([height.into()]);
+
+        assert_eq!(*client.method.borrow(), "getblockfilter");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_blockchain_info() {
+        let client = MockRpcClient::new();
+        let get_blockchain_info_res = GetBlockchainInfo {
+            chain: "main".to_string(),
+            blocks: 1000,
+            headers: 1000,
+            best_block_hash: "".to_string(),
+            difficulty: 1.0,
+            automatic_pruning: None,
+            bits: "1d00ffff".to_string(),
+            chain_work: "".to_string(),
+            initial_block_download: false,
+            median_time: 0,
+            prune_height: None,
+            prune_target_size: None,
+            pruned: false,
+            signet_challenge: None,
+            size_on_disk: 0,
+            target: "1d00ffff".to_string(),
+            time: 0,
+            verification_progress: 1.0,
+            warnings: vec![],
+        };
+        let expected_result = serde_json::to_value(get_blockchain_info_res).unwrap();
+        client.set_result(expected_result.clone());
+
+        let result = client.get_blockchain_info().unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(result_serialized, expected_result);
+
+        assert_eq!(*client.method.borrow(), "getblockchaininfo");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_best_block_hash() {
+        let client = MockRpcClient::new();
+        let expected_result = BlockHash::all_zeros();
+        client.set_result(Value::String(expected_result.to_string()));
+
+        let result = client.get_best_block_hash().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getbestblockhash");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_block_hash() {
+        let client = MockRpcClient::new();
+        let expected_result = BlockHash::all_zeros();
+        client.set_result(Value::String(expected_result.to_string()));
+
+        let height = 100u32;
+
+        let result = client.get_block_hash(height).unwrap();
+
+        let expected_params = rpc_params([height.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockhash");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_block_header() {
+        let client: MockRpcClient = MockRpcClient::new();
+        let block_header = GetBlockHeaderRes::Raw("Header".to_string());
+        let expected_result = serde_json::to_value(block_header).unwrap();
+        client.set_result(expected_result.clone());
+
+        let block_hash = BlockHash::all_zeros();
+
+        let result = client.get_block_header(block_hash, None).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([block_hash.into(), None::<bool>.into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockheader");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        let result = client.get_block_header(block_hash, Some(true)).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([block_hash.into(), Some(true).into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockheader");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_transaction() {
+        let client = MockRpcClient::new();
+        let expected_result: GetRawTransactionRes =
+            GetRawTransactionRes::Zero("transactionhex".to_string());
+        let expected_result_serialize = serde_json::to_value(expected_result).unwrap();
+        client.set_result(expected_result_serialize.clone());
+
+        let tx_id = Txid::all_zeros();
+        let mut verbosity = Some(1);
+
+        let result = client.get_raw_transaction(tx_id, verbosity).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([tx_id.into(), verbosity.into()]); // verbosity is always passed
+
+        assert_eq!(result_serialized, expected_result_serialize);
+        assert_eq!(*client.method.borrow(), "getrawtransaction");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        verbosity = None;
+        let _ = client.get_raw_transaction(tx_id, None);
+
+        let expected_params = rpc_params([tx_id.into(), verbosity.into()]);
+
+        assert_eq!(*client.method.borrow(), "getrawtransaction");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_txout_proof() {
+        let client = MockRpcClient::new();
+        let expected_result = "proof".to_string();
+        client.set_result(Value::String(expected_result.clone()));
+
+        let txids = vec![Txid::all_zeros()];
+        let blockhash = Some(BlockHash::all_zeros());
+
+        let result = client.get_txout_proof(txids.clone(), blockhash).unwrap();
+
+        let expected_params = rpc_params([txids.clone().into(), blockhash.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "gettxoutproof");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without blockhash parameter
+        let _ = client.get_txout_proof(txids.clone(), None);
+
+        let expected_params = rpc_params([txids.clone().into(), None::<BlockHash>.into()]);
+
+        assert_eq!(*client.method.borrow(), "gettxoutproof");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_load_descriptor() {
+        let client = MockRpcClient::new();
+        let expected_result = true;
+        client.set_result(Value::Bool(expected_result));
+
+        let descriptor = "wpkh([aabbccdd/84'/0'/0']xpub6CatD...)".to_string();
+
+        let result = client.load_descriptor(descriptor.clone()).unwrap();
+
+        let expected_params = rpc_params([descriptor.clone().into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "loaddescriptor");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_rescanblockchain() {
+        let client = MockRpcClient::new();
+        let expected_result = true;
+        client.set_result(Value::Bool(expected_result));
+
+        let start_height = 100u32;
+        let stop_height = 200u32;
+        let use_timestamp = true;
+        let confidence = RescanConfidence::High;
+
+        let result = client
+            .rescanblockchain(
+                Some(start_height),
+                Some(stop_height),
+                use_timestamp,
+                confidence.clone(),
+            )
+            .unwrap();
+
+        let expected_params = [
+            Value::Number(Number::from(start_height)),
+            Value::Number(Number::from(stop_height)),
+            Value::Bool(use_timestamp),
+            serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
+        ];
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "rescanblockchain");
+        assert_eq!(client.params.borrow().len(), 4);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test with None parameters
+        let _ = client.rescanblockchain(None, None, use_timestamp, confidence.clone());
+
+        let expected_params = [
+            Value::Null,
+            Value::Null,
+            Value::Bool(use_timestamp),
+            serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
+        ];
+
+        assert_eq!(*client.method.borrow(), "rescanblockchain");
+        assert_eq!(client.params.borrow().len(), 4); // All parameters are passed, but start/stop heights are defaulted
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_block_count() {
+        let client = MockRpcClient::new();
+        let expected_result = 1000u32;
+        client.set_result(Value::Number(Number::from(expected_result)));
+
+        let result = client.get_block_count().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getblockcount");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_send_raw_transaction() {
+        let client = MockRpcClient::new();
+        let expected_result = Txid::all_zeros();
+        client.set_result(Value::String(expected_result.to_string()));
+
+        let tx = "02000000010123456789abcdef...".to_string();
+
+        let result = client.send_raw_transaction(tx.clone()).unwrap();
+
+        let expected_params = rpc_params([tx.clone().into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "sendrawtransaction");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_roots() {
+        let client = MockRpcClient::new();
+        let expected_result = vec!["root1".to_string(), "root2".to_string()];
+        client.set_result(Value::Array(
+            expected_result
+                .iter()
+                .map(|root| Value::String(root.clone()))
+                .collect(),
+        ));
+
+        let result = client.get_roots().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getroots");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_peer_info() {
+        let client = MockRpcClient::new();
+        let peer_info = vec![PeerInfo {
+            address: "address".to_string(),
+            id: 1,
+            initial_height: 100,
+            kind: "kind".to_string(),
+            services: "services".to_string(),
+            state: "state".to_string(),
+            transport_protocol: "transport_protocol".to_string(),
+            user_agent: "user_agent".to_string(),
+            bip152_hb_from: false,
+            bip152_hb_to: false,
+            inbound: true,
+            permissions: vec![],
+            relay_txs: true,
+            services_names: vec![],
+            time_offset: 1,
+        }];
+        let expected_result = serde_json::to_value(&peer_info).unwrap();
+        client.set_result(expected_result.clone());
+
+        let result = client.get_peer_info().unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getpeerinfo");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_connection_count() {
+        let client = MockRpcClient::new();
+        let expected_result = 8usize;
+        client.set_result(Value::Number(Number::from(expected_result)));
+
+        let result = client.get_connection_count().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "getconnectioncount");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_get_block() {
+        let client = MockRpcClient::new();
+        let get_block = GetBlockRes::Zero("block".to_string());
+        let expected_result = serde_json::to_value(&get_block).unwrap();
+        client.set_result(expected_result.clone());
+
+        let block_hash = BlockHash::all_zeros();
+        let verbosity = Some(1u32);
+
+        let result = client.get_block(block_hash, verbosity).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([block_hash.into(), verbosity.into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getblock");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without verbosity parameter
+        let _ = client.get_block(block_hash, None);
+
+        let expected_params = rpc_params([block_hash.into(), None::<u32>.into()]);
+
+        assert_eq!(*client.method.borrow(), "getblock");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_tx_out() {
+        let client = MockRpcClient::new();
+        let expected_result = GetTxOut {
+            best_block: "best_block".to_string(),
+            confirmations: 10,
+            value: 0.1,
+            coinbase: false,
+            script_pubkey: corepc_types::ScriptPubKey {
+                address: Some("address".to_string()),
+                asm: "asm".to_string(),
+                hex: "hex".to_string(),
+                type_: "type".to_string(),
+                addresses: None,
+                descriptor: None,
+                required_signatures: None,
+            },
+        };
+        client.set_result(serde_json::to_value(&expected_result).unwrap());
+
+        let tx_id = Txid::all_zeros();
+        let outpoint = 0u32;
+
+        let result = client.get_tx_out(tx_id, outpoint).unwrap();
+
+        let expected_params = rpc_params([tx_id.into(), outpoint.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "gettxout");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_stop() {
+        let client = MockRpcClient::new();
+        let _ = client.stop();
+
+        assert_eq!(*client.method.borrow(), "stop");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_add_node() {
+        let client = MockRpcClient::new();
+        let expected_result = serde_json::json!({"success": true});
+        client.set_result(expected_result.clone());
+
+        let node = "192.168.1.1:8333".to_string();
+        let command = AddNodeCommand::Add;
+        let v2transport = Some(true);
+
+        let result = client
+            .add_node(node.clone(), command.clone(), v2transport)
+            .unwrap();
+
+        let expected_params = rpc_params([
+            node.clone().into(),
+            command.clone().to_string().into(),
+            v2transport.into(),
+        ]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "addnode");
+        assert_eq!(client.params.borrow().len(), 3);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without v2transport parameter
+        let _ = client.add_node(node.clone(), command.clone(), None);
+
+        let expected_params = rpc_params([
+            node.clone().into(),
+            command.to_string().into(),
+            None::<bool>.into(),
+        ]);
+
+        assert_eq!(*client.method.borrow(), "addnode");
+        assert_eq!(client.params.borrow().len(), 3);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_disconnect_node() {
+        let client = MockRpcClient::new();
+        let expected_result = serde_json::json!({"success": true});
+        client.set_result(expected_result.clone());
+
+        let node_address = "192.168.1.1".to_string();
+        let node_id = Some(1u32);
+
+        let result = client
+            .disconnect_node(node_address.clone(), node_id)
+            .unwrap();
+
+        let expected_params = rpc_params([node_address.clone().into(), node_id.into()]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "disconnectnode");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test with None node_id
+        let _ = client.disconnect_node(node_address.clone(), None);
+
+        let expected_params = rpc_params([node_address.clone().into(), None::<u32>.into()]);
+
+        assert_eq!(*client.method.borrow(), "disconnectnode");
+        assert_eq!(client.params.borrow().len(), 2);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_find_tx_out() {
+        let client = MockRpcClient::new();
+        let expected_result = serde_json::json!({"success": true});
+        client.set_result(expected_result.clone());
+
+        let txid = Txid::all_zeros();
+        let outpoint = 0;
+        let script = "76a91488ac".to_string();
+        let mut height_hint = Some(100);
+
+        let result = client
+            .find_tx_out(txid, outpoint, script.clone(), height_hint)
+            .unwrap();
+
+        let expetecd_params = rpc_params([
+            txid.into(),
+            outpoint.into(),
+            script.clone().into(),
+            height_hint.into(),
+        ]);
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "findtxout");
+        assert_eq!(client.params.borrow().len(), 4);
+        assert_eq!(*client.params.borrow(), expetecd_params);
+
+        // Test that None height hint is filtered out
+        height_hint = None;
+
+        let _ = client.find_tx_out(txid, outpoint, script.clone(), height_hint);
+
+        let expetecd_params = rpc_params([
+            txid.into(),
+            outpoint.into(),
+            script.clone().into(),
+            height_hint.into(),
+        ]);
+
+        assert_eq!(*client.method.borrow(), "findtxout");
+        assert_eq!(client.params.borrow().len(), 4);
+        assert_eq!(*client.params.borrow(), expetecd_params);
+    }
+
+    #[test]
+    fn test_get_memory_info() {
+        let client = MockRpcClient::new();
+        let memory_info = GetMemInfoRes::MallocInfo("Malloc".to_string());
+        let expected_result = serde_json::to_value(&memory_info).unwrap();
+        client.set_result(expected_result.clone());
+
+        let mode = Some("all".to_string());
+
+        let result = client.get_memory_info(mode.clone()).unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        let expected_params = rpc_params([mode.clone().into()]);
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getmemoryinfo");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+
+        // Test without mode parameter
+        let _ = client.get_memory_info(None);
+
+        let expected_params = rpc_params([None::<String>.into()]);
+
+        assert_eq!(*client.method.borrow(), "getmemoryinfo");
+        assert_eq!(client.params.borrow().len(), 1);
+        assert_eq!(*client.params.borrow(), expected_params);
+    }
+
+    #[test]
+    fn test_get_rpc_info() {
+        let client = MockRpcClient::new();
+        let rpc_info = GetRpcInfoRes {
+            logpath: "logpath".to_string().into(),
+            active_commands: Vec::new(),
+        };
+        let expected_result = serde_json::to_value(&rpc_info).unwrap();
+        client.set_result(expected_result.clone());
+
+        let result = client.get_rpc_info().unwrap();
+        let result_serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(result_serialized, expected_result);
+        assert_eq!(*client.method.borrow(), "getrpcinfo");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_uptime() {
+        let client = MockRpcClient::new();
+        let expected_result = 3600u32;
+        client.set_result(Value::Number(Number::from(expected_result)));
+
+        let result = client.uptime().unwrap();
+
+        assert_eq!(result, expected_result);
+        assert_eq!(*client.method.borrow(), "uptime");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_list_descriptors() {
+        let client = MockRpcClient::new();
+        let expect_ed_result = vec!["desc1".to_string(), "desc2".to_string()];
+        client.set_result(Value::Array(
+            expect_ed_result
+                .iter()
+                .map(|desc| Value::String(desc.clone()))
+                .collect(),
+        ));
+
+        let result = client.list_descriptors().unwrap();
+
+        assert_eq!(result, expect_ed_result);
+        assert_eq!(*client.method.borrow(), "listdescriptors");
+        assert!(client.params.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_ping() {
+        let client = MockRpcClient::new();
+        client.ping().unwrap();
+
+        assert_eq!(*client.method.borrow(), "ping");
+        assert!(client.params.borrow().is_empty());
+    }
 
     #[test]
     fn test_rpc_arg_from_string() {
@@ -488,11 +1140,11 @@ mod tests {
         assert_eq!(params.len(), 7);
         assert!(matches!(params[0], Value::String(ref s) if s == "node1"));
         assert!(matches!(params[1], Value::Bool(true)));
-        assert!(matches!(params[2], Value::Number(_)));
+        assert!(matches!(&params[2], Value::Number(n) if n.as_u64() == Some(123)));
         assert!(matches!(params[3], Value::Null));
         assert!(matches!(params[4], Value::Null));
         assert!(matches!(params[5], Value::String(ref s) if s == "node2"));
-        assert!(matches!(params[6], Value::Number(_)));
+        assert!(matches!(&params[6], Value::Number(n) if n.as_u64() == Some(321)));
     }
 
     #[test]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::fmt::Debug;
-use std::vec;
 
 use bitcoin::BlockHash;
 use bitcoin::Txid;
@@ -9,6 +8,7 @@ use corepc_types::v29::GetTxOut;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
+use serde::Serialize;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -134,7 +134,7 @@ pub trait FlorestaRPC {
     ///
     /// The peer can be referenced either by node_address or node_id.
     /// If referencing by node_id, an empty string must be passed as the node_address.
-    fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value>;
+    fn disconnect_node(&self, node_address: String, node_id: Option<u32>) -> Result<Value>;
     /// Finds an specific utxo in the chain
     ///
     /// You can use this to look for a utxo. If it exists, it will return the amount and
@@ -145,10 +145,10 @@ pub trait FlorestaRPC {
         tx_id: Txid,
         outpoint: u32,
         script: String,
-        height_hint: u32,
+        height_hint: Option<u32>,
     ) -> Result<Value>;
     #[doc = include_str!("../../../doc/rpc/getmemoryinfo.md")]
-    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
+    fn get_memory_info(&self, mode: Option<String>) -> Result<GetMemInfoRes>;
     #[doc = include_str!("../../../doc/rpc/getrpcinfo.md")]
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
     #[doc = include_str!("../../../doc/rpc/uptime.md")]
@@ -179,25 +179,25 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         tx_id: Txid,
         outpoint: u32,
         script: String,
-        height_hint: u32,
+        height_hint: Option<u32>,
     ) -> Result<Value> {
-        self.call(
-            "findtxout",
-            &[
-                Value::String(tx_id.to_string()),
-                Value::Number(Number::from(outpoint)),
-                Value::String(script),
-                Value::Number(Number::from(height_hint)),
-            ],
-        )
+        let params = rpc_params([
+            tx_id.into(),
+            outpoint.into(),
+            script.into(),
+            height_hint.into(),
+        ]);
+
+        self.call("findtxout", &params)
     }
 
     fn uptime(&self) -> Result<u32> {
         self.call("uptime", &[])
     }
 
-    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes> {
-        self.call("getmemoryinfo", &[Value::String(mode)])
+    fn get_memory_info(&self, mode: Option<String>) -> Result<GetMemInfoRes> {
+        let params = rpc_params([mode.into()]);
+        self.call("getmemoryinfo", &params)
     }
 
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes> {
@@ -210,26 +210,15 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         command: AddNodeCommand,
         v2transport: Option<bool>,
     ) -> Result<Value> {
-        let mut params = vec![Value::String(node), Value::String(command.to_string())];
-
-        if let Some(v2transport) = v2transport {
-            params.push(Value::Bool(v2transport));
-        }
+        let params = rpc_params([node.into(), command.to_string().into(), v2transport.into()]);
 
         self.call("addnode", &params)
     }
 
-    fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value> {
-        match node_id {
-            Some(node_id) => self.call(
-                "disconnectnode",
-                &[
-                    Value::String(node_address),
-                    Value::Number(Number::from(node_id)),
-                ],
-            ),
-            None => self.call("disconnectnode", &[Value::String(node_address)]),
-        }
+    fn disconnect_node(&self, node_address: String, node_id: Option<u32>) -> Result<Value> {
+        let params = rpc_params([node_address.into(), node_id.into()]);
+
+        self.call("disconnectnode", &params)
     }
 
     fn stop(&self) -> Result<String> {
@@ -243,19 +232,16 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         use_timestamp: bool,
         confidence: RescanConfidence,
     ) -> Result<bool> {
-        let start_height = start_height.unwrap_or(0u32);
+        let params = rpc_params([
+            start_height.into(),
+            stop_height.into(),
+            use_timestamp.into(),
+            serde_json::to_value(&confidence)
+                .expect("RescanConfidence implements Ser/De")
+                .into(),
+        ]);
 
-        let stop_height = stop_height.unwrap_or(0u32);
-
-        self.call(
-            "rescanblockchain",
-            &[
-                Value::Number(Number::from(start_height)),
-                Value::Number(Number::from(stop_height)),
-                Value::Bool(use_timestamp),
-                serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
-            ],
-        )
+        self.call("rescanblockchain", &params)
     }
 
     fn get_roots(&self) -> Result<Vec<String>> {
@@ -263,15 +249,9 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes> {
-        let verbosity = verbosity.unwrap_or(1);
+        let params = rpc_params([hash.into(), verbosity.into()]);
 
-        self.call(
-            "getblock",
-            &[
-                Value::String(hash.to_string()),
-                Value::Number(Number::from(verbosity)),
-            ],
-        )
+        self.call("getblock", &params)
     }
 
     fn get_block_count(&self) -> Result<u32> {
@@ -279,10 +259,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_deployment_info(&self, blockhash: Option<BlockHash>) -> Result<GetDeploymentInfo> {
-        let params = match blockhash {
-            Some(h) => vec![Value::String(h.to_string())],
-            None => vec![],
-        };
+        let params = rpc_params([blockhash.into()]);
         self.call("getdeploymentinfo", &params)
     }
 
@@ -291,32 +268,18 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut> {
-        let result: serde_json::Value = self.call(
-            "gettxout",
-            &[
-                Value::String(tx_id.to_string()),
-                Value::Number(Number::from(outpoint)),
-            ],
-        )?;
+        let params = rpc_params([tx_id.into(), outpoint.into()]);
+
+        let result: serde_json::Value = self.call("gettxout", &params)?;
         if result.is_null() {
             return Err(Error::TxOutNotFound);
         }
+
         serde_json::from_value(result).map_err(Error::Serde)
     }
 
     fn get_txout_proof(&self, txids: Vec<Txid>, blockhash: Option<BlockHash>) -> Result<String> {
-        let params: Vec<Value> = match blockhash {
-            Some(blockhash) => vec![
-                serde_json::to_value(txids)
-                    .expect("Unreachable, Vec<Txid> can be parsed into a json value"),
-                Value::String(blockhash.to_string()),
-            ],
-            None => {
-                let txids = serde_json::to_value(txids)
-                    .expect("Unreachable, Vec<Txid> can be parsed into a json value");
-                vec![txids]
-            }
-        };
+        let params = rpc_params([txids.into(), blockhash.into()]);
         self.call("gettxoutproof", &params)
     }
 
@@ -337,7 +300,8 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn get_block_hash(&self, height: u32) -> Result<BlockHash> {
-        self.call("getblockhash", &[Value::Number(Number::from(height))])
+        let params = rpc_params([height.into()]);
+        self.call("getblockhash", &params)
     }
 
     fn get_raw_transaction(
@@ -345,21 +309,19 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         tx_id: Txid,
         verbosity: Option<u8>,
     ) -> Result<GetRawTransactionRes> {
-        let mut params = vec![Value::String(tx_id.to_string())];
-
-        if let Some(verbosity) = verbosity {
-            params.push(Value::Number(Number::from(verbosity)));
-        }
+        let params = rpc_params([tx_id.into(), verbosity.into()]);
 
         self.call("getrawtransaction", &params)
     }
 
     fn load_descriptor(&self, descriptor: String) -> Result<bool> {
-        self.call("loaddescriptor", &[Value::String(descriptor)])
+        let params = rpc_params([descriptor.into()]);
+        self.call("loaddescriptor", &params)
     }
 
     fn get_block_filter(&self, height: u32) -> Result<String> {
-        self.call("getblockfilter", &[Value::Number(Number::from(height))])
+        let params = rpc_params([height.into()]);
+        self.call("getblockfilter", &params)
     }
 
     fn get_block_header(
@@ -367,10 +329,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         hash: BlockHash,
         verbosity: Option<bool>,
     ) -> Result<GetBlockHeaderRes> {
-        let mut params = vec![Value::String(hash.to_string())];
-        if let Some(verbosity) = verbosity {
-            params.push(Value::Bool(verbosity));
-        }
+        let params = rpc_params([hash.into(), verbosity.into()]);
         self.call("getblockheader", &params)
     }
 
@@ -379,7 +338,8 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     }
 
     fn send_raw_transaction(&self, tx: String) -> Result<Txid> {
-        self.call("sendrawtransaction", &[Value::String(tx)])
+        let params = rpc_params([tx.into()]);
+        self.call("sendrawtransaction", &params)
     }
 
     fn list_descriptors(&self) -> Result<Vec<String>> {
@@ -392,5 +352,155 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+}
+
+enum RpcArg {
+    Value(Value),
+    Optional(Option<Value>),
+}
+
+impl From<String> for RpcArg {
+    fn from(v: String) -> Self {
+        Self::Value(Value::String(v))
+    }
+}
+
+impl From<&str> for RpcArg {
+    fn from(v: &str) -> Self {
+        Self::Value(Value::String(v.to_owned()))
+    }
+}
+
+impl From<bool> for RpcArg {
+    fn from(v: bool) -> Self {
+        Self::Value(Value::Bool(v))
+    }
+}
+
+impl From<u32> for RpcArg {
+    fn from(v: u32) -> Self {
+        Self::Value(Value::Number(Number::from(v)))
+    }
+}
+
+impl From<Txid> for RpcArg {
+    fn from(value: Txid) -> Self {
+        Self::Value(Value::String(value.to_string()))
+    }
+}
+
+impl From<BlockHash> for RpcArg {
+    fn from(value: BlockHash) -> Self {
+        Self::Value(Value::String(value.to_string()))
+    }
+}
+
+impl<T: Serialize> From<Vec<T>> for RpcArg {
+    fn from(v: Vec<T>) -> Self {
+        let values: Vec<Value> = v
+            .into_iter()
+            .filter_map(|item| serde_json::to_value(item).ok())
+            .collect();
+        Self::Value(Value::Array(values))
+    }
+}
+
+impl<T: Serialize> From<Option<T>> for RpcArg {
+    fn from(v: Option<T>) -> Self {
+        Self::Optional(v.and_then(|x| serde_json::to_value(x).ok()))
+    }
+}
+
+impl From<Value> for RpcArg {
+    fn from(v: Value) -> Self {
+        Self::Value(v)
+    }
+}
+
+fn rpc_params(args: impl IntoIterator<Item = RpcArg>) -> Vec<Value> {
+    args.into_iter()
+        .map(|arg| match arg {
+            RpcArg::Value(v) => v,
+            RpcArg::Optional(Some(v)) => v,
+            RpcArg::Optional(None) => Value::Null,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rpc_arg_from_string() {
+        let arg = RpcArg::from("test".to_string());
+        match arg {
+            RpcArg::Value(Value::String(s)) => assert_eq!(s, "test"),
+            _ => panic!("Expected RpcArg::Value"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_arg_from_bool() {
+        let arg = RpcArg::from(true);
+        match arg {
+            RpcArg::Value(Value::Bool(b)) => assert!(b),
+            _ => panic!("Expected RpcArg::Value with bool"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_arg_from_option_some() {
+        let opt: Option<u32> = Some(42);
+        let arg = RpcArg::from(opt);
+        match arg {
+            RpcArg::Optional(Some(Value::Number(n))) => {
+                assert_eq!(n.as_u64(), Some(42));
+            }
+            _ => panic!("Expected RpcArg::Optional(Some(...))"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_arg_from_option_none() {
+        let opt: Option<u32> = None;
+        let arg = RpcArg::from(opt);
+        match arg {
+            RpcArg::Optional(None) => {}
+            _ => panic!("Expected RpcArg::Optional(None)"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_params_preserves_null_for_none() {
+        let params = rpc_params([
+            "node1".into(),
+            true.into(),
+            Some(123u32).into(),
+            None::<u32>.into(),
+            None::<String>.into(),
+            "node2".into(),
+            Some(321u32).into(),
+        ]);
+
+        // Should have only 3 elements (None was filtered)
+        assert_eq!(params.len(), 7);
+        assert!(matches!(params[0], Value::String(ref s) if s == "node1"));
+        assert!(matches!(params[1], Value::Bool(true)));
+        assert!(matches!(params[2], Value::Number(_)));
+        assert!(matches!(params[3], Value::Null));
+        assert!(matches!(params[4], Value::Null));
+        assert!(matches!(params[5], Value::String(ref s) if s == "node2"));
+        assert!(matches!(params[6], Value::Number(_)));
+    }
+
+    #[test]
+    fn test_rpc_params_all_none() {
+        let params = rpc_params([None::<u32>.into(), None::<String>.into()]);
+
+        assert_eq!(params.len(), 2);
+        assert!(matches!(params[0], Value::Null));
+        assert!(matches!(params[1], Value::Null));
     }
 }

--- a/doc/rpc/addnode.md
+++ b/doc/rpc/addnode.md
@@ -27,7 +27,7 @@ floresta-cli addnode 192.168.0.1 onetry false
 
 `command` - (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once.
 
-`v2transport` - (boolean, optional) Only tries to connect with this address using BIP0324 P2P V2 protocol. ignored for 'remove' command.
+`v2transport` - (boolean, optional, default=set by --allow-v1-fallback) Only tries to connect with this address using BIP0324 P2P V2 protocol. Ignored for 'remove' command. Default: `true` unless `--allow-v1-fallback` is used (then defaults to `false`).
 
 ## Returns
 

--- a/tests/florestad/rpcserver_request_parsing.py
+++ b/tests/florestad/rpcserver_request_parsing.py
@@ -23,6 +23,7 @@ from test_framework.constants import (
     JSONRPC_ERRMSG_METHOD_NOT_FOUND,
     JSONRPC_ERRMSG_MISSING_PARAMS,
     JSONRPC_ERRMSG_WRONG_PARAM_TYPE,
+    OPTIONAL_PARAM_METHODS,
     METHODS_REQUIRING_PARAMS,
     NO_PARAM_METHODS,
 )
@@ -33,6 +34,18 @@ class TestRpcServerRequestParsing:
     Test JSON-RPC request parsing, parameter extraction (positional and named),
     error codes, and edge cases on the florestad RPC server.
     """
+
+    def test_optionalparammethods_omittedparams_succeeds(self, shared_florestad_node):
+        """Verify methods with only optional params succeed when params is omitted."""
+        for method in OPTIONAL_PARAM_METHODS:
+            shared_florestad_node.rpc.ensure_rpc_call_success(method=method)
+
+    def test_optionalparammethods_nullparams_succeeds(self, shared_florestad_node):
+        """Verify methods with only optional params succeed when params is explicitly null."""
+        for method in OPTIONAL_PARAM_METHODS:
+            shared_florestad_node.rpc.ensure_rpc_raw_request_call_success(
+                {"jsonrpc": "2.0", "id": "test", "method": method, "params": None}
+            )
 
     def test_noparammethods_omittedparams_succeeds(self, shared_florestad_node):
         """Verify all no-param methods succeed when the params field is omitted."""

--- a/tests/test_framework/constants.py
+++ b/tests/test_framework/constants.py
@@ -71,3 +71,9 @@ METHODS_REQUIRING_PARAMS = [
     "loaddescriptor",
     "sendrawtransaction",
 ]
+
+# Methods that accept only optional parameters (all have defaults/None)
+OPTIONAL_PARAM_METHODS = [
+    "getmemoryinfo",
+    "getdeploymentinfo",
+]


### PR DESCRIPTION
## Description and Notes

Transfers the responsibility for deciding default values from the CLI and RPC clients to the server, so the logic is centralized in one place instead of being duplicated across multiple layers.

In `floresta-cli` and `floresta-rpc`, client-side defaults for `Option` parameters were removed. When a parameter is optional, the client now omits it entirely instead of forcing a default value with `unwrap_or()`, allowing the server to apply its own configured behavior.

*The `addnode` `v2transport` default was also adjusted to match the node configuration, following Bitcoin Core behavior:*
- *`true` by default, unless `--allow-v1-fallback` is enabled*
- *`false` when `--allow-v1-fallback` is configured*

## How to verify the changes you have done?

Check that optional RPC and CLI parameters are no longer defaulted on the client side and are instead handled by the server.

*For `addnode`, verify that the `v2transport` behavior follows the node configuration, matching Bitcoin Core defaults.*
- *Without `--allow-v1-fallback`, the default should be `true`.*
- *With `--allow-v1-fallback`, the default should be `false`.*
- *Confirm that omitted optional parameters are no longer sent with forced defaults from the client.*