### PR TITLE
docs(cli): document getroots, getpeerinfo, and uptime RPCs

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -275,8 +275,13 @@ pub enum Methods {
     )]
     LoadDescriptor { desc: String },
 
-    /// Returns the roots of the current utreexo forest
-    #[command(name = "getroots")]
+    #[doc = include_str!("../../../doc/rpc/getroots.md")]
+    #[command(
+        name = "getroots",
+        about = "Returns the roots of the current utreexo forest",
+        long_about = Some(include_str!("../../../doc/rpc/getroots.md")),
+        disable_help_subcommand = true
+    )]
     GetRoots,
 
     /// Returns a block
@@ -292,8 +297,13 @@ pub enum Methods {
         verbosity: Option<u32>,
     },
 
-    /// Returns information about the peers we are connected to
-    #[command(name = "getpeerinfo")]
+    #[doc = include_str!("../../../doc/rpc/getpeerinfo.md")]
+    #[command(
+        name = "getpeerinfo",
+        about = "Returns information about the peers we are connected to",
+        long_about = Some(include_str!("../../../doc/rpc/getpeerinfo.md")),
+        disable_help_subcommand = true
+    )]
     GetPeerInfo,
 
     #[doc = include_str!("../../../doc/rpc/getconnectioncount.md")]
@@ -372,8 +382,13 @@ pub enum Methods {
     #[command(name = "getrpcinfo")]
     GetRpcInfo,
 
-    /// Returns for how long the node has been running, in seconds
-    #[command(name = "uptime")]
+    #[doc = include_str!("../../../doc/rpc/uptime.md")]
+    #[command(
+        name = "uptime",
+        about = "Returns for how long the node has been running, in seconds",
+        long_about = Some(include_str!("../../../doc/rpc/uptime.md")),
+        disable_help_subcommand = true
+    )]
     Uptime,
 
     /// Returns a list of all descriptors currently loaded in the wallet

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -80,17 +80,9 @@ pub trait FlorestaRPC {
     /// hexadecimal string. If the transaction is valid, it will be broadcast to the network, and
     /// return the transaction id. If the transaction is invalid, an error will be returned.
     fn send_raw_transaction(&self, tx: String) -> Result<Txid>;
-    /// Gets the current accumulator for the chain we're on
-    ///
-    /// This method returns the current accumulator for the chain we're on. The accumulator is
-    /// a set of roots, that let's us prove that a UTXO exists in the chain. This method returns
-    /// a vector of hexadecimal strings, each of which is a root in the accumulator.
+    #[doc = include_str!("../../../doc/rpc/getroots.md")]
     fn get_roots(&self) -> Result<Vec<String>>;
-    /// Gets information about the peers we're connected with
-    ///
-    /// This method returns information about the peers we're connected with. This includes
-    /// the peer's IP address, the peer's version, the peer's user agent, the transport protocol
-    /// and the peer's current height.
+    #[doc = include_str!("../../../doc/rpc/getpeerinfo.md")]
     fn get_peer_info(&self) -> Result<Vec<PeerInfo>>;
     /// Returns the number of peers currently connected to the node.
     fn get_connection_count(&self) -> Result<usize>;
@@ -140,7 +132,7 @@ pub trait FlorestaRPC {
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
     /// Returns stats about our RPC server
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
-    /// Returns for how long florestad has been running, in seconds
+    #[doc = include_str!("../../../doc/rpc/uptime.md")]
     fn uptime(&self) -> Result<u32>;
     /// Returns a list of all descriptors currently loaded in the wallet
     fn list_descriptors(&self) -> Result<Vec<String>>;

--- a/doc/rpc/getpeerinfo.md
+++ b/doc/rpc/getpeerinfo.md
@@ -1,0 +1,45 @@
+# `getpeerinfo`
+
+Returns general information about the peers we are currently connected to.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getpeerinfo
+```
+
+### Examples
+
+```bash
+# Get information about connected peers
+floresta-cli getpeerinfo
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON array of objects, each representing a connected peer with the following fields:
+
+- `id` - (numeric) This peer's unique identifier in the node's peer manager. This is useful for commands like `disconnectnode` which can target a peer by its ID.
+- `address` - (string) The network address and port for this peer (e.g., "192.168.1.5:8333"). This helps identify where the connection is established.
+- `services` - (string) A string listing the services this peer advertises (e.g., NODE_NETWORK, UTREEXO, WITNESS). This indicates what capabilities the peer supports and what data we can request from them.
+- `user_agent` - (string) The User Agent string representing the client software and version being used by the peer (e.g., `/Satoshi-26.0/`). Useful for identifying the software distribution on the network.
+- `initial_height` - (numeric) The block height this peer reported when the connection was first established. This may differ from the current chain tip if the peer has not announced new blocks since connecting.
+- `kind` - (string) The connection type of this peer. Possible values are "feeler" (short-lived connections to test address validity), "regular" (standard persistent P2P connection), "extra", or "manual".
+- `state` - (string) The current state of this peer. Can be "Ready" (fully handshaked and active), "Awaiting" (still establishing connection), or "Banned" (connection rejected/dropped).
+- `transport_protocol` - (string) The transport protocol used to communicate with the peer (e.g., "V1" or "V2").
+
+### Error Enum
+
+* `JsonRpcError::Node` - If there is an internal node error preventing the retrieval of peer information (e.g., "Failed to get peer information").
+
+## Notes
+
+- This RPC method has a direct equivalent in Bitcoin Core. However, Floresta's `getpeerinfo` is a more lightweight version that currently returns a subset of essential connection and state information, whereas Bitcoin Core provides extensive additional telemetry (like bytes sent/received, ping times, etc.).

--- a/doc/rpc/getroots.md
+++ b/doc/rpc/getroots.md
@@ -1,0 +1,36 @@
+# `getroots`
+
+Returns the hex-encoded roots of the current utreexo accumulator forest.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getroots
+```
+
+### Examples
+
+```bash
+# Get the roots of the utreexo accumulator
+floresta-cli getroots
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON array of strings representing the actual hex-encoded roots of the utreexo accumulator.
+
+### Error Enum
+
+This command typically does not return any specific logic errors under normal operation.
+
+## Notes
+
+- This command relates specifically to Utreexo. These are the roots of the current utreexo forest state maintained by the node.

--- a/doc/rpc/uptime.md
+++ b/doc/rpc/uptime.md
@@ -1,0 +1,36 @@
+# `uptime`
+
+Returns the total uptime of the node in seconds.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli uptime
+```
+
+### Examples
+
+```bash
+# Get the server uptime
+floresta-cli uptime
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+Returns a numeric value representing the number of seconds that the node has been running.
+
+### Error Enum
+
+This command typically does not return any specific logic errors under normal operation.
+
+## Notes
+
+- This RPC method has a direct equivalent in Bitcoin Core and functions identically by returning the server uptime in seconds.


### PR DESCRIPTION
### Description and Notes

Adds RPC documentation for `getroots`, `getpeerinfo`, and `uptime` endpoints following the established template and tone of `getblockchaininfo.md`.

Part of #799

### How to verify the changes done?

The documentation was verified against a live `florestad` node running on `regtest`. Field names, return types, and enum values (peer connection states, transport protocols) were cross-referenced with the Rust source in `floresta-rpc` and `floresta-wire` crates to confirm accuracy.

You can verify by running:
```bash
floresta-cli getroots
floresta-cli getpeerinfo
floresta-cli uptime
```
And comparing the output against the documented fields.

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've linked any related issue(s) in the sections above