### PR TITLE
wallet: `KvDatabase::new` takes in `impl AsRef<Path>`

### DIFF
--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -4,6 +4,7 @@ use core::error::Error;
 use core::fmt;
 use core::fmt::Display;
 use core::fmt::Formatter;
+use std::path::Path;
 
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::encode::Error as EncodingError;
@@ -21,7 +22,7 @@ use super::Stats;
 
 pub struct KvDatabase(Store, Bucket<'static, String, Vec<u8>>);
 impl KvDatabase {
-    pub fn new(datadir: String) -> Result<KvDatabase> {
+    pub fn new(datadir: impl AsRef<Path>) -> Result<KvDatabase> {
         // Configure the database
         let cfg = Config::new(datadir);
 

--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -18,54 +18,77 @@ use kv::Config;
 use kv::Store;
 
 use super::AddressCacheDatabase;
+use super::CachedAddress;
+use super::CachedTransaction;
 use super::Stats;
 
+/// A key-value database for the watch-only wallet.
 pub struct KvDatabase(Store, Bucket<'static, String, Vec<u8>>);
-impl KvDatabase {
-    pub fn new(datadir: impl AsRef<Path>) -> Result<KvDatabase> {
-        // Configure the database
-        let cfg = Config::new(datadir);
 
-        // Open the key/value store
-        let store = Store::new(cfg)?;
-        let bucket = store.bucket::<String, Vec<u8>>(Some("addresses"))?;
-        Ok(KvDatabase(store, bucket))
+impl KvDatabase {
+    /// Create a new [`KvDatabase`] inside the `datadir`.
+    pub fn new(datadir: impl AsRef<Path>) -> Result<KvDatabase> {
+        let kv_db_config = Config::new(datadir);
+
+        let kv_db_store = Store::new(kv_db_config)?;
+        let kv_db_bucket = kv_db_store.bucket::<String, Vec<u8>>(Some("addresses"))?;
+
+        Ok(KvDatabase(kv_db_store, kv_db_bucket))
     }
 }
+
+/// Errors related to the [`KvDatabase`].
 #[derive(Debug)]
 pub enum KvDatabaseError {
+    /// A [`kv`] error.
     KvError(kv::Error),
+
+    /// A [`serde_json`] error.
     SerdeJsonError(serde_json::Error),
+
+    /// The wallet is not initialized.
     WalletNotInitialized,
+
+    /// Failed to deseriliaze data.
     DeserializeError(EncodingError),
+
+    /// The [`CachedTransaction`] was not found.
     TransactionNotFound,
 }
-impl_error_from!(KvDatabaseError, serde_json::Error, SerdeJsonError);
-impl_error_from!(KvDatabaseError, kv::Error, KvError);
-impl_error_from!(KvDatabaseError, EncodingError, DeserializeError);
 
 impl Display for KvDatabaseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            KvDatabaseError::KvError(e) => write!(f, "KvError: {e}"),
-            KvDatabaseError::SerdeJsonError(e) => write!(f, "SerdeJsonError: {e}"),
-            KvDatabaseError::WalletNotInitialized => write!(f, "WalletNotInitialized"),
-            KvDatabaseError::DeserializeError(e) => write!(f, "DeserializeError: {e}"),
-            KvDatabaseError::TransactionNotFound => write!(f, "TransactionNotFound"),
+            KvDatabaseError::KvError(e) => write!(f, "kv error: {e}"),
+            KvDatabaseError::SerdeJsonError(e) => write!(f, "JSON error: {e}"),
+            KvDatabaseError::WalletNotInitialized => write!(f, "The wallet is not initialized"),
+            KvDatabaseError::DeserializeError(e) => write!(f, "Error whilst deserilializing: {e}"),
+            KvDatabaseError::TransactionNotFound => {
+                write!(f, "The requested transaction was not found in the database")
+            }
         }
     }
 }
 
 impl Error for KvDatabaseError {}
 
+impl_error_from!(KvDatabaseError, serde_json::Error, SerdeJsonError);
+impl_error_from!(KvDatabaseError, kv::Error, KvError);
+impl_error_from!(KvDatabaseError, EncodingError, DeserializeError);
+
 type Result<T> = floresta_common::prelude::Result<T, KvDatabaseError>;
 
 impl AddressCacheDatabase for KvDatabase {
     type Error = KvDatabaseError;
-    fn load(&self) -> Result<Vec<super::CachedAddress>> {
+
+    /// Load [`CachedAddress`]es from the [`KvDatabase`].
+    fn load(&self) -> Result<Vec<CachedAddress>> {
+        let bucket = &self.1;
         let mut addresses = Vec::new();
-        for item in self.1.iter() {
+
+        for item in bucket.iter() {
             let item = item?;
+
             let key = item.key::<String>()?;
             if *"height" == key || *"desc" == key {
                 continue;
@@ -76,98 +99,131 @@ impl AddressCacheDatabase for KvDatabase {
         }
         Ok(addresses)
     }
-    fn save(&self, address: &super::CachedAddress) {
+
+    /// Save a [`CachedAddress`] to the [`KvDatabase`].
+    fn save(&self, address: &CachedAddress) {
         let key = address.script_hash.to_string();
         let value = serde_json::to_vec(&address).expect("Invalid object serialization");
+        let bucket = &self.1;
 
-        self.1
+        bucket
             .set(&key, &value)
             .expect("Fatal: Database isn't working");
-        self.1.flush().expect("Could not write to disk");
+        bucket.flush().expect("Could not write to disk");
     }
-    fn update(&self, address: &super::CachedAddress) {
+
+    /// Update a [`CachedAddress`] in the [`KvDatabase`].
+    fn update(&self, address: &CachedAddress) {
         self.save(address);
     }
+
+    /// Get the height which [`CachedAddress`]es are cached to.
     fn get_cache_height(&self) -> Result<u32> {
-        let height = self.1.get(&String::from("height"))?;
-        if let Some(height) = height {
-            return Ok(deserialize(&height)?);
+        let bucket = &self.1;
+
+        let cached_height = bucket.get(&String::from("height"))?;
+        if let Some(cached_height) = cached_height {
+            return Ok(deserialize(&cached_height)?);
         }
+
         Err(KvDatabaseError::WalletNotInitialized)
     }
+
+    /// Set the height which [`CachedAddress`]es are cached to.
     fn set_cache_height(&self, height: u32) -> Result<()> {
-        self.1.set(&String::from("height"), &serialize(&height))?;
-        self.1.flush()?;
-        Ok(())
-    }
+        let bucket = &self.1;
 
-    fn desc_save(&self, descriptor: &str) -> Result<()> {
-        let mut descs = self.descs_get()?;
-        descs.push(String::from(descriptor));
-        self.1
-            .set(&String::from("desc"), &serde_json::to_vec(&descs).unwrap())?;
-        self.1.flush()?;
+        bucket.set(&String::from("height"), &serialize(&height))?;
+        bucket.flush()?;
 
         Ok(())
     }
 
-    fn descs_get(&self) -> Result<Vec<String>> {
-        let res = self.1.get(&String::from("desc"))?;
-        if let Some(res) = res {
-            return Ok(serde_json::de::from_slice(&res)?);
+    /// Add a new descriptor to the [`KvDatabase`].
+    fn save_descriptor(&self, descriptor: &str) -> Result<()> {
+        let bucket = &self.1;
+        let mut descriptors = self.get_descriptors()?;
+
+        descriptors.push(String::from(descriptor));
+
+        bucket.set(
+            &String::from("desc"),
+            &serde_json::to_vec(&descriptors).unwrap(),
+        )?;
+        bucket.flush()?;
+
+        Ok(())
+    }
+
+    /// Get the [`KvDatabase`]'s descriptors.
+    fn get_descriptors(&self) -> Result<Vec<String>> {
+        let descriptor = self.1.get(&String::from("desc"))?;
+
+        if let Some(descriptor) = descriptor {
+            return Ok(serde_json::de::from_slice(&descriptor)?);
         }
         Ok(Vec::new())
     }
 
-    fn get_transaction(&self, txid: &bitcoin::Txid) -> Result<super::CachedTransaction> {
-        let store = self.0.bucket::<&[u8], Vec<u8>>(Some("transactions"))?;
-        let res = store.get(&txid.as_byte_array().to_vec().as_slice())?;
-        if let Some(res) = res {
-            return Ok(serde_json::de::from_slice(&res)?);
+    /// Get a [`CachedTransaction`] from the [`KvDatabase`], given its [`Txid`].
+    fn get_transaction(&self, txid: &Txid) -> Result<CachedTransaction> {
+        let tx_store = self.0.bucket::<&[u8], Vec<u8>>(Some("transactions"))?;
+
+        let transaction = tx_store.get(&txid.as_byte_array().to_vec().as_slice())?;
+        if let Some(transaction) = transaction {
+            return Ok(serde_json::de::from_slice(&transaction)?);
         }
         Err(KvDatabaseError::TransactionNotFound)
     }
 
-    fn save_transaction(&self, tx: &super::CachedTransaction) -> Result<()> {
-        let store = self.0.bucket::<&[u8], Vec<u8>>(Some("transactions"))?;
-        let ser_tx = serde_json::to_vec(&tx)?;
-        store.set(
+    /// Save a [`CachedTransaction`] to the [`KvDatabase`].
+    fn save_transaction(&self, tx: &CachedTransaction) -> Result<()> {
+        let tx_store = self.0.bucket::<&[u8], Vec<u8>>(Some("transactions"))?;
+        let bucket = &self.1;
+
+        let serialized_tx = serde_json::to_vec(&tx)?;
+        tx_store.set(
             &tx.tx.compute_txid().as_byte_array().to_vec().as_slice(),
-            &ser_tx,
+            &serialized_tx,
         )?;
-        self.1.flush()?;
+        bucket.flush()?;
 
         Ok(())
     }
 
-    fn get_stats(&self) -> Result<super::Stats> {
-        let store = self.0.bucket::<&[u8], Vec<u8>>(Some("stats"))?;
-        let res = store.get(&String::from("stats").as_bytes())?;
-        if let Some(res) = res {
-            return Ok(serde_json::de::from_slice(&res)?);
-        }
-        Err(KvDatabaseError::TransactionNotFound)
-    }
-
-    fn save_stats(&self, stats: &Stats) -> Result<()> {
-        let store = self.0.bucket::<&[u8], Vec<u8>>(Some("stats"))?;
-        let ser_stats = serde_json::to_vec(&stats)?;
-        store.set(&String::from("stats").as_bytes(), &ser_stats)?;
-        self.1.flush()?;
-
-        Ok(())
-    }
-
-    fn list_transactions(&self) -> Result<Vec<bitcoin::Txid>> {
+    /// List the [`CachedTransaction`]s [`Txid`]s.
+    fn list_transactions(&self) -> Result<Vec<Txid>> {
         let mut transactions = Vec::new();
-        let store = self.0.bucket::<&[u8], Vec<u8>>(Some("transactions"))?;
+        let tx_store = self.0.bucket::<&[u8], Vec<u8>>(Some("transactions"))?;
 
-        for item in store.iter() {
+        for item in tx_store.iter() {
             let item = item?;
             let key = item.key::<&[u8]>()?;
             transactions.push(Txid::from_slice(key).unwrap());
         }
         Ok(transactions)
+    }
+
+    /// Get [`Stats`] about the [`KvDatabase`].
+    fn get_stats(&self) -> Result<Stats> {
+        let stats_store = self.0.bucket::<&[u8], Vec<u8>>(Some("stats"))?;
+
+        let stats = stats_store.get(&String::from("stats").as_bytes())?;
+        if let Some(stats) = stats {
+            return Ok(serde_json::de::from_slice(&stats)?);
+        }
+        Err(KvDatabaseError::TransactionNotFound)
+    }
+
+    /// Save [`Stats`] to the [`KvDatabase`].
+    fn save_stats(&self, stats: &Stats) -> Result<()> {
+        let stats_store = self.0.bucket::<&[u8], Vec<u8>>(Some("stats"))?;
+
+        let ser_stats = serde_json::to_vec(&stats)?;
+        stats_store.set(&String::from("stats").as_bytes(), &ser_stats)?;
+        self.1.flush()?;
+
+        Ok(())
     }
 }
 
@@ -252,8 +308,8 @@ mod test {
         db.set_cache_height(test_height).unwrap();
         assert_eq!(db.get_cache_height().unwrap(), test_height);
 
-        db.desc_save(desc).unwrap();
-        assert_eq!(db.descs_get().unwrap(), vec![desc]);
+        db.save_descriptor(desc).unwrap();
+        assert_eq!(db.get_descriptors().unwrap(), vec![desc]);
 
         db.update(&cache_address);
         assert_eq!(db.load().unwrap()[0].script_hash, cache_address.script_hash);

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -181,9 +181,9 @@ pub trait AddressCacheDatabase {
     /// Saves the height of the last block we filtered
     fn set_cache_height(&self, height: u32) -> Result<(), Self::Error>;
     /// Saves the descriptor of associated cache
-    fn desc_save(&self, descriptor: &str) -> Result<(), Self::Error>;
+    fn save_descriptor(&self, descriptor: &str) -> Result<(), Self::Error>;
     /// Get associated descriptors
-    fn descs_get(&self) -> Result<Vec<String>, Self::Error>;
+    fn get_descriptors(&self) -> Result<Vec<String>, Self::Error>;
     /// Get a transaction from the database
     fn get_transaction(&self, txid: &Txid) -> Result<CachedTransaction, Self::Error>;
     /// Saves a transaction to the database
@@ -361,7 +361,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
     /// Setup is the first command that should be executed. In a new cache. It sets our wallet's
     /// state, like the height we should start scanning and the wallet's descriptor.
     fn setup(&self) -> Result<(), WatchOnlyError<D::Error>> {
-        if self.database.descs_get().is_err() {
+        if self.database.get_descriptors().is_err() {
             self.database.set_cache_height(0)?;
         }
         Ok(())
@@ -369,7 +369,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
 
     fn derive_addresses(&mut self) -> Result<(), WatchOnlyError<D::Error>> {
         let mut stats = self.database.get_stats()?;
-        let descriptors = self.database.descs_get()?;
+        let descriptors = self.database.get_descriptors()?;
 
         let addresses = derive_addresses_from_list_descriptors(
             &descriptors,
@@ -653,7 +653,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
     /// Tells whether or not a descriptor is already cached
     pub fn is_cached(&self, desc: &str) -> Result<bool, WatchOnlyError<D::Error>> {
         let inner = self.inner.read().expect("poisoned lock");
-        let known_descs = inner.database.descs_get()?;
+        let known_descs = inner.database.get_descriptors()?;
         Ok(known_descs.iter().any(|s| s == desc))
     }
 
@@ -681,7 +681,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         }
 
         let inner = self.inner.write().expect("poisoned lock");
-        inner.database.desc_save(descriptor)?;
+        inner.database.save_descriptor(descriptor)?;
 
         Ok(address_descriptors)
     }
@@ -809,7 +809,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         let inner = self.inner.read().expect("poisoned lock");
         inner
             .database
-            .descs_get()
+            .get_descriptors()
             .map_err(WatchOnlyError::DatabaseError)
     }
 

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -5,6 +5,7 @@
 //! It's not meant to use in production, but for the integrated testing framework
 //!
 //! For actual databases that can be used for production code, see [KvDatabase](crate::kv_database::KvDatabase).
+
 use bitcoin::hashes::sha256;
 use bitcoin::Txid;
 use floresta_common::prelude::sync::RwLock;
@@ -14,6 +15,7 @@ use super::AddressCacheDatabase;
 use super::CachedAddress;
 use super::CachedTransaction;
 use super::Stats;
+
 #[derive(Debug, Default)]
 struct Inner {
     addresses: HashMap<sha256::Hash, CachedAddress>,
@@ -24,10 +26,14 @@ struct Inner {
 }
 
 #[derive(Debug)]
+/// Errors related to the [`MemoryDatabase`].
 pub enum MemoryDatabaseError {
+    /// The lock is poisoned.
     PoisonedLock,
 }
+
 #[derive(Debug, Default)]
+/// An in-memory database for the watch-only wallet.
 pub struct MemoryDatabase {
     inner: RwLock<Inner>,
 }
@@ -35,24 +41,37 @@ pub struct MemoryDatabase {
 type Result<T> = floresta_common::prelude::Result<T, MemoryDatabaseError>;
 
 impl MemoryDatabase {
-    fn get_inner(&self) -> Result<sync::RwLockReadGuard<'_, Inner>> {
-        self.inner
-            .read()
-            .map_err(|_| MemoryDatabaseError::PoisonedLock)
-    }
-    fn get_inner_mut(&self) -> Result<sync::RwLockWriteGuard<'_, Inner>> {
-        self.inner
-            .write()
-            .map_err(|_| MemoryDatabaseError::PoisonedLock)
-    }
+    /// Create a new [`MemoryDatabase`].
     pub fn new() -> MemoryDatabase {
         MemoryDatabase {
             inner: Default::default(),
         }
     }
+
+    /// Get the [`MemoryDatabase`]'s [`Inner`] for read operations.
+    fn get_inner(&self) -> Result<sync::RwLockReadGuard<'_, Inner>> {
+        self.inner
+            .read()
+            .map_err(|_| MemoryDatabaseError::PoisonedLock)
+    }
+
+    /// Get the [`MemoryDatabase`]'s [`Inner`] for write operations.
+    fn get_inner_mut(&self) -> Result<sync::RwLockWriteGuard<'_, Inner>> {
+        self.inner
+            .write()
+            .map_err(|_| MemoryDatabaseError::PoisonedLock)
+    }
 }
+
 impl AddressCacheDatabase for MemoryDatabase {
     type Error = MemoryDatabaseError;
+
+    /// Load [`CachedAddress`]es from the [`MemoryDatabase`].
+    fn load(&self) -> Result<Vec<CachedAddress>> {
+        Ok(self.get_inner()?.addresses.values().cloned().collect())
+    }
+
+    /// Save a [`CachedAddress`] to the [`MemoryDatabase`].
     fn save(&self, address: &CachedAddress) {
         self.get_inner_mut()
             .map(|mut inner| {
@@ -63,22 +82,8 @@ impl AddressCacheDatabase for MemoryDatabase {
             .unwrap();
     }
 
-    fn load(&self) -> Result<Vec<CachedAddress>> {
-        Ok(self.get_inner()?.addresses.values().cloned().collect())
-    }
-
-    fn get_stats(&self) -> Result<super::Stats> {
-        Ok(self.get_inner()?.stats.to_owned())
-    }
-
-    fn save_stats(&self, stats: &super::Stats) -> Result<()> {
-        self.get_inner_mut().map(|mut inner| {
-            inner.stats.clone_from(stats);
-        })?;
-        Ok(())
-    }
-
-    fn update(&self, address: &super::CachedAddress) {
+    /// Update a [`CachedAddress`] in the [`MemoryDatabase`].
+    fn update(&self, address: &CachedAddress) {
         self.get_inner_mut()
             .map(|mut inner| {
                 inner
@@ -89,40 +94,60 @@ impl AddressCacheDatabase for MemoryDatabase {
             .unwrap();
     }
 
+    /// Get the height which [`CachedAddress`]es are cached to.
     fn get_cache_height(&self) -> Result<u32> {
         Ok(self.get_inner()?.height)
     }
 
+    /// Set the height which [`CachedAddress`]es are cached to.
     fn set_cache_height(&self, height: u32) -> Result<()> {
         self.get_inner_mut()?.height = height;
         Ok(())
     }
 
-    fn desc_save(&self, descriptor: &str) -> Result<()> {
+    /// Add a new descriptor to the [`MemoryDatabase`].
+    fn save_descriptor(&self, descriptor: &str) -> Result<()> {
         self.get_inner_mut().map(|mut inner| {
             inner.descriptors.push(descriptor.into());
         })
     }
 
-    fn descs_get(&self) -> Result<Vec<String>> {
+    /// Get the [`MemoryDatabase`]'s descriptors.
+    fn get_descriptors(&self) -> Result<Vec<String>> {
         Ok(self.get_inner()?.descriptors.to_owned())
     }
 
-    fn get_transaction(&self, txid: &bitcoin::Txid) -> Result<super::CachedTransaction> {
+    /// Get a [`CachedTransaction`] from the [`MemoryDatabase`].
+    fn get_transaction(&self, txid: &bitcoin::Txid) -> Result<CachedTransaction> {
         if let Some(tx) = self.get_inner()?.transactions.get(txid) {
             return Ok(tx.clone());
         }
         Err(MemoryDatabaseError::PoisonedLock)
     }
 
-    fn save_transaction(&self, tx: &super::CachedTransaction) -> Result<()> {
+    /// Save a [`CachedTransaction`] to the [`MemoryDatabase`].
+    fn save_transaction(&self, tx: &CachedTransaction) -> Result<()> {
         self.get_inner_mut()?
             .transactions
             .insert(tx.hash, tx.to_owned());
         Ok(())
     }
 
+    /// List the [`CachedTransaction`]s [`Txid`]s.
     fn list_transactions(&self) -> Result<Vec<Txid>> {
         Ok(self.get_inner()?.transactions.keys().copied().collect())
+    }
+
+    /// Get [`Stats`] about the [`MemoryDatabase`].
+    fn get_stats(&self) -> Result<Stats> {
+        Ok(self.get_inner()?.stats.to_owned())
+    }
+
+    /// Save [`Stats`] to the [`MemoryDatabase`].
+    fn save_stats(&self, stats: &Stats) -> Result<()> {
+        self.get_inner_mut().map(|mut inner| {
+            inner.stats.clone_from(stats);
+        })?;
+        Ok(())
     }
 }

--- a/crates/floresta-watch-only/src/merkle.rs
+++ b/crates/floresta-watch-only/src/merkle.rs
@@ -12,9 +12,16 @@ use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+/// A Merkle inclusion proof for a [`Transaction`](bitcoin::Transaction).
 pub struct MerkleProof {
+    /// The [`Txid`] of the [`Transaction`](bitcoin::Transaction).
     pub target: Txid,
+
+    /// The [`Transaction`](bitcoin::Transaction)'s position
+    /// in the [`Block`]s Merkle tree.
     pub pos: u64,
+
+    /// The Merkle proof's node hashes.
     pub hashes: Vec<sha256d::Hash>,
 }
 
@@ -25,7 +32,7 @@ impl Default for MerkleProof {
 }
 
 impl MerkleProof {
-    /// Creates an empty proof
+    /// Create a new and empty [`MerkleProof`].
     fn new() -> Self {
         MerkleProof {
             target: Txid::all_zeros(),
@@ -34,12 +41,12 @@ impl MerkleProof {
         }
     }
 
-    /// Return the hashes for this proof as a [`Vec<String>`]
+    /// Return the hashes for this [`MerkleProof`], as a [`Vec<String>`].
     pub fn to_string_array(&self) -> Vec<String> {
         self.hashes().iter().map(|hash| hash.to_string()).collect()
     }
 
-    /// Returns the hashes for this proof
+    /// Return the hashes for this [`MerkleProof`].
     pub fn hashes(&self) -> Vec<sha256d::Hash> {
         self.hashes.clone()
     }


### PR DESCRIPTION
Towards #939 

## Changelog
```
- `KvDatabase::new` takes in `impl AsRef<Path>` instead of `String`
- Update call sites

- Clean up `floresta-watch-only`:
  - Add missing comments
  - Move things around
```