### PR TITLE
functional tests: wait for sync and wait for height helpers, expose timeouts to environment variables, timeouts for stallment to avoid misleading breaks

### DIFF
--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -46,6 +46,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 ## Testing Options
+
 There's a set of unit and integration Rust tests that you can run with:
 
 ```bash
@@ -63,11 +64,13 @@ Next sections will cover the Python functional tests.
 ### Setting Functional Tests Binaries
 
 We provide three way for running functional tests:
-* from `just` tool that abstracts what is necessary to run the tests before doing a commit;
-* from helper scripts — [prepare.sh](https://github.com/getfloresta/Floresta/blob/master/tests/prepare.sh) and [run.sh](https://github.com/getfloresta/Floresta/blob/master/tests/run.sh) — to automatically build and run the tests;
-* from python utility directly: the most laborious, but you can run a specific test suite.
+
+- from `just` tool that abstracts what is necessary to run the tests before doing a commit;
+- from helper scripts — [prepare.sh](https://github.com/getfloresta/Floresta/blob/master/tests/prepare.sh) and [run.sh](https://github.com/getfloresta/Floresta/blob/master/tests/run.sh) — to automatically build and run the tests;
+- from python utility directly: the most laborious, but you can run a specific test suite.
 
 #### From `just` tool
+
 It abstracts all things that will be explained in the next sections, and for that
 reason, we recommend to use it before doing a commit when changes only the functional tests.
 
@@ -98,9 +101,9 @@ just test-functional-run "-t floresta-cli -k getblock"
 
 We provide two helper scripts to support our functional tests in this process and guarantee isolation and reproducibility.
 
-* [prepare.sh](https://github.com/getfloresta/Floresta/blob/master/tests/prepare.sh) checks for build dependencies for both `utreexod` and `florestad`, builds them, and sets the `$FLORESTA_TEMP_DIR` environment variable. This variable points to where our functional tests will look for the binaries — specifically at `$FLORESTA_TEMP_DIR/binaries`.
+- [prepare.sh](https://github.com/getfloresta/Floresta/blob/master/tests/prepare.sh) checks for build dependencies for both `utreexod` and `florestad`, builds them, and sets the `$FLORESTA_TEMP_DIR` environment variable. This variable points to where our functional tests will look for the binaries — specifically at `$FLORESTA_TEMP_DIR/binaries`.
 
-* [run.sh](https://github.com/getfloresta/Floresta/blob/master/tests/run.sh) adds the binaries found at `$FLORESTA_TEMP_DIR/binaries` to your `$PATH` and runs the tests in that environment.
+- [run.sh](https://github.com/getfloresta/Floresta/blob/master/tests/run.sh) adds the binaries found at `$FLORESTA_TEMP_DIR/binaries` to your `$PATH` and runs the tests in that environment.
 
 So a basic usage would be:
 
@@ -119,19 +122,23 @@ UTREEXO_REVISION=0.1.0 ./tests/prepare.sh && ./tests/run.sh
 ```
 
 ##### Bitcoin-core
+
 By default, the `prepare.sh` script will obtain a runnable `bitcoind` binary in one of three exclusive ways. The default Bitcoin Core version is `30.2`, but you can override this by setting the `BITCOIN_REVISION` environment variable. The three methods are:
 
 1. **Using a user-provided binary**: If the `BITCOIND_EXE` environment variable is set and points to an executable, that exact binary is used. No download or build is attempted, and any `BITCOIN_REVISION` or build-parallelism settings are ignored.
+
 ```bash
     BITCOIND_EXE=/path/to/bitcoind ./tests/prepare.sh
 ```
 
 2. **Downloading a prebuilt binary**: If `BITCOIND_EXE` is not set, the script will try to download a prebuilt Bitcoin Core tarball for the specified `BITCOIN_REVISION`. Prebuilt binaries are available for all platforms and operating systems supported by Bitcoin Core. The supported versions are `30.2`, `29.2`, `28.3` and `27.2`.
