### PR TITLE
update rustls to 0.23.40 - deps housekeeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,13 +2491,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2519,7 +2519,6 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ sha2 = { version = "0.10", default-features = false }
 spin = { version = "0.10", default-features = false, features = ["spin_mutex", "rwlock"] }
 tempfile = "3.23"
 tokio = { version = "1.48", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
-tokio-rustls = "0.26"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 toml = { version = "0.9", default-features = false, features = ["std", "parse", "serde"] }
 tracing = { version = "0.1", default-features = false }
 zstd = "0.13"

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -19,7 +19,7 @@ bip324 = { version = "0.10", features = [ "tokio" ] }
 bitcoin = { workspace = true }
 dns-lookup = { workspace = true }
 rand = { workspace = true }
-rustls = "=0.23.27"
+rustls = { version = "0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
 rustreexo = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -1162,7 +1162,7 @@ pub mod dns_proxy {
         // but the Bitcoin DNS query remains encrypted. Only Google can see the query contents.
         let proxy = Proxy::new(&format!("socks5://{proxy_addr}"))?;
 
-        let crypto = Arc::new(crypto::aws_lc_rs::default_provider());
+        let crypto = Arc::new(crypto::ring::default_provider());
         let tls_config = TlsConfig::builder()
             .provider(TlsProvider::Rustls)
             .unversioned_rustls_crypto_provider(crypto)


### PR DESCRIPTION
`rustls` in floresta-wire was pinned to `=0.23.27`. That pin was likely a transient issue at the time the workspace was reorganized.  The crate compiles and and all tests pass with `0.23.40`.

Also in this PR the crypto backend is switched from `aws-lc-rs` to `ring`.

Because `rustls` is configured with `default-features = false` to avoid pulling in `aws-lc-rs`, the features that were implicit must be explicit now: `features = ["ring", "std", "tls12"]`.

`tokio-rustls` in the workspace is updated for the same reason and with the same features. This is necessary because `floresta-electrum` depends on both `tokio-rustls` and `floresta-wire`.