### PR TITLE
fix: gates mallinfo for linux only.

### DIFF
--- a/crates/floresta-node/src/json_rpc/control.rs
+++ b/crates/floresta-node/src/json_rpc/control.rs
@@ -9,7 +9,7 @@ use super::server::RpcImpl;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     pub(super) fn get_memory_info(&self, mode: &str) -> Result<GetMemInfoRes, JsonRpcError> {
-        #[cfg(target_env = "gnu")]
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
         match mode {
             "stats" => {
                 let info = unsafe { libc::mallinfo() };
@@ -92,7 +92,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             _ => Err(JsonRpcError::InvalidMemInfoMode),
         }
 
-        #[cfg(not(any(target_env = "gnu", target_os = "macos")))]
+        #[cfg(not(any(all(target_os = "linux", target_env = "gnu"), target_os = "macos")))]
         // Just return zeroed stats for non-GNU and non-MacOS targets
         match mode {
             "stats" => Ok(GetMemInfoRes::Stats(GetMemInfoStats::default())),


### PR DESCRIPTION
### Description and Notes

Before this commit, the linux-specific mallinfo could be exposed to windows when compiled with the gnu toolchain.

### How to verify the changes you have done?

You pretty much have to compile for windows with the gnu toolchain.

In my machine i did that using floresta-nix.

This [post](https://users.rust-lang.org/t/cross-compile-on-macos-for-windows/137555) may help you to achieve that.