+
 ```bash
     BITCOIN_REVISION=28.3 ./tests/prepare.sh
 ```
 
 3. **Building from source**: If no prebuilt binary is available for the platform, operating system, or specified version, the script will clone the Bitcoin Core repository and build `bitcoind` from the specified `BITCOIN_REVISION`. This can be a version tag (e.g., `29.1`) or a branch(e.g., `master`) from the remote repository.
+
 ```bash
     BITCOIN_REVISION=master ./tests/prepare.sh
 ```
@@ -168,16 +175,36 @@ Furthermore, you can run a set of specific tests, rather than all at once.
 ./tests/run.sh -t floresta-cli -k getblock
 ```
 
+#### Environment Variables
+
+| Variable                           | Default        | Description                                                                                                 |
+| ---------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `FLORESTA_SYNC_TIMEOUT`            | `120`          | Stale-state timeout for `wait_for_sync`. The countdown resets on progress; fires only when the node stalls. |
+| `FLORESTA_PEER_CONNECTION_TIMEOUT` | `30`           | Timeout in seconds for `wait_for_peers_connections` when waiting for nodes to discover each other.          |
+| `FLORESTA_REQUEST_TIMEOUT`         | `15`           | Timeout in seconds for individual RPC requests and socket wait operations.                                  |
+| `FLORESTA_REQUEST_STALE_TIMEOUT`   | `60`           | How long to retry transient RPC errors (read timeouts, connection errors) before giving up.                 |
+| `FLORESTA_TEMP_DIR`                | —              | Directory where functional tests look for binaries (at `$FLORESTA_TEMP_DIR/binaries`).                      |
+| `UTREEXO_REVISION`                 | latest release | Tag (without `v` prefix) of `utreexod` to build.                                                            |
+| `BITCOIN_REVISION`                 | `30.2`         | Version tag or branch of Bitcoin Core to use.                                                               |
+| `BITCOIND_EXE`                     | —              | Path to a user-provided `bitcoind` binary, skipping download/build.                                         |
+
+Example:
+
+```bash
+FLORESTA_SYNC_TIMEOUT=300 FLORESTA_PEER_CONNECTION_TIMEOUT=60 just test-functional-run
+```
+
 #### From python utility directly
+
 Additional functional tests are available (minimum python version: 3.12).
 It's not recommended to run them directly, since you will need to manually
 build the binaries yourself and place them at `$FLORESTA_TEMP_DIR/binaries`.
 The advantage is that you can run a specific test suite. For this you'll need to:
 
-* Setup `floresta`/`utreexod` environment;
-* Setup python utility;
-* Run tests from python utility directly;
-* Clean up the environment.
+- Setup `floresta`/`utreexod` environment;
+- Setup python utility;
+- Run tests from python utility directly;
+- Clean up the environment.
 
 ##### Setup `floresta`/`utreexod` environment
 
@@ -186,9 +213,10 @@ a `FLORESTA_TEMP_DIR` environment variable. This variable points to where
 our functional tests will look for the binaries.
 
 ##### Setup python utility
-* Recommended: install [uv: a rust-based python package and project manager](https://docs.astral.sh/uv/).
 
-* Configure an isolated environment:
+- Recommended: install [uv: a rust-based python package and project manager](https://docs.astral.sh/uv/).
+
+- Configure an isolated environment:
 
 ```bash
 # create a virtual environment
@@ -205,7 +233,7 @@ source .venv/bin/activate
 which python
 ```
 
-* Install module dependencies:
+- Install module dependencies:
 
 ```bash
 # installs dependencies listed in pyproject.toml.
@@ -224,7 +252,8 @@ uv pip install -r tests/requirements.txt
 uv sync
 ```
 
-* Format code
+- Format code
+
 ```bash
 uv run black ./tests
 
