### PR TITLE
Use `license.workspace = true` on all crate `Cargo.toml`'s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ default-members = [
 
 [workspace.package]
 rust-version = "1.81.0" # MSRV declaration
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 # Version Convention: Use major.minor only (e.g., "1.9" not "1.9.1")

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "floresta-cli"
 version = "0.5.0"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+license.workspace = true
 description = """
 A command line interface for Florestad.
 

--- a/bin/florestad/Cargo.toml
+++ b/bin/florestad/Cargo.toml
@@ -3,7 +3,7 @@ name = "florestad"
 version = "0.9.0"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+license.workspace = true
 description = """
 The main binary for Floresta, a lightweight Bitcoin node implementation in Rust,
 utilizing Utreexo for efficient state management.

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -9,7 +9,7 @@ description = """
     and transactions, according to the Bitcoin consensus rules.
 """
 repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
+license.workspace = true
 readme.workspace = true # Floresta/README.md
 keywords = ["bitcoin", "utreexo", "node", "consensus"]
 categories = ["cryptography::cryptocurrencies", "database"]

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 edition = "2021"
 description = "Common types and functions for Floresta"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+license.workspace = true
 repository = "https://github.com/getfloresta/Floresta"
 readme.workspace = true # Floresta/README.md
 

--- a/crates/floresta-compact-filters/Cargo.toml
+++ b/crates/floresta-compact-filters/Cargo.toml
@@ -9,6 +9,7 @@ description = """
 BIP158 compact filters for easy rescan of the blockchain in light clients.
 """
 readme.workspace = true # Floresta/README.md
+license.workspace = true
 
 [dependencies]
 bitcoin = { workspace = true }

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -9,7 +9,7 @@ description = """
     that supports Electrum servers.
 """
 repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
+license.workspace = true
 readme.workspace = true # Floresta/README.md
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies"]

--- a/crates/floresta-mempool/Cargo.toml
+++ b/crates/floresta-mempool/Cargo.toml
@@ -9,7 +9,7 @@ description = """
     block template construction.
 """
 repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
+license.workspace = true
 readme.workspace = true
 keywords = ["bitcoin", "mempool", "transactions"]
 

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "floresta-node"
 version = "0.9.0"
 edition = "2021"
+license.workspace = true
 readme.workspace = true # Floresta/README.md
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 

--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -3,7 +3,7 @@ name = "floresta-rpc"
 version = "0.5.0"
 edition = "2021"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
-license = "MIT"
+license.workspace = true
 description = """
 floresta-rpc is a Rust library that provides a JSON-RPC interface for interacting with Floresta. It allows
 users to perform various operations such as querying blockchain data, managing wallets, and

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -6,7 +6,7 @@ description = "A simple, lightweight and Electrum-First, watch-only wallet"
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 keywords = ["bitcoin", "watch-only", "electrum-server"]
 categories = ["cryptography::cryptocurrencies"]
-license = "MIT"
+license.workspace = true
 repository = "https://github.com/getfloresta/Floresta"
 readme.workspace = true # Floresta/README.md
 

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -9,7 +9,7 @@ description = """
     your own transactions.
 """
 repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
+license.workspace = true
 readme = "README.md"
 keywords = ["bitcoin", "utreexo", "p2p", "networking"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -17,7 +17,7 @@ description = """
     each crate's documentation for more information on how to use each module.
 """
 repository = "https://github.com/getfloresta/Floresta"
-license = "MIT"
+license.workspace = true
 readme.workspace = true # Floresta/README.md
 keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "floresta-fuzz"
 version = "0.1.0"
+license.workspace = true
 publish = false
 edition = "2021"
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -2,6 +2,7 @@
 name = "metrics"
 version = "0.2.0"
 edition = "2021"
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Closes #1002 

## Changelog
```
- Add missing `license` field to the workspace's `Cargo.toml`
- Inherit the workspace's `license` (`license.workspace = true`) on all crate `Cargo.toml`'s
```