### PR TITLE
Add compiler optimizations for release builds

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_FUZZ_VERSION: 0.11.4
+  CARGO_FUZZ_VERSION: 0.13.1
   APT_CONFIG: |
     Dir::Cache "./.apt-cache";
     Dir::Cache::archives "./.apt-cache/archives";
@@ -34,11 +34,11 @@ jobs:
           # Use '10#' to always treat week number as base-10 (avoids octal when number has a leading zero)
           BIWEEK=$(( (10#$WEEK + 1) / 2 ))
           echo "CACHE_VERSION=${YEAR}(${BIWEEK})" >> $GITHUB_ENV
-          
+
           # Hash of all files that could affect the build
           HASH=$(echo "${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '.github/workflows/**') }}")
           echo "BUILD_HASH=${HASH}" >> $GITHUB_ENV
-          
+
           # Hash of apt packages we need
           APT_PACKAGES="build-essential cmake clang"
           echo "APT_HASH=$(echo $APT_PACKAGES | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
@@ -56,10 +56,11 @@ jobs:
             ~/.cargo/bin/cargo-fuzz
             target/
             fuzz/target/
-          key: ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ env.BUILD_HASH }}
+          key: ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-fuzz${{ env.CARGO_FUZZ_VERSION }}-${{ env.BUILD_HASH }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-
-            ${{ runner.os }}-cargo-
+              ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-fuzz${{ env.CARGO_FUZZ_VERSION }}-
+              ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-
+              ${{ runner.os }}-cargo-
 
       # Restore apt packages cache
       - name: Restore apt cache
@@ -86,7 +87,7 @@ jobs:
       # Install cargo-fuzz only if not found in cache
       - name: Install cargo-fuzz
         if: steps.cache-rust.outputs.cache-hit != 'true'
-        run: cargo +nightly install cargo-fuzz --locked --force
+        run: cargo +nightly install cargo-fuzz --version ${{ env.CARGO_FUZZ_VERSION }} --force
 
       # Pull corpus data from the floresta-qa-assets repository
       - name: Pull corpus data
@@ -102,7 +103,7 @@ jobs:
           cargo +nightly fuzz list
           for target in $(cargo fuzz list); do
             echo "Running fuzz target: $target"
-            cargo +nightly fuzz run $target -- -max_total_time=60
+            CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz run $target -- -max_total_time=60
           done
 
       # Save Rust cache if there was no exact match

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,9 @@ metrics = { path = "metrics" }
 
 [workspace.lints.clippy]
 unused_async = "deny"
+
+[profile.release]
+opt-level = 3     # maximum optimization level
+strip = true      # strip symbol tables and metadata
+lto = true        # enable link-time optimizations
+codegen-units = 1 # compile a single codegen unit

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -1,8 +1,9 @@
 # Fuzzing
+
 This project uses `cargo-fuzz` (libfuzzer) for fuzzing, you can run a fuzz target with:
 
 ```bash
-cargo +nightly fuzz run local_address_str
+CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz run local_address_str
 ```
 
 You can replace `local_address_str` with the name of any other target you want to run.


### PR DESCRIPTION
Closes #1008

This PR adds compiler optimizations for the release profile.

Warning: release builds now take a long time!

| Binary             | Before Optimazations (Bytes) | After Optimizations (Bytes) | Size Reduction (Bytes / %)  |
| --------------| -----------------------------  | --------------------------- | --------------------------- |                                               
| `florestad`     | `16_499_008`                          | `11_974_336`                       | `4_524_672` / -27.42%      |
| `floresta-cli`  | `1_616_400`                             | `1_031_776`                         | `584_624` / -36.17%          |

---

## Changelog 
```
- Add compiler optimizations for the release profile:
  - `opt-level = 3`: max out rustc optimizations
  - `strip = true`: strip symbol tables and metadata
  - `lto = true`: enable link-time optimizations (gives all IR to LLVM and lets it link it optimally)
  - `codegen-units = 1`: hand all code to LLVM so it has a global view,
     allowing it to better inline functions and prune dead code

- Update the `fuzz.yml` CI workflow:
  - Override the workspace-level link-time optimization when fuzzing on CI.
  - Bump CI's `cargo-fuzz` to v0.13.1: v0.12.0 pulled in `rustix 0.36.5`,
    which pulled some transitive dependencies that used reserverd keywords
    and would conflict with the binary symbols generated by non-LTO
    profiling optimizations.
  - Actually install `cargo-fuzz` with the version set by `CARGO_FUZZ_VERSION`.
  - Include `cargo-fuzz`'s version in the cache and cache restore keys so that
    bumping `cargo-fuzz` invalidates the cache.
```