@@ -232,8 +261,8 @@ uv run black ./tests
 uv run black --check --verbose ./tests
 ```
 
+- Lint code
 
-* Lint code
 ```bash
 uv run pylint ./tests
 ```

--- a/tests/floresta-cli/getbestblockhash.py
+++ b/tests/floresta-cli/getbestblockhash.py
@@ -7,14 +7,11 @@ utreexod. Then, assert that the command returns the same hash of
 and utreexod, respectively.
 """
 
-import time
 import pytest
-
-TIMEOUT_SECONDS = 20
 
 
 @pytest.mark.rpc
-def test_get_best_block_hash(florestad_utreexod):
+def test_get_best_block_hash(florestad_utreexod, node_manager):
     """
     Test checks if Floresta can synchronize with the blockchain
     and retrieve the hash of the last block via the getbestblockhash RPC.
@@ -27,14 +24,7 @@ def test_get_best_block_hash(florestad_utreexod):
     assert floresta_best_block == utreexo_best_block
 
     utreexod.rpc.generate(10)
-    end = time.time() + TIMEOUT_SECONDS
-    while time.time() < end:
-        floresta_block = florestad.rpc.get_block_count()
-        utreexo_block = utreexod.rpc.get_block_count()
-        if floresta_block == utreexo_block:
-            break
-
-        time.sleep(1)
+    node_manager.wait_for_sync(florestad, 10)
 
     utreexo_chain = utreexod.rpc.get_blockchain_info()
     floresta_best_block = florestad.rpc.get_bestblockhash()

--- a/tests/floresta-cli/getblock.py
+++ b/tests/floresta-cli/getblock.py
@@ -6,13 +6,11 @@ floresta_cli_getblock.py
 This functional test cli utility to interact with a Floresta node with `getblock`
 """
 
-import time
 import random
+import time
 from typing import Any
 
 import pytest
-
-TIMEOUT_SECONDS = 20
 
 
 class TestGetBlock:
@@ -44,14 +42,7 @@ class TestGetBlock:
         self.node_manager.connect_nodes(self.florestad, self.bitcoind)
 
         block_count = self.bitcoind.rpc.get_block_count()
-        end = time.time() + TIMEOUT_SECONDS
-        while time.time() < end:
-            floresta_count = self.florestad.rpc.get_block_count()
-            if floresta_count == block_count:
-                break
-            time.sleep(0.5)
-
-        assert floresta_count == block_count
+        self.node_manager.wait_for_height(self.florestad, block_count)
 
         self.log.info("Testing getblock RPC in the genesis block")
         self.compare_block(0)

--- a/tests/floresta-cli/getblockcount.py
+++ b/tests/floresta-cli/getblockcount.py
@@ -6,15 +6,13 @@ utreexod. Then, assert that the command returns the same number of
 `blocks` and `height/validated` fields given in `getblockchaininfo`
 of utreexod/bitcoind and floresta, respectively"""
 
-import time
 import pytest
 
 MINE_BLOCKS = 10
-TIMEOUT_SECONDS = 20
 
 
 @pytest.mark.rpc
-def test_get_block_count(florestad_utreexod):
+def test_get_block_count(florestad_utreexod, node_manager):
     """
     Test the `getblockcount` shows the block count changes before and after mining.
     """
@@ -28,15 +26,7 @@ def test_get_block_count(florestad_utreexod):
 
     # Mine blocks with utreexod
     utreexod.rpc.generate(MINE_BLOCKS)
-    timeout = time.time() + TIMEOUT_SECONDS
-    while time.time() < timeout:
-        if (
-            florestad.rpc.get_block_count()
-            == utreexod.rpc.get_block_count()
-            == MINE_BLOCKS
-        ):
-            break
-        time.sleep(1)
+    node_manager.wait_for_sync(florestad, MINE_BLOCKS)
 
     # Get final block counts
     final_florestad_count = florestad.rpc.get_block_count()

--- a/tests/floresta-cli/getblockhash.py
+++ b/tests/floresta-cli/getblockhash.py
@@ -6,17 +6,14 @@ getblockhash.py
 This functional test cli utility to interact with a Floresta node with `getblockhash`
 """
 
-import time
 import pytest
-
 from test_framework.constants import GENESIS_BLOCK_HASH
 
 MINED_BLOCKS = 10
-TIMEOUT = 20
 
 
 @pytest.mark.rpc
-def test_get_block_hash(florestad_utreexod):
+def test_get_block_hash(florestad_utreexod, node_manager):
     """
     Test the `getblockhash` shows the block hash.
     """
@@ -30,15 +27,7 @@ def test_get_block_hash(florestad_utreexod):
 
     # Mine blocks with utreexod
     utreexod.rpc.generate(MINED_BLOCKS)
-    timeout = time.time() + TIMEOUT
-    while time.time() < timeout:
-        if (
-            florestad.rpc.get_block_count()
-            == utreexod.rpc.get_block_count()
-            == MINED_BLOCKS
-        ):
-            break
-        time.sleep(1)
+    node_manager.wait_for_sync(florestad, MINED_BLOCKS)
 
     # Get final block hashes
     final_florestad_hash = florestad.rpc.get_blockhash(MINED_BLOCKS)

--- a/tests/floresta-cli/getblockheader.py
+++ b/tests/floresta-cli/getblockheader.py
@@ -6,13 +6,12 @@ floresta_cli_getblockheader.py
 This functional test cli utility to interact with a Floresta node with `getblockheader`
 """
 
-import time
 import random
+import time
 from typing import Any
+
 import pytest
 from requests.exceptions import HTTPError
-
-TIMEOUT_SECONDS = 20
 
 
 class TestGetBlockheader:
@@ -62,14 +61,7 @@ class TestGetBlockheader:
         self.node_manager.connect_nodes(self.florestad, self.bitcoind)
 
         block_count = self.bitcoind.rpc.get_block_count()
-        start = time.time()
-        while time.time() - start < TIMEOUT_SECONDS:
-            florestad_count = self.florestad.rpc.get_block_count()
-            if florestad_count == block_count:
-                break
-            time.sleep(0.5)
-
-        assert florestad_count == block_count
+        self.node_manager.wait_for_height(self.florestad, block_count)
 
         self.log.info("Testing getblockheader RPC in the genesis block")
         self.validate_block_header(0)

--- a/tests/florestad/reorg_chain.py
+++ b/tests/florestad/reorg_chain.py
@@ -9,23 +9,22 @@ make florestad switch to the new chain. We then compare the two node's main chai
 accumulator to make sure they are the same.
 """
 
-import time
 import pytest
 
 
 @pytest.mark.florestad
-def test_reorg_chain(setup_logging, florestad_utreexod):
+def test_reorg_chain(setup_logging, florestad_utreexod, node_manager):
     """Mine blocks, trigger a reorg and assert both nodes end up on the same chain."""
     log = setup_logging
     florestad, utreexod = florestad_utreexod
 
-    ChainReorgTest(log, florestad, utreexod).run()
+    ChainReorgTest(log, florestad, utreexod, node_manager).run()
 
 
 class ChainReorgTest:
     """Tests that Florestad follows Utreexod during a chain reorganization."""
 
-    def __init__(self, log, florestad, utreexod):
+    def __init__(self, log, florestad, utreexod, node_manager):
         """
         Attributes initialized to satisfy static analysis; real values are
         provided by pytest fixtures.
@@ -33,6 +32,7 @@ class ChainReorgTest:
         self.log = log
         self.florestad = florestad
         self.utreexod = utreexod
+        self.node_manager = node_manager
 
     def run(self):
         """Mine blocks, trigger a reorg and assert both nodes end up on the same chain."""
@@ -74,16 +74,5 @@ class ChainReorgTest:
         self.log.info(f"Utreexod node mine {blocks} blocks")
         self.utreexod.rpc.generate(blocks)
 
-        timeout = 30
-        end = time.time() + timeout
-        while time.time() < end:
-            florestad_block = self.florestad.rpc.get_block_count()
-            utreexod_block = self.utreexod.rpc.get_block_count()
-            if florestad_block == utreexod_block:
-                self.log.info(f"Nodes are in sync: {florestad_block} blocks")
-                break
-
-            time.sleep(1)
-
-        if florestad_block != utreexod_block:
-            pytest.fail("Florestad node did not sync with Utreexod node in time")
+        target_height = self.utreexod.rpc.get_block_count()
+        self.node_manager.wait_for_sync(self.florestad, target_height, stale_timeout=30)

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -12,30 +12,57 @@ The difference is that `florestad` will run under a `cargo run` subprocess, whic
 `add_node_settings`.
 """
 
-import os
-import re
-import sys
+import contextlib
 import copy
+import inspect
+import os
 import random
-import socket
+import re
 import shutil
 import signal
-import contextlib
+import socket
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Pattern, Tuple, Optional
+from typing import Any, Dict, List, Optional, Pattern, Tuple
 
+from requests.exceptions import RequestException
 from test_framework.crypto.pkcs8 import (
     create_pkcs8_private_key,
     create_pkcs8_self_signed_certificate,
 )
 from test_framework.daemon import ConfigP2P
-from test_framework.rpc import ConfigRPC
 from test_framework.electrum import ConfigElectrum, ConfigTls
 from test_framework.node import Node, NodeType
+from test_framework.rpc import ConfigRPC
 from test_framework.util import Utility
+
+SYNC_TIMEOUT = float(os.environ.get("FLORESTA_SYNC_TIMEOUT", "120"))
+PEER_CONNECTION_TIMEOUT = float(
+    os.environ.get("FLORESTA_PEER_CONNECTION_TIMEOUT", "30")
+)
+
+
+def wait_until(predicate, *, timeout=SYNC_TIMEOUT, interval=0.5):
+    """Wait until ``predicate()`` returns True, or raise after *timeout* seconds.
+
+    This is a general-purpose primitive inspired by Bitcoin Core's
+    ``wait_until_helper_internal``.  Domain-specific helpers such as
+    ``FlorestaTestFramework.wait_for_sync`` build on top of this for
+    cases that need stale-state detection or RPC error tolerance.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+
+    source = inspect.getsource(predicate)
+    raise AssertionError(
+        f"wait_until() timed out after {timeout}s. Predicate:\n{source}"
+    )
 
 
 # pylint: disable=too-many-public-methods
@@ -293,8 +320,8 @@ class FlorestaTestFramework:
         Wait for two peers to connect/disconnect to each other.
         """
         attempts = 0
-        timeout = time.time() + 30
-        while time.time() < timeout:
+        deadline = time.time() + PEER_CONNECTION_TIMEOUT
+        while time.time() < deadline:
             if self.check_connection(peer_one, peer_two, is_connected):
                 self.log.debug(
                     f"Peers {peer_one.variant} and {peer_two.variant} are in the expected "
@@ -328,6 +355,103 @@ class FlorestaTestFramework:
             f"Peers {peer_one.variant} and {peer_two.variant} failed to reach the expected "
             f"connection state within the timeout. Expected connected: {is_connected}."
         )
+
+    def wait_for_sync(
+        self, node: Node, target_height: int, stale_timeout: float = SYNC_TIMEOUT
+    ):
+        """
+        Wait until a node is synced to the target height and out of IBD with stale detection.
+
+        If the node stops making progress for ``stale_timeout`` seconds, the test fails.
+        """
+        last_progress_time = time.time()
+        prev_height = None
+        prev_validated = None
+
+        while True:
+            try:
+                info = node.rpc.get_blockchain_info()
+            except RequestException as exc:
+                self.log.debug(f"Node '{node.variant}' RPC error (will retry): {exc}")
+                stale_elapsed = time.time() - last_progress_time
+                if stale_elapsed >= stale_timeout:
+                    raise AssertionError(
+                        f"Node '{node.variant}' RPC unreachable for {stale_timeout}s "
+                        f"trying to sync to height {target_height}: {exc}"
+                    ) from exc
+                time.sleep(1)
+                continue
+
+            if info["height"] == target_height and not info["ibd"]:
+                self.log.debug(
+                    f"Node '{node.variant}' synced to height {target_height}"
+                )
+                return
+
+            cur_height = info["height"]
+            cur_validated = info.get("validated")
+
+            if cur_height != prev_height or cur_validated != prev_validated:
+                last_progress_time = time.time()
+                prev_height = cur_height
+                prev_validated = cur_validated
+
+            stale_elapsed = time.time() - last_progress_time
+            if stale_elapsed >= stale_timeout:
+                raise AssertionError(
+                    f"Node '{node.variant}' stalled for {stale_timeout}s trying to "
+                    f"sync to height {target_height}: height={info['height']}, "
+                    f"validated={cur_validated}, ibd={info['ibd']}"
+                )
+
+            time.sleep(1)
+
+    def wait_for_height(
+        self, node: Node, target_height: int, stale_timeout: float = SYNC_TIMEOUT
+    ):
+        """
+        Wait until a node reaches the target height, regardless of IBD state.
+
+        Use this instead of ``wait_for_sync`` when the node only needs headers
+        sync(e.g. syncing from bitcoind which doesn't offer utreexo proofs).
+
+        Uses the same stale-state detection as ``wait_for_sync``.
+        """
+        last_progress_time = time.time()
+        prev_height = None
+
+        while True:
+            try:
+                info = node.rpc.get_blockchain_info()
+            except RequestException as exc:
+                self.log.debug(f"Node '{node.variant}' RPC error (will retry): {exc}")
+                stale_elapsed = time.time() - last_progress_time
+                if stale_elapsed >= stale_timeout:
+                    raise AssertionError(
+                        f"Node '{node.variant}' RPC unreachable for {stale_timeout}s "
+                        f"trying to reach height {target_height}: {exc}"
+                    ) from exc
+                time.sleep(1)
+                continue
+
+            cur_height = info["height"]
+            if cur_height == target_height:
+                self.log.debug(f"Node '{node.variant}' reached height {target_height}")
+                return
+
+            if cur_height != prev_height:
+                last_progress_time = time.time()
+                prev_height = cur_height
+
+            stale_elapsed = time.time() - last_progress_time
+            if stale_elapsed >= stale_timeout:
+                raise AssertionError(
+                    f"Node '{node.variant}' stalled for {stale_timeout}s trying to "
+                    f"reach height {target_height}: height={cur_height}, "
+                    f"ibd={info['ibd']}"
+                )
+
+            time.sleep(1)
 
     def connect_nodes(
         self,

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -8,18 +8,23 @@ Define a base class for making RPC calls to a
 """
 
 import json
+import os
+import re
 import socket
 import time
-import re
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
-from abc import ABC, abstractmethod
 
 from requests import post
-from requests.exceptions import HTTPError
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError, ReadTimeout
 from requests.models import HTTPBasicAuth
-from test_framework.rpc.exceptions import JSONRPCError
 from test_framework.rpc import ConfigRPC
+from test_framework.rpc.exceptions import JSONRPCError
+
+REQUEST_TIMEOUT = int(os.environ.get("FLORESTA_REQUEST_TIMEOUT", "15"))
+REQUEST_STALE_TIMEOUT = int(os.environ.get("FLORESTA_REQUEST_STALE_TIMEOUT", "60"))
 
 
 # pylint: disable=too-many-public-methods
@@ -39,7 +44,8 @@ class BaseRPC(ABC):
     Subclasses should use `perform_request` to implement RPC calls.
     """
 
-    TIMEOUT: int = 15  # seconds
+    REQUEST_TIMEOUT: int = REQUEST_TIMEOUT  # seconds
+    REQUEST_STALE_TIMEOUT: int = REQUEST_STALE_TIMEOUT  # seconds
 
     def __init__(self, config: ConfigRPC, log):
         self._config = config
@@ -116,7 +122,7 @@ class BaseRPC(ABC):
                     "params": params,
                 }
             ),
-            "timeout": self.TIMEOUT,
+            "timeout": self.REQUEST_TIMEOUT,
         }
         if self._config.user is not None and self._config.password is not None:
             request["auth"] = HTTPBasicAuth(self._config.user, self._config.password)
@@ -146,26 +152,42 @@ class BaseRPC(ABC):
         )
 
         self.log.debug(self.log_msg(logmsg))
-        response = post(**request)
 
-        # If response isnt 200, raise an HTTPError
-        if response.status_code != 200:
-            raise HTTPError
+        deadline = time.time() + self.REQUEST_STALE_TIMEOUT
+        last_exc = None
+        while time.time() < deadline:
+            try:
+                response = post(**request)
+            except (ReadTimeout, RequestsConnectionError) as exc:
+                last_exc = exc
+                self.log.debug(
+                    self.log_msg(f"Transient error on {method}, retrying: {exc}")
+                )
+                time.sleep(1)
+                continue
 
-        result = response.json()
-        # Error could be None or a str
-        # If in the future this change,
-        # cast the resulted error to str
-        if "error" in result and result["error"] is not None:
-            raise JSONRPCError(
-                data=result["error"] if isinstance(result["error"], str) else None,
-                rpc_id=result["id"],
-                code=result["error"]["code"],
-                message=result["error"]["message"],
-            )
+            # If response isnt 200, raise an HTTPError
+            if response.status_code != 200:
+                raise HTTPError
 
-        self.log.debug(self.log_msg(result["result"]))
-        return result["result"]
+            result = response.json()
+            # Error could be None or a str
+            # If in the future this change,
+            # cast the resulted error to str
+            if "error" in result and result["error"] is not None:
+                raise JSONRPCError(
+                    data=result["error"] if isinstance(result["error"], str) else None,
+                    rpc_id=result["id"],
+                    code=result["error"]["code"],
+                    message=result["error"]["message"],
+                )
+
+            self.log.debug(self.log_msg(result["result"]))
+            return result["result"]
+
+        if last_exc is not None:
+            raise last_exc
+        raise TimeoutError(f"RPC deadline for '{method}' expired without a response")
 
     def is_socket_listening(self) -> bool:
         """Check if the socket is listening for connections on the specified port."""
@@ -196,7 +218,7 @@ class BaseRPC(ABC):
         Ensure the RPC connection reaches the desired state within a timeout.
         Raises TimeoutError if the state is not reached.
         """
-        timeout = self.TIMEOUT
+        timeout = self.REQUEST_TIMEOUT
         success = self.try_wait_on_socket(opened, timeout)
         if not success:
             state = "open" if opened else "closed"


### PR DESCRIPTION
### Description and Notes

Here i present some general DX improvements for the functional tests, with simple changes on how we deal with timeouts.

The tests are not bounded by CPU speed but bounded by IO heavy usage, thats why the stale check helps to provide preciser timeouts.

Heres a breakdown of the impact of the changes on my machine:
```Markdown
- master, no workers definition (defaults to 4) - 28 passed in 252.09s (0:04:12).

