### PR TITLE
ci: run build and test for each commit in pushed range

### DIFF
--- a/.github/ci-test-each-commit-exec.sh
+++ b/.github/ci-test-each-commit-exec.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COMMIT_HASH=$(git log -1 --oneline)
+
+echo -e "\n================================================"
+echo -e " running tests for commit: $COMMIT_HASH"
+echo -e "================================================\n"
+
+cargo build --workspace --release
+cargo test --workspace --release

--- a/.github/workflows/test-each-commit.yml
+++ b/.github/workflows/test-each-commit.yml
@@ -1,0 +1,95 @@
+name: per-commit tests
+
+on:
+  push:
+
+jobs:
+  check-commits:
+    name: check intermediate commits
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@1.81.0
+        with:
+          components: rustfmt, clippy
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
+      - name: compute cache key
+        run: |
+          YEAR=$(date +%Y)
+          WEEK=$(date +%U)
+          BIWEEK=$(( (10#$WEEK + 1) / 2 ))
+          echo "CACHE_VERSION=${YEAR}(${BIWEEK})" >> $GITHUB_ENV
+
+      - name: restore cargo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/release/
+          key: ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-
+
+      - name: setup git
+        run: |
+          git config user.email "ci@floresta.test"
+          git config user.name "Floresta CI"
+
+      - name: run tests for each pushed commit
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          echo "checking commits from $BEFORE_SHA to $HEAD_SHA"
+
+          if [[ "$BEFORE_SHA" == *"0000000000"* ]]; then
+            echo "new branch detected. normal ci will handle the tip commit"
+            exit 0
+          fi
+
+          COMMIT_COUNT=$(git rev-list --count "$BEFORE_SHA..$HEAD_SHA")
+          echo "total commits to check: $COMMIT_COUNT"
+
+          if [ "$COMMIT_COUNT" -le 1 ]; then
+            echo "only one commit in this push, skipping per-commit iteration"
+            exit 0
+          fi
+
+          SCRIPT="/tmp/run_tests.sh"
+          cp .github/ci-test-each-commit-exec.sh "$SCRIPT"
+          chmod +x "$SCRIPT"
+
+          mapfile -t COMMITS < <(git rev-list --reverse "$BEFORE_SHA..$HEAD_SHA")
+
+          FAILED=0
+          FAILED_COMMITS=()
+
+          for SHA in "${COMMITS[@]}"; do
+            git checkout --quiet --detach "$SHA"
+            if ! bash "$SCRIPT"; then
+              FAILED=1
+              FAILED_COMMITS+=("$SHA")
+            fi
+          done
+
+          git checkout --quiet --detach "$HEAD_SHA"
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo ""
+            echo "the following intermediate commits failed tests"
+            printf ' - %s\n' "${FAILED_COMMITS[@]}"
+            exit 1
+          fi
+
+          echo "all intermediate commits compiled and passed tests"


### PR DESCRIPTION
### Description and Notes

FIXES #708

this PR adds a new CI workflow that runs `cargo build` and `cargo test` on every intermediate commit in a push batch to ensure PR history remains fully compilable

**notes:**
* uses a manual `git checkout --detach` loop instead of `git rebase --exec` for better reliability in headless CI
* tests run in `--release` mode to prevent the `floresta-rpc` tests from hitting the 30-second node startup timeout
* integrates the existing bi-weekly cache strategy so the per-commit checks run quickly

### How to verify the changes you have done?

push a branch with multiple commits to your fork, the new per-commit tests action will run alongside the standard CI, logging each commit it tests and cleanly failing if an intermediate commit is broken

### screenshots
below are the screenshot of the result of the per-commit tests

<img width="1068" height="142" alt="Screenshot 2026-05-09 at 00 49 35" src="https://github.com/user-attachments/assets/492b2283-0bed-4a75-a8cc-cd2e979eba2a" />
<br>
<br>
<img width="1082" height="115" alt="Screenshot 2026-05-09 at 01 32 40" src="https://github.com/user-attachments/assets/bb59aa1a-1393-4ec5-a3fb-cf414aeb829d" />

### minor note

the below change is intentional(not ai generated), to make the start of every commit check visible

<img width="531" height="61" alt="Screenshot 2026-05-09 at 01 28 15" src="https://github.com/user-attachments/assets/cd0ca158-be57-4a3d-89f6-a7afd9e3f720" />
