### PR TITLE
fix: apply clippy latest suggestions

### DIFF
--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -163,7 +163,7 @@ impl Mempool {
         let mut size = 0;
 
         let mut txs = Vec::new();
-        for (_, tx) in self.transactions.iter() {
+        for tx in self.transactions.values() {
             let tx_size = tx.transaction.weight().to_wu();
             if size + tx_size > max_block_weight {
                 break;

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -789,7 +789,7 @@ impl AddressMan {
     pub fn rearrange_buckets(&mut self) {
         let now = Self::time_since_unix();
 
-        for (_, address) in self.addresses.iter_mut() {
+        for address in self.addresses.values_mut() {
             match address.state {
                 AddressState::Banned(ban_time) => {
                     if ban_time < now {

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -470,7 +470,7 @@ where
         }
 
         self.peer_ids.retain(|&id| id != peer);
-        for (_, v) in self.peer_by_service.iter_mut() {
+        for v in self.peer_by_service.values_mut() {
             v.retain(|&id| id != peer);
         }
 


### PR DESCRIPTION
clippy added a new nightly lint for cases where you create an interator over a map, just to use the keys. It tells you to use `values` rather than `iter`, which makes plenty of sense!

This commit fixes all the lint warnings applying the correct way of doing this.

### Changelog

```
 - crates/floresta-mempool/src/mempool.rs:166 -> use `values` instead of `iter`
 - crates/floresta-wire/src/p2p_wire/address_man.rs:792 -> use `values_mut` instead of `iter_mut`
 - crates/floresta-wire/src/p2p_wire/node/peer_man.rs:473 -> use `values_mut` instead of `iter_mut`
```