### PR TITLE
feat(rpc): expose compact filter sync progress in getblockchaininfo

### DIFF
--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -397,6 +397,21 @@ impl Florestad {
         #[cfg(not(feature = "compact-filters"))]
         let cfilters = None;
 
+        // Resolve the configured filter start height to an absolute block height for the RPC
+        // context. Negative values are tip-relative
+        let resolved_filters_start: Option<u32> = if self.config.cfilters {
+            match self.config.filters_start_height {
+                None | Some(0) => None,
+                Some(h) if h > 0 => Some(h as u32),
+                Some(h) => {
+                    let tip = blockchain_state.get_height().unwrap_or(0);
+                    Some(tip.saturating_sub((-h) as u32))
+                }
+            }
+        } else {
+            None
+        };
+
         // If this network already allows pow fraud proofs, we should use it instead of assumeutreexo
         let assume_utreexo = match self.config.assume_utreexo {
             true => Some(ChainParams::get_assume_utreexo(self.config.network)),
@@ -478,6 +493,7 @@ impl Florestad {
                     .map(|x| Self::resolve_hostname(x, 8332))
                     .transpose()?,
                 format!("{data_dir}/debug.log"),
+                resolved_filters_start,
             ));
 
             if self.json_rpc.set(server).is_err() {

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -270,6 +270,11 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             0.0
         };
 
+        let filters = self
+            .block_filter_storage
+            .as_ref()
+            .and_then(|s| s.get_height().ok());
+
         Ok(GetBlockchainInfoRes {
             best_block: hash.to_string(),
             height,
@@ -283,6 +288,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             chain: self.network.to_string(),
             difficulty: latest_header.difficulty(self.chain.get_params()) as u64,
             progress: validated_percentage,
+            filters,
+            filters_start: self.filters_start_height,
         })
     }
 

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -27,6 +27,12 @@ pub struct GetBlockchainInfoRes {
     pub chain: String,
     pub progress: f32,
     pub difficulty: u64,
+    /// Height up to which compact block filters have been downloaded.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub filters: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub filters_start: Option<u32>,
 }
 
 /// A confidence enum to auxiliate rescan timestamp values.

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -83,6 +83,8 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
     pub(super) log_path: String,
     pub(super) start_time: Instant,
+    /// Resolved absolute height at which compact filter download started.
+    pub(super) filters_start_height: Option<u32>,
 }
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
@@ -749,6 +751,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         address: Option<SocketAddr>,
         log_path: String,
+        filters_start_height: Option<u32>,
     ) {
         let address = address.unwrap_or_else(|| {
             format!("127.0.0.1:{}", Self::get_port(&network))
@@ -789,6 +792,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 inflight: Arc::new(RwLock::new(HashMap::new())),
                 log_path,
                 start_time: Instant::now(),
+                filters_start_height,
             }));
 
         axum::serve(listener, router)

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -55,6 +55,12 @@ pub struct GetBlockchainInfoRes {
     /// On average, miners needs to make `difficulty` hashes before finding one that
     /// solves a block's PoW
     pub difficulty: u64,
+    /// Height up to which compact block filters have been downloaded.
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub filters: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub filters_start: Option<u32>,
 }
 
 /// The information returned by a get_raw_tx


### PR DESCRIPTION
Fixes #1020 

### Description and Notes

`getblockchaininfo` reports `progress: 1.0, ibd: false` once block validation finishes, but compact filter (BIP 157/158) download may still be thousands of blocks behind. Clients that rely on the local filter store — `loaddescriptor`, `rescanblockchain`, downstream Electrum servers — see incomplete history during this window without any visible                                             
  signal. This was observed in production in the Mandacaru Android wallet.  

## Changes                                                                                                          
                                                                                                                      
  Added two optional fields to `GetBlockchainInfoRes`:                                                                  
  
  - **`filters`** – height up to which compact block filters have been  downloaded. Absent when the node was started without compact-filter support.                                                                                                          
  - **`filters_start`** – resolved absolute height at which the current on-disk filter store began downloading. Absent when filters started from genesis or compact filters are disabled.                                                                     
  
  Clients can compute honest filter-sync progress as:                                                                 
                                                                                                                    
  (filters - filters_start) / (height - filters_start)                                                                
                                                                                                                    
  Without `filters_start`, using `filters / height` would show ~99% on mainnet for any non-genesis wallet birthday (the chain has 800k+ blocks but only the last N are in the download window).                                                                    
                                                                                                                                                                            
                                                                                                                      
  ## Testing                                                                                                          
                                                                                                                    
  - Existing `test_get_blockchaininfo` and `test_get_roots` tests pass                                                
    unchanged (they don't assert on the new fields; the `default` serde
  - Both fields use `#[serde(skip_serializing_if = "Option::is_none",                                                 
    default)]` — absent from JSON when not applicable, fully backwards                                                
    compatible with existing clients and snapshot tests.                                                              
                                                                                                                      
  ## Testing                                                                                                          
                                                                                                                      
  - Existing `test_get_blockchaininfo` and `test_get_roots` tests pass unchanged (they don't assert on the new fields; the `default` serde unchanged (they don't assert on the new fields; the `default` serde  attribute sets them to `None` on deserialization when absent).
  - No new RPC method, no changes to filter sync logic.
  - Both fields use 
  `#[serde(skip_serializing_if = "Option::is_none", default)]`
 absent from JSON when not applicable, fully backwards compatible with existing clients and snapshot tests.


### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

