### PR TITLE
feat: set overflow-check to true on release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,6 @@ metrics = { path = "metrics" }
 
 [workspace.lints.clippy]
 unused_async = "deny"
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
### Description and Notes

Rust's overflow-check flag controls runtime behavior of integer overflow. When set to true, an integer overflow causes the program to panic!, Otherwise it just silently overflows and execution continue.

On debug builds default is true, in release builds it's set to false. This PR changes the release behavior by setting the flag to true.

I would say that this a sound approach for this application to take.

### How to verify the changes you have done?

https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=673f1c6981a6ae0530c84d94c306af7f

This playground demos this behavior, you can check it out what happens when you run on Debug vs Release.

You can reproduce the behavior inside the project by adding something like on the first line of florestad main function. 

```
    let x: u8 = std::hint::black_box(255);
    let y: u8 = std::hint::black_box(1);
    let _ = x + y;
```

Note that the black_box is needed because of #![deny(arithmetic_overflow)], and if not used, rustc's const evaluator would catch it in compile time. In "real life" overflows happens with runtime defined values, but I think this verification is enough to prove the bahevior.

With flag set to true:
<img width="683" height="140" alt="image" src="https://github.com/user-attachments/assets/35c47999-6372-4ec6-a2c8-dd1b97c46265" />

With no flag at all:
<img width="725" height="187" alt="image" src="https://github.com/user-attachments/assets/e06628c3-ac97-4348-94e7-058e5fe6327e" />

Closes https://github.com/getfloresta/Floresta/issues/1016