### PR TITLE
Replace the hardcoded release string with env!(CARGO_PKG_VERSION) 

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -135,7 +135,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
 }
 
 #[derive(Debug, Parser)]
-#[command(author = "Davidson Souza", version = "0.1.0", about = r#"
+#[command(author = "Davidson Souza", version = env!("CARGO_PKG_VERSION"), about = r#"
     A simple command line interface to the Floresta JSON RPC interface.
 "#, long_about = None)]
 pub struct Cli {


### PR DESCRIPTION


Fixes #988

### Description and Notes

floresta-cli -V was returning a hardcoded 0.1.0, this was adjusted by replcing the hardcoded string with env!(CARGO_PKG_VERSION) to get the version from cargo.toml at compile time

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->
<!-- In this section you can also include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### How to verify the changes you have done?

Build the CLI and check the version output

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
