### PR TITLE
Add Zizmor to CI and fix audit warnings

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+permissions: {}
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,10 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.81.0
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          components: rustfmt, clippy
+          persist-credentials: false
+
+      - name: Install 1.81.0 Rust Toolchain
+        run: |
+          rustup toolchain install 1.81.0 --profile minimal --no-self-update
+          rustup default 1.81.0
 
         # Bi-weekly numbers to refresh caches every two weeks, ensuring recent project changes are cached
       - name: Set bi-weekly cache key
@@ -37,7 +42,7 @@ jobs:
       # Restore Rust build cache and artifacts
       - name: Restore Rust cache
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -59,7 +64,7 @@ jobs:
       # This happens everytime we modify any `cargo.lock` or `cargo.toml`, or each two weeks (caching recent changes)
       - name: Save Rust cache
         if: success() && steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -70,7 +75,7 @@ jobs:
 
       # Store benchmark results
       - name: Store benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results
           path: target/criterion

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -29,6 +29,8 @@ jobs:
         steps:
             - name: Checkout Repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                persist-credentials: false
 
             - name: Check Commit Messages
               uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,20 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
           tags: dlsz/floresta:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -6,6 +6,8 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   functional:
     name: Functional

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+            persist-credentials: false
 
       # see more at
       # https://docs.astral.sh/uv/guides/integration/github/
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.12"
           enable-cache: true
@@ -41,7 +44,7 @@ jobs:
           sudo apt-get install -y libboost-all-dev
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Prepare functional tests tasks
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,8 @@ env:
     Dir::State "./.apt-state";
     Dir::State::lists "./.apt-state/lists/";
 
+permissions: {}
+
 jobs:
   fuzz:
     name: Run Fuzzing Tests

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,12 +23,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          components: rustfmt, clippy
+          persist-credentials: false
+
+      - name: Install Nightly Rust Toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup default nightly
 
       # Calculate cache keys
       - name: Generate cache keys
@@ -51,7 +54,7 @@ jobs:
       # Restore Rust build cache
       - name: Restore Rust cache
         id: cache-rust
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -69,7 +72,7 @@ jobs:
       # Restore apt packages cache
       - name: Restore apt cache
         id: cache-apt
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ./.apt-cache
@@ -113,7 +116,7 @@ jobs:
       # Save Rust cache if there was no exact match
       - name: Save Rust cache
         if: success() && steps.cache-rust.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -127,7 +130,7 @@ jobs:
       # Save apt cache if there was no exact match
       - name: Save apt cache
         if: success() && steps.cache-apt.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ./.apt-cache
@@ -137,7 +140,7 @@ jobs:
       # Upload artifacts (if crashes are found)
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-artifacts
           path: fuzz/artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-hack
-
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          components: rustfmt, clippy
+          persist-credentials: false
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: cargo-hack
+
+      - name: Install Nightly Rust Toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --component rustfmt,clippy --no-self-update
+          rustup default nightly
 
       - name: Install Boost
         run: |
@@ -29,7 +36,7 @@ jobs:
           sudo apt-get install -y libboost-all-dev
 
       - name: Spell check
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@5374cbf686e897b15713110e233094e2874de7ef # v1.46.1
         with:
           config: ./_typos.toml
 
@@ -52,11 +59,20 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.81.0 # The version in our `Cargo.toml`
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          components: rustfmt, clippy
-      - uses: taiki-e/install-action@cargo-hack
+          persist-credentials: false
+
+      - name: Install 1.81.0 Rust Toolchain
+        run: |
+          rustup toolchain install 1.81.0 --profile minimal --component rustfmt,clippy --no-self-update
+          rustup default 1.81.0
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: cargo-hack
 
       - name: Install Boost (Ubuntu)
         if: runner.os == 'Linux'
@@ -102,7 +118,7 @@ jobs:
       # Restore cached dependencies and build artifacts
       - name: Restore Rust cache
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -128,7 +144,7 @@ jobs:
       # This happens everytime we modify any `cargo.lock` or `cargo.toml`, or each two weeks (caching recent changes)
       - name: Save Rust cache
         if: success() && steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -147,12 +163,15 @@ jobs:
             feature_args: ""
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@1.81.0
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Common bare-metal Cortex-M target (no_std: `core` + `alloc`).
-          targets: thumbv7em-none-eabi
+          persist-credentials: false
+
+      - name: Install 1.81.0 Rust Toolchain and no-std Target
+        run: |
+          rustup toolchain install 1.81.0 --profile minimal --target thumbv7em-none-eabi --no-self-update
+          rustup default 1.81.0
 
       - name: Install ARM GCC (for secp256k1-sys)
         run: |
@@ -171,13 +190,16 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+permissions: {}
 
 jobs:
   linting:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Zizmor
+
+on:
+    push:
+    pull_request:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 12 * * 1" # Monday, 12:00:00 UTC
+
+permissions: {}
+
+jobs:
+    zizmor:
+        name: CI Action Static Analysis
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+            - name: Run Zizmor
+              run: uvx zizmor .


### PR DESCRIPTION
Closes #1000 

This PR introduces [Zizmor](https://github.com/zizmorcore/zizmor), which performs static analysis on GitHub actions in order to detect badly written workflows, per [Zizmor's Audit Rules](https://docs.zizmor.sh/audits).

## Changelog
```
- Add `zizmor.yml` for GHAction static analysis
- Fix Zizmor's audit warnings:
  - Pin `actions/cache` to v5.0.5's hash
  - Pin `actions/checkout` to v6.0.2's hash
  - Pin `actions/upload-artifact` to v7.0.1's hash
  - Pin `docker/setup-buildx-action` to v4.0.0's hash
  - Pin `docker/login-action` to v4.1.0's hash
  - Pin `docker/build-push-action` to v7.1.0's hash
  - Pin `crate-ci/typos` to v1.46.1's hash
  - Pin `taiki-e/install-action` to v2.77.6's hash
  - Pin `astral-sh/setup-uv` to v8.1.0's hash
  - Drop `dtolnay/rust-toolchain` action: GH's CI runners already ship `rustup`
```

### Notes to the reviewers

You can verify that Zizmor is satisfied with these changes by running
```
uvx zizmor .
```