### PR TITLE
chore(deps): install cargo-hack to run `just pcc` on flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
               uv
               gcc
               go
+              cargo-hack
             ];
 
             preCommitHooks = pre-commit-hooks.lib.${system}.run {


### PR DESCRIPTION
### Description and Notes

Add cargo-hack to flake.nix

### How to verify the changes you have done?

run `nix develop` then `just pcc`.

Closes https://github.com/getfloresta/Floresta/issues/1018