### PR TITLE
chore: bump version for 0.9.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "floresta"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "floresta",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-chain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "bitcoinkernel",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "hashbrown",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-compact-filters"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "floresta-chain",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-electrum"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "floresta-chain",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-mempool"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "bitcoin",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-node"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "axum",
  "bitcoin",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-rpc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "clap",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-watch-only"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "floresta-chain",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-wire"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bip324",
  "bitcoin",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "florestad"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bitcoin",
  "clap",

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 license = "MIT"

--- a/bin/florestad/Cargo.toml
+++ b/bin/florestad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "florestad"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 license = "MIT"

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-chain"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 description = """

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-common"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Common types and functions for Floresta"
 authors = ["Floresta Developers <contact@getfloresta.org>"]

--- a/crates/floresta-compact-filters/Cargo.toml
+++ b/crates/floresta-compact-filters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-compact-filters"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 edition = "2018"
 homepage = "https://github.com/davidson-souza/floresta"

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-electrum"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 description = """

--- a/crates/floresta-mempool/Cargo.toml
+++ b/crates/floresta-mempool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-mempool"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 description = """

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-node"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 readme.workspace = true # Floresta/README.md
 authors = ["Floresta Developers <contact@getfloresta.org>"]

--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-rpc"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 license = "MIT"

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-watch-only"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A simple, lightweight and Electrum-First, watch-only wallet"
 authors = ["Floresta Developers <contact@getfloresta.org>"]

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-wire"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 description = """

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 edition = "2021"
 description = """

--- a/tests/example/electrum.py
+++ b/tests/example/electrum.py
@@ -21,7 +21,7 @@ class ElectrumTest(FlorestaTestFramework):
     """
 
     index = [-1]
-    expected_version = ["Floresta 0.5.0", "1.4"]
+    expected_version = ["Floresta 0.5.1", "1.4"]
 
     def set_test_params(self):
         """


### PR DESCRIPTION
Changelog:
```
 - fix: prevent disk filling attack against running node (#980)
 - fix: don't request the same block twice (#942)
 -  refactor(peer): use Duration instead of numerical values (#942)