### PR TITLE
chore: ignore /testdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /builds
 /result
+/testdata
 
 # Man-pages
 doc/rpc_man/*.gz


### PR DESCRIPTION
### Description and Notes

Theres a directory that can be generated while running tests that is not currently being ignored on `.gitignore`. 

This commit ignores it, avoiding it to be committed.