### PR TITLE
Avoid `as` casting on `floresta_electrum` crate

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -254,10 +254,10 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         // Methods are in alphabetical order
         match request.method.as_str() {
             "blockchain.block.header" => {
-                let height = get_arg!(request, u64, 0);
+                let height = get_arg!(request, u32, 0);
                 let hash = self
                     .chain
-                    .get_block_hash(height as u32)
+                    .get_block_hash(height)
                     .map_err(|_| super::error::Error::InvalidParams)?;
                 let header = self
                     .chain
@@ -267,27 +267,32 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 json_rpc_res!(request, header)
             }
             "blockchain.block.headers" => {
-                let start_height = get_arg!(request, u64, 0);
-                let count = get_arg!(request, u64, 1);
-                let mut headers = String::new();
-                let count = if count < 2016 { count } else { 2016 };
-                for height in start_height..(start_height + count) {
-                    let hash = self
-                        .chain
-                        .get_block_hash(height as u32)
-                        .map_err(|_| super::error::Error::InvalidParams)?;
+                const MAX_COUNT: u32 = 2016;
 
-                    let header = self
-                        .chain
-                        .get_block_header(&hash)
-                        .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
-                    let header = serialize_hex(&header);
-                    headers.push_str(&header);
-                }
+                let start_height = get_arg!(request, u32, 0);
+                let count = get_arg!(request, u32, 1).min(MAX_COUNT);
+
+                let chain_height = self
+                    .chain
+                    .get_height()
+                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+
+                let end_height =
+                    (chain_height.saturating_add(1)).min(start_height.saturating_add(count));
+
+                let heights = start_height..end_height;
+                let count = heights.len();
+
+                let headers = heights.filter_map(|height| {
+                    let hash = self.chain.get_block_hash(height).ok()?;
+                    let header = self.chain.get_block_header(&hash).ok()?;
+                    Some(serialize_hex(&header))
+                });
+
                 json_rpc_res!(request, {
                     "count": count,
-                    "hex": headers,
-                    "max": 2016
+                    "hex": String::from_iter(headers),
+                    "max": MAX_COUNT,
                 })
             }
             "blockchain.estimatefee" => json_rpc_res!(request, 0.0001),

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -7,6 +7,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/getfloresta/floresta-media/master/logo_png/Icon-Green(main).png"
 )]
 #![allow(clippy::manual_is_multiple_of)]
+#![cfg_attr(not(test), deny(clippy::as_conversions))]
 
 use serde::Deserialize;
 use serde::Serialize;


### PR DESCRIPTION
### Description and Notes

First step to avoid `as` casting and unchecked math operation. Also did a small change on `"blockchain.block.headers"` handling, initializing `headers` with its intended capacity. Addresses https://github.com/getfloresta/Floresta/issues/1014

### How to verify the changes you have done?

run `cargo clippy`