- master, auto workers definition (14) - 3 failed, 22 passed in 90.21s (0:01:30). 
(failure because of IO read reached timeout).
 test_get_ping, test_add_node_v2, getconnectioncount failed

- this branch, no workers definition (default to 4) - 28 passed in 257.95s (0:04:17) 

- this branch, auto workers definition (14) - 28 passed in 143.31s (0:02:23)
```
With this we can add the `-n auto` flag to CI and see if anything breaks, Ill do that after the checks for this PR are completed and ill add them here.

### CI runs
```Markdown
master, no workers definition ( defaults to 4 ) - 28 passed in 70.67s (0:01:10)  

this branch, no workers definition ( defaults to  4 ) - 28 passed in 73.71s (0:01:13)

this branch, workers on auto (still 4) - 28 passed in 142.72s (0:02:22)

```

Yeah, CI is a lost cause for performance... luisschwab When you will give us a CI runner ?
 
### How to verify the changes you have done?

Run the prepare, the general `just test-functional` does not accept args and will run prepare and build binaries whitout need:

just test-functional-prepare

In master and checked in this branch:

just test-functional-run '-n auto'

and youll see that tests will break on master but not on this branch.

### Speculation

The major bound still IO, this is proven by the tests breaking because of READ timeouts. Perhaps we could make tests to run totally on ram ? Can we cache datadirs ? Can we avoid to write in disk on test environments ? The logs are being more usefull to debug running phase than datadirs itself

The tests got faster on more workers not necessarily because of CPU working more but because more tests were running at the same time, IO usage spiked even more in this case.

Also, this show us that we can optimize tests even more... Why ? you ask me.

Its obvious! Faster and well engineered test framework will allow us to run those tests on more environments, being able to verify floresta functionality in more cases and even add more extensive heavy load tests whitout bothering about the execution phase. 
