### PR TITLE
chore(nix): remove pre-commit hook on flake.nix, update flake.lock and clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ utreexod/
 
 # Configuration files
 config.toml
-.pre-commit-config.yaml
 
 # direnv cache
 .direnv/
@@ -35,6 +34,3 @@ config.toml
 
 # tests pycache
 tests/**/__pycache__/*
-
-# commitizen under nixdevshell
-.cz.toml

--- a/flake.lock
+++ b/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -93,27 +77,6 @@
       "inputs": {
         "nixpkgs": [
           "floresta-flake",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
           "pre-commit-hooks",
           "nixpkgs"
         ]
@@ -216,35 +179,12 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769939035,
-        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "floresta-flake": "floresta-flake",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit-hooks": "pre-commit-hooks_2",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,6 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     floresta-flake.url = "github:getfloresta/floresta-nix/stable_building";
-    pre-commit-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
-    };
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -21,7 +17,6 @@
       rust-overlay,
       flake-utils,
       nixpkgs-unstable,
-      pre-commit-hooks,
       floresta-flake,
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -76,106 +71,9 @@
               go
               cargo-hack
             ];
-
-            preCommitHooks = pre-commit-hooks.lib.${system}.run {
-              src.root = src;
-              default_stages = [
-                "pre-commit"
-                "pre-push"
-              ];
-              hooks = {
-                check-merge-conflicts = {
-                  enable = true;
-                  stages = [ "pre-commit" ];
-                };
-                nixfmt = {
-                  enable = true;
-                  stages = [ "pre-commit" ];
-                };
-                commitizen.enable = true;
-                statix = {
-                  enable = true;
-                  stages = [ "pre-commit" ];
-                };
-                flake-checker = {
-                  enable = true;
-                  stages = [ "pre-commit" ];
-                };
-                rustfmt-hook = {
-                  enable = true;
-                  name = "rustfmt-hook";
-                  entry = "${pkgs.just}/bin/just format";
-                  language = "system";
-                  stages = [ "pre-commit" ];
-                  types = [ "rust" ];
-                  pass_filenames = false;
-                  verbose = true;
-                };
-                rusttest-unit-hook = {
-                  enable = true;
-                  name = "rusttest-unit-hook";
-                  entry = "${pkgs.just}/bin/just test-unit";
-                  language = "system";
-                  stages = [ "pre-commit" ];
-                  types = [ "rust" ];
-                  pass_filenames = false;
-                  verbose = true;
-                };
-                typos-hook = {
-                  enable = true;
-                  name = "typos-hook";
-                  entry = "${pkgs.just}/bin/just spell-check";
-                  language = "system";
-                  stages = [ "pre-commit" ];
-                  types = [ "rust" ];
-                  pass_filenames = false;
-                  verbose = true;
-                };
-                rusttest-full-hook = {
-                  enable = true;
-                  name = "rusttest-full-hook";
-                  entry = "${pkgs.just}/bin/just test";
-                  language = "system";
-                  stages = [ "pre-push" ];
-                  types = [ "rust" ];
-                  pass_filenames = false;
-                  verbose = true;
-                };
-              };
-            };
-
-            # Floresta flavored commitizen config file.
-            czFlorestaConfigFile = pkgs.writeText ".cz.toml" ''
-              [tool.commitizen]
-              name = "cz_customize"
-
-              [tool.commitizen.customize]
-              types = [
-                { type = "feat",    description = "A new feature" },
-                { type = "fix",     description = "A bug fix" },
-                { type = "docs",    description = "Documentation changes" },
-                { type = "style",   description = "Code style changes (formatting, missing semicolons, etc.)" },
-                { type = "refactor",description = "Code changes that neither fix a bug nor add a feature" },
-                { type = "test",    description = "Adding missing tests or correcting existing tests" },
-                { type = "perf",    description = "A code change that improves performance" },
-                { type = "ci",      description = "Changes to CI configuration files and scripts" },
-                { type = "chore",   description = "Other changes that don't modify src or test files" },
-                { type = "fuzz",    description = "Fuzzing-related changes" },
-                { type = "bench",   description = "Benchmark-related changes" }
-              ]
-
-              schema_pattern = '^(feat|fix|docs|style|refactor|test|perf|ci|chore|fuzz|bench)(\([^)]+\))?: [^\n]+(\n\n[\s\S]+)?$'
-            '';
-
-            czHook = ''
-              cp -f ${czFlorestaConfigFile} .cz.toml
-              echo "Commitizen config written"
-            '';
-
-            shellHook = preCommitHooks.shellHook + czHook;
           in
           mkShell {
-            inherit packages shellHook;
+            inherit packages;
             LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
             CMAKE_PREFIX_PATH = "${pkgs.boost.dev}";
           };


### PR DESCRIPTION
### Description and Notes

Removes pre-commit hooks from `flake.nix`, update `flake.lock` to reflect removal and clean up `.gitignore` and `cz.toml`

### How to verify the changes you have done?

Run `nix develop` and commit something. It shouldn't trigger a pre-commit hook :)

### Note

 Existing contributors: after pulling, run `rm -f .git/hooks/{pre-commit,pre-push,commit-msg} .pre-commit-config.yaml .cz.toml` to remove the previously-installed hooks and stale configs.