### PR TITLE
fix(rpc): make verificationprogress tip-aware

### DIFF
--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -310,6 +310,10 @@ mod tests {
     impl BlockchainInterface for MockBlockchainInterface {
         type Error = MockBlockchainError;
 
+        fn size_on_disk(&self) -> Result<u64, Self::Error> {
+            unimplemented!("MockBlockchainInterface has no on-disk presence")
+        }
+
         fn get_block_header(&self, hash: &BlockHash) -> Result<Header, Self::Error> {
             self.headers
                 .get(hash)

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1042,6 +1042,10 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         read_lock!(self).acc.to_owned()
     }
 
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        Ok(read_lock!(self).chainstore.size_on_disk()?)
+    }
+
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error> {
         let fork_point = self.find_fork_point(&self.get_block_header(&block)?)?;
         Ok(fork_point.block_hash())

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -72,6 +72,13 @@ pub trait ChainStore {
     /// If you're using a database that already checks for integrity by itself,
     /// this can safely be a no-op.
     fn check_integrity(&self) -> Result<(), Self::Error>;
+
+    /// Returns the total size on disk, in bytes, of the data this store persists.
+    ///
+    /// The returned value is the sum of the sizes of each backing file managed by
+    /// this store. Implementations should not include the size of any enclosing
+    /// directory or unrelated data.
+    fn size_on_disk(&self) -> Result<u64, Self::Error>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1122,6 +1122,16 @@ impl ChainStore for FlatChainStore {
         unsafe { self.do_flush() }
     }
 
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        let headers_size = self.headers.len() as u64;
+        let metadata_size = self.metadata.len() as u64;
+        let block_index_size = self.block_index.index_map.len() as u64;
+        let fork_headers_size = self.fork_headers.len() as u64;
+        let accumulator_size = self.accumulator_file.metadata()?.len();
+
+        Ok(headers_size + metadata_size + block_index_size + fork_headers_size + accumulator_size)
+    }
+
     fn save_roots_for_block(&mut self, roots: Vec<u8>, height: u32) -> Result<(), Self::Error> {
         let index = Index::new(height)?;
 
@@ -1666,6 +1676,23 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_size_on_disk() {
+        let store = get_test_chainstore(None).unwrap();
+
+        let size = store.size_on_disk().unwrap();
+
+        // Sum of the four mmap regions plus the accumulator file. At init the accumulator
+        // file is empty, so the total should equal the sum of the four mapped files.
+        let expected = (store.headers.len()
+            + store.metadata.len()
+            + store.block_index.index_map.len()
+            + store.fork_headers.len()) as u64;
+
+        assert_eq!(size, expected);
+        assert!(size > 0);
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1384,6 +1384,7 @@ mod tests {
     use super::FlatChainStore;
     use super::FlatChainStoreConfig;
     use super::FlatChainstoreError;
+    use super::HashedDiskHeader;
     use super::Index;
     use super::FLAT_CHAINSTORE_MAGIC;
     use super::FLAT_CHAINSTORE_VERSION;
@@ -1678,21 +1679,79 @@ mod tests {
         }
     }
 
+    fn make_sized_store(
+        block_index_size: usize,
+        headers_file_size: usize,
+        fork_file_size: usize,
+    ) -> FlatChainStore {
+        let test_id = rand::random::<u64>();
+        let config = FlatChainStoreConfig {
+            block_index_size: Some(block_index_size),
+            headers_file_size: Some(headers_file_size),
+            fork_file_size: Some(fork_file_size),
+            cache_size: Some(10),
+            file_permission: Some(0o660),
+            path: format!("./tmp-db/{test_id}/"),
+        };
+        FlatChainStore::new(config).unwrap()
+    }
+
     #[test]
     fn test_size_on_disk() {
-        let store = get_test_chainstore(None).unwrap();
+        // Baseline matches the formula in `size_on_disk`.
+        let mut store = make_sized_store(32_768, 32_768, 16_384);
+        let baseline = (32_768 * size_of::<u32>()
+            + 32_768 * size_of::<HashedDiskHeader>()
+            + 16_384 * size_of::<HashedDiskHeader>()
+            + size_of::<Metadata>()) as u64;
+        assert_eq!(store.size_on_disk().unwrap(), baseline);
 
-        let size = store.size_on_disk().unwrap();
+        // Vary each preallocated field; check the per-field delta so any
+        // dropped or miscounted summand in `size_on_disk` fails here.
+        let bigger_index = make_sized_store(65_536, 32_768, 16_384);
+        assert_eq!(
+            bigger_index.size_on_disk().unwrap() - baseline,
+            (32_768 * size_of::<u32>()) as u64,
+        );
 
-        // Sum of the four mmap regions plus the accumulator file. At init the accumulator
-        // file is empty, so the total should equal the sum of the four mapped files.
-        let expected = (store.headers.len()
-            + store.metadata.len()
-            + store.block_index.index_map.len()
-            + store.fork_headers.len()) as u64;
+        let bigger_headers = make_sized_store(32_768, 65_536, 16_384);
+        assert_eq!(
+            bigger_headers.size_on_disk().unwrap() - baseline,
+            (32_768 * size_of::<HashedDiskHeader>()) as u64,
+        );
 
-        assert_eq!(size, expected);
-        assert!(size > 0);
+        let bigger_fork = make_sized_store(32_768, 32_768, 32_768);
+        assert_eq!(
+            bigger_fork.size_on_disk().unwrap() - baseline,
+            (16_384 * size_of::<HashedDiskHeader>()) as u64,
+        );
+
+        // Accumulator file is the only dynamic component; grows by payload.
+        let genesis = genesis_block(Network::Regtest);
+        store
+            .save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))
+            .unwrap();
+        store.update_block_index(0, genesis.block_hash()).unwrap();
+
+        let acc = vec![0xab; 64];
+        store.save_roots_for_block(acc.clone(), 0).unwrap();
+        assert_eq!(store.size_on_disk().unwrap(), baseline + acc.len() as u64);
+
+        // Cumulative append at height 1.
+        let mut next = genesis.header;
+        next.prev_blockhash = genesis.block_hash();
+        store
+            .save_header(&DiskBlockHeader::FullyValid(next, 1))
+            .unwrap();
+        store.update_block_index(1, next.block_hash()).unwrap();
+
+        let acc2 = vec![0xcd; 32];
+        let pre_second = store.size_on_disk().unwrap();
+        store.save_roots_for_block(acc2.clone(), 1).unwrap();
+        assert_eq!(
+            store.size_on_disk().unwrap(),
+            pre_second + acc2.len() as u64,
+        );
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -128,6 +128,9 @@ pub trait BlockchainInterface {
 
     /// Returns the amount of [`Work`] associated with a given chain tip
     fn get_work(&self, tip: BlockHash) -> Result<Work, Self::Error>;
+
+    /// Returns the total size on disk, in bytes, of the chain data persisted by this backend.
+    fn size_on_disk(&self) -> Result<u64, Self::Error>;
 }
 
 /// [UpdatableChainstate] is a contract that a is expected from a chainstate
@@ -360,6 +363,10 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
 
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error> {
         T::get_fork_point(self, block)
+    }
+
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        T::size_on_disk(self)
     }
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -335,6 +335,10 @@ impl BlockchainInterface for PartialChainState {
         self.inner().current_acc.clone()
     }
 
+    fn size_on_disk(&self) -> Result<u64, Self::Error> {
+        unimplemented!("partialChainState has no on-disk presence")
+    }
+
     fn get_height(&self) -> Result<u32, Self::Error> {
         Ok(self.inner().current_height)
     }

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -9,6 +9,7 @@ use bitcoin::Address;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::MerkleBlock;
+use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitcoin::Script;
 use bitcoin::ScriptBuf;
@@ -16,6 +17,7 @@ use bitcoin::Txid;
 use bitcoin::VarInt;
 use corepc_types::v29::GetTxOut;
 use corepc_types::v30::GetBlockVerboseOne;
+use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::ScriptPubkey;
 use floresta_chain::extensions::HeaderExt;
 use floresta_chain::extensions::WorkExt;
@@ -24,7 +26,6 @@ use serde_json::json;
 use serde_json::Value;
 use tracing::debug;
 
-use super::res::GetBlockchainInfoRes;
 use super::res::GetTxOutProof;
 use super::res::JsonRpcError;
 use super::server::RpcChain;
@@ -243,7 +244,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     }
 
     // getblockchaininfo
-    pub(super) fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes, JsonRpcError> {
+    pub(super) fn get_blockchain_info(&self) -> Result<GetBlockchainInfo, JsonRpcError> {
         let (height, hash) = self.chain.get_best_block().unwrap();
         let validated = self.chain.get_validation_index().unwrap();
         let ibd = self.chain.is_in_ibd();
@@ -252,37 +253,47 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .calculate_chain_work(&self.chain)?
             .to_string_hex();
         let latest_block_time = latest_header.time;
-        let leaf_count = self.chain.acc().leaves as u32;
-        let root_count = self.chain.acc().roots.len() as u32;
-        let root_hashes = self
-            .chain
-            .acc()
-            .roots
-            .into_iter()
-            .map(|r| r.to_string())
-            .collect();
-
-        let validated_blocks = self.chain.get_validation_index().unwrap();
 
         let validated_percentage = if height != 0 {
-            validated_blocks as f32 / height as f32
+            validated as f64 / height as f64
         } else {
             0.0
         };
 
-        Ok(GetBlockchainInfoRes {
-            best_block: hash.to_string(),
-            height,
-            ibd,
-            validated,
-            latest_work,
-            latest_block_time,
-            leaf_count,
-            root_count,
-            root_hashes,
-            chain: self.network.to_string(),
-            difficulty: latest_header.difficulty(self.chain.get_params()) as u64,
-            progress: validated_percentage,
+        let mediantime = latest_header.calculate_median_time_past(&self.chain)?;
+        let bits = latest_header.get_bits_hex();
+        let target = latest_header.get_target_hex();
+        let size_on_disk = self.chain.size_on_disk().map_err(|_| JsonRpcError::Chain)?;
+
+        let chain = match self.network {
+            Network::Bitcoin => "main",
+            Network::Testnet => "test",
+            Network::Signet => "signet",
+            Network::Regtest => "regtest",
+            _ => "unknown",
+        }
+        .to_string();
+
+        Ok(GetBlockchainInfo {
+            chain,
+            blocks: validated as i64,
+            headers: height as i64,
+            best_block_hash: hash.to_string(),
+            bits,
+            target,
+            difficulty: latest_header.get_difficulty(),
+            time: latest_block_time as i64,
+            median_time: mediantime as i64,
+            verification_progress: validated_percentage,
+            initial_block_download: ibd,
+            chain_work: latest_work,
+            size_on_disk,
+            pruned: true,
+            prune_height: Some((height as i64) + 1),
+            automatic_pruning: Some(true),
+            prune_target_size: Some(0),
+            signet_challenge: None,
+            warnings: vec![],
         })
     }
 

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
 use bitcoin::block::Header;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::consensus::Encodable;
@@ -254,11 +257,25 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .to_string_hex();
         let latest_block_time = latest_header.time;
 
-        let validated_percentage = if height != 0 {
-            validated as f64 / height as f64
-        } else {
-            0.0
-        };
+        let validated_hash = self
+            .chain
+            .get_block_hash(validated)
+            .map_err(|_| JsonRpcError::Chain)?;
+        let validated_header = self
+            .chain
+            .get_block_header(&validated_hash)
+            .map_err(|_| JsonRpcError::BlockNotFound)?;
+        let validated_block_time = validated_header.time;
+
+        let genesis_time = genesis_block(self.network).header.time;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let validated_percentage =
+            verification_progress(validated_block_time, latest_block_time, now, genesis_time);
 
         let mediantime = latest_header.calculate_median_time_past(&self.chain)?;
         let bits = latest_header.get_bits_hex();
@@ -675,5 +692,115 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .get_descriptors()
             .map_err(|e| JsonRpcError::Wallet(e.to_string()))?;
         Ok(descriptors)
+    }
+}
+
+/// Time-based estimate of validated-tip progress in `[0.0, 1.0]`.
+///
+/// Ratio of chain-time elapsed between genesis and the validated block,
+/// over chain-time between genesis and the later of `now` or
+/// `header_tip_time`. Returns `0.0` for cold start, clamps to `1.0` at tip.
+fn verification_progress(
+    validated_block_time: u32,
+    header_tip_time: u32,
+    now: u64,
+    genesis_time: u32,
+) -> f64 {
+    if validated_block_time <= genesis_time {
+        return 0.0;
+    }
+
+    let elapsed_validated = u64::from(validated_block_time - genesis_time);
+    let denom_anchor = now.max(u64::from(header_tip_time));
+    let genesis = u64::from(genesis_time);
+
+    if denom_anchor <= genesis {
+        return 0.0;
+    }
+
+    let elapsed_total = denom_anchor - genesis;
+    (elapsed_validated as f64 / elapsed_total as f64).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verification_progress;
+
+    // Mainnet genesis block timestamp (2009-01-03 18:15:05 UTC).
+    const GENESIS_TIME: u32 = 1_231_006_505;
+    // Synthetic "now" for tests (approximately 2026-05-10).
+    const NOW: u64 = 1_778_544_000;
+
+    #[test]
+    fn test_validated_at_or_before_genesis_returns_zero() {
+        // Cold start (validated == genesis), plus the defensive case
+        // (validated < genesis, which shouldn't happen but the guard catches it).
+        assert_eq!(
+            verification_progress(GENESIS_TIME, GENESIS_TIME, NOW, GENESIS_TIME),
+            0.0,
+        );
+        assert_eq!(
+            verification_progress(GENESIS_TIME - 1, GENESIS_TIME, NOW, GENESIS_TIME),
+            0.0,
+        );
+    }
+
+    #[test]
+    fn test_fully_synced_returns_one() {
+        let validated = NOW as u32;
+        let p = verification_progress(validated, validated, NOW, GENESIS_TIME);
+        assert_eq!(p, 1.0);
+    }
+
+    #[test]
+    fn test_future_dated_block_clamps_to_one() {
+        let p = verification_progress(NOW as u32 + 86_400, NOW as u32, NOW, GENESIS_TIME);
+        assert_eq!(p, 1.0);
+    }
+
+    #[test]
+    fn test_mid_sync_returns_intermediate_value() {
+        let midpoint = ((GENESIS_TIME as u64 + NOW) / 2) as u32;
+        let p = verification_progress(midpoint, midpoint, NOW, GENESIS_TIME);
+        assert!(p > 0.45 && p < 0.55, "expected ~0.5, got {p}");
+    }
+
+    #[test]
+    fn test_frozen_validated_reports_falling_progress() {
+        // Stall scenario: validated freezes while `now` advances;
+        // progress must strictly decrease, never stick at 1.0.
+        let frozen_validated: u32 = 1_295_049_600; // 2011-01-15 (~block 17,904)
+
+        let p_t1 = verification_progress(frozen_validated, frozen_validated, NOW, GENESIS_TIME);
+        let p_t2 = verification_progress(
+            frozen_validated,
+            frozen_validated,
+            NOW + 365 * 86_400,
+            GENESIS_TIME,
+        );
+
+        assert!(p_t1 < 1.0, "progress should not be 1.0 (was {p_t1})");
+        assert!(
+            p_t2 < p_t1,
+            "progress should decrease over time ({p_t2} vs {p_t1})",
+        );
+    }
+
+    #[test]
+    fn test_header_tip_ahead_of_now_used_as_denominator() {
+        // Peers' headers slightly ahead of local clock: max() picks
+        // header_tip so progress doesn't artificially round to 1.0.
+        let header_tip_ahead = NOW as u32 + 3600;
+        let validated = NOW as u32;
+        let p = verification_progress(validated, header_tip_ahead, NOW, GENESIS_TIME);
+        assert!(p < 1.0, "expected p < 1.0, got {p}");
+        assert!(p > 0.99, "expected p > 0.99, got {p}");
+    }
+
+    #[test]
+    fn test_broken_clock_returns_zero() {
+        // Defensive: `now` and `header_tip_time` both 0 (clock before UNIX epoch).
+        let p = verification_progress(GENESIS_TIME + 1000, 0, 0, GENESIS_TIME);
+        assert_eq!(p, 0.0);
     }
 }

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -13,22 +13,6 @@ use floresta_mempool::mempool::MempoolError;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Deserialize, Serialize)]
-pub struct GetBlockchainInfoRes {
-    pub best_block: String,
-    pub height: u32,
-    pub ibd: bool,
-    pub validated: u32,
-    pub latest_work: String,
-    pub latest_block_time: u32,
-    pub leaf_count: u32,
-    pub root_count: u32,
-    pub root_hashes: Vec<String>,
-    pub chain: String,
-    pub progress: f32,
-    pub difficulty: u64,
-}
-
 /// A confidence enum to auxiliate rescan timestamp values.
 ///
 /// Serves to tell how much confidence you need in such a rescan request. That is, the need for a high confidence rescan

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -157,9 +157,9 @@ mod tests {
 
         let gbi = client.get_blockchain_info().expect("rpc not working");
 
-        assert_eq!(gbi.height, 0);
+        assert_eq!(gbi.blocks, 0);
         assert_eq!(gbi.chain, "regtest".to_owned());
-        assert!(gbi.ibd);
+        assert!(gbi.initialblockdownload);
         assert_eq!(gbi.leaf_count, 0);
         assert_eq!(gbi.root_hashes, Vec::<String>::new());
     }

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -159,18 +159,7 @@ mod tests {
 
         assert_eq!(gbi.blocks, 0);
         assert_eq!(gbi.chain, "regtest".to_owned());
-        assert!(gbi.initialblockdownload);
-        assert_eq!(gbi.leaf_count, 0);
-        assert_eq!(gbi.root_hashes, Vec::<String>::new());
-    }
-
-    #[test]
-    fn test_get_roots() {
-        let (_proc, client) = start_florestad();
-
-        let gbi = client.get_blockchain_info().expect("rpc not working");
-
-        assert_eq!(gbi.root_hashes, Vec::<String>::new());
+        assert!(gbi.initial_block_download);
     }
 
     #[test]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use bitcoin::block::Header as BlockHeader;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::GetBlockchainInfo;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -28,7 +29,7 @@ pub trait FlorestaRPC {
     /// This method returns a bunch of information about the chain we are on, including
     /// the current height, the best block hash, the difficulty, and whether we are
     /// currently in IBD (Initial Block Download) mode.
-    fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes>;
+    fn get_blockchain_info(&self) -> Result<GetBlockchainInfo>;
     /// Returns the hash of the best (tip) block in the most-work fully-validated chain.
     fn get_best_block_hash(&self) -> Result<BlockHash>;
     /// Returns the hash of the block at the given height
@@ -327,7 +328,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getblockheader", &[Value::String(hash.to_string())])
     }
 
-    fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes> {
+    fn get_blockchain_info(&self) -> Result<GetBlockchainInfo> {
         self.call("getblockchaininfo", &[])
     }
 

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -15,48 +15,6 @@ use serde::Serialize;
 /// by btc core.
 pub struct GetTxOutProof(pub Vec<u8>);
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GetBlockchainInfoRes {
-    /// The best block we know about
-    ///
-    /// This should be the hash of the latest block in the most PoW chain we know about. We may
-    /// or may not have fully-validated it yet
-    pub best_block: String,
-    /// The depth of the most-PoW chain we know about
-    pub height: u32,
-    /// Whether we are on Initial Block Download
-    pub ibd: bool,
-    /// How many blocks we have fully-validated so far? This number will be smaller than
-    /// height during IBD, and should be equal to height otherwise
-    pub validated: u32,
-    /// The work performed by the last block
-    ///
-    /// This is the estimated amount of hashes the miner of this block had to perform
-    /// before mining that block, on average
-    pub latest_work: String,
-    /// The UNIX timestamp for the latest block, as reported by the block's header
-    pub latest_block_time: u32,
-    /// How many leaves we have in the utreexo accumulator so far
-    ///
-    /// This should be equal to the number of UTXOs returned by core's `gettxoutsetinfo`
-    pub leaf_count: u32,
-    /// How many roots we have in the acc
-    pub root_count: u32,
-    /// The actual hex-encoded roots
-    pub root_hashes: Vec<String>,
-    /// A short string representing the chain we're in
-    pub chain: String,
-    /// The validation progress
-    ///
-    /// 0 means we didn't validate any block. 1 means we've validated all blocks. so validated == height.
-    pub progress: f32,
-    /// Current network "difficulty"
-    ///
-    /// On average, miners needs to make `difficulty` hashes before finding one that
-    /// solves a block's PoW
-    pub difficulty: u64,
-}
-
 /// The information returned by a get_raw_tx
 #[derive(Deserialize, Serialize)]
 pub struct RawTx {

--- a/doc/rpc/getblockchaininfo.md
+++ b/doc/rpc/getblockchaininfo.md
@@ -1,6 +1,6 @@
 # `getblockchaininfo`
 
-Returns general information about the current state of the blockchain, including block height, validation progress, network difficulty, and utreexo accumulator statistics.
+Returns general information about the current state of the blockchain, including block height, validation progress, and network difficulty.
 
 ## Usage
 
@@ -27,36 +27,57 @@ This command takes no arguments.
 
 Returns a JSON object with the following fields:
 
-- `best_block` - (string) The hash of the best (most-work) block we know about. This is the latest block in the most PoW chain, which may or may not be fully validated yet.
+- `bestblockhash` - (string) The hash of the best (most-work) block we know about. This is the latest block in the most PoW chain, which may or may not be fully validated yet.
 
-- `height` - (numeric) The depth of the most-work chain we know about, representing the total number of blocks.
+- `blocks` - (numeric) The height of the most-work fully-validated chain. During IBD, this number will be smaller than `headers`; after IBD completes, it should be equal to `headers`.
 
-- `ibd` - (boolean) Whether the node is currently in Initial Block Download (IBD) mode.
+- `initialblockdownload` - (boolean) Whether the node is currently in Initial Block Download (IBD) mode.
 
-- `validated` - (numeric) How many blocks have been fully validated so far. During IBD, this number will be smaller than `height`. After IBD completes, it should be equal to `height`.
+- `headers` - (numeric) The count of headers we have validated. During IBD, this number will be larger than `blocks`; after IBD completes, it should be equal to `blocks`.
 
-- `latest_work` - (string) The work performed by the last block. This is the estimated number of hashes the miner had to perform before mining that block, on average.
+- `chainwork` - (string) Total amount of work in the active chain, in hexadecimal.
 
-- `latest_block_time` - (numeric) The UNIX timestamp for the latest block, as reported by the block's header.
-
-- `leaf_count` - (numeric) The number of leaves in the utreexo accumulator. This represents the total number of transaction outputs (TXOs) that have ever been added to the accumulator.
-
-- `root_count` - (numeric) The number of roots in the utreexo accumulator.
-
-- `root_hashes` - (array of strings) The actual hex-encoded roots of the utreexo accumulator.
+- `time` - (numeric) The UNIX timestamp for the latest block, as reported by the block's header.
 
 - `chain` - (string) A short string representing the blockchain network (e.g., "bitcoin", "testnet", "signet").
 
-- `progress` - (numeric) The validation progress as a decimal between 0 and 1. A value of 0 means no blocks have been validated, while 1 means all blocks are validated (validated == height).
+- `verificationprogress` - (numeric) The validation progress as a decimal between 0 and 1. A value of 0 means no blocks have been validated, while 1 means all blocks are validated (headers == blocks).
 
 - `difficulty` - (numeric) The current network difficulty. On average, miners need to make `difficulty` hashes before finding one that solves a block's Proof-of-Work.
 
+- `mediantime` - (numeric) The median block time of the last 11 blocks, expressed in UNIX epoch time.
+
+- `bits` - (string) nBits: compact representation of the block difficulty target, in hexadecimal.
+
+- `target` - (string) The difficulty target, in hexadecimal.
+
+- `pruned` - (boolean) Whether the blocks are subject to pruning. Always `true` for Floresta since it does not store full blocks.
+
+- `pruneheight` - (numeric) Height of the last pruned block plus one. In Floresta, always equals `blocks + 1` since every validated block is immediately pruned.
+
+- `automatic_pruning` - (boolean) Whether automatic pruning is enabled. Always `true` for Floresta.
+
+- `prune_target_size` - (numeric) Target on-disk size used for pruning, in bytes. Always `0` in Floresta since blocks are not retained on disk.
+
+- `signet_challenge` - (string or null) The block challenge used on signet networks. Always `null` in Floresta; not yet exposed on signet.
+
+- `warnings` - (array of strings) Any network and blockchain warnings.
+
+- `size_on_disk` - (numeric) The total size, in bytes, of the chain-store files persisted by Floresta. See the note below on what this value represents.
+
+
 ### Error Enum `CommandError`
 
-* `JsonRpcError::ChainWorkOverflow` - Overflow occurred while calculating accumulated chain work 
-* `JsonRpcError::BlockNotFound` - The requested block hash was not found in the blockchain
-* `JsonRpcError::Chain` - If there's an error accessing blockchain data.
+- `JsonRpcError::ChainWorkOverflow` - Overflow occurred while calculating accumulated chain work
+- `JsonRpcError::BlockNotFound` - The requested block hash was not found in the blockchain
+- `JsonRpcError::Chain` - If there's an error accessing blockchain data.
 
 ## Notes
 
 - During IBD, some features may be limited.
+- `pruned`, `automatic_pruning`, and `prune_target_size` are hardcoded (`true`, `true`, `0`) because Floresta does not store raw blocks or undo files locally.
+- `pruneheight` always equals `blocks + 1` since pruning is immediate. Detect pruning via `pruned`; do not use `pruneheight` to decide which blocks to fetch.
+- `warnings` is hardcoded to `[]`. Floresta does not currently pipe network or node warnings here.
+- `signet_challenge` is hardcoded to `null`. Floresta does not currently expose the signet challenge script.
+- `blocks`, `headers`, `difficulty`, `mediantime`, `bits`, `target`, and `chainwork` are dynamically calculated and behave identically to Bitcoin Core.
+- `size_on_disk` reports the **total allocated capacity** of Floresta's memory-mapped files, not the amount actually written. A fresh node may report gigabytes even with only the genesis block. On filesystems that support sparse files, physical usage (reported by `du`) will be much smaller. This will always differ from Bitcoin Core, it's inherent to the implementation.

--- a/tests/example/functional.py
+++ b/tests/example/functional.py
@@ -17,8 +17,7 @@ import pytest
 from test_framework.constants import (
     GENESIS_BLOCK_HEIGHT,
     GENESIS_BLOCK_HASH,
-    GENESIS_BLOCK_DIFFICULTY_INT,
-    GENESIS_BLOCK_LEAF_COUNT,
+    GENESIS_BLOCK_DIFFICULTY_FLOAT,
 )
 
 
@@ -31,7 +30,6 @@ def test_functional(florestad_node):
     """
     response = florestad_node.rpc.get_blockchain_info()
 
-    assert response["height"] == GENESIS_BLOCK_HEIGHT
-    assert response["best_block"] == GENESIS_BLOCK_HASH
-    assert response["difficulty"] == GENESIS_BLOCK_DIFFICULTY_INT
-    assert response["leaf_count"] == GENESIS_BLOCK_LEAF_COUNT
+    assert response["blocks"] == GENESIS_BLOCK_HEIGHT
+    assert response["bestblockhash"] == GENESIS_BLOCK_HASH
+    assert response["difficulty"] == pytest.approx(GENESIS_BLOCK_DIFFICULTY_FLOAT)

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -1,37 +1,80 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 """
-floresta_cli_getblockchainfo.py
+floresta_cli_getblockchaininfo.py
 
-This functional test cli utility to interact with a Floresta node with `getblockchaininfo`
+Functional test for `getblockchaininfo`. Mines blocks via utreexod, then
+compares florestad's response against bitcoind's field-by-field. Bitcoind is
+treated as the source of truth, so future Core API changes surface as test
+failures rather than silent drift.
 """
 
+import time
 import pytest
-from test_framework.constants import (
-    GENESIS_BLOCK_HASH,
-    GENESIS_BLOCK_DIFFICULTY_INT,
-    GENESIS_BLOCK_HEIGHT,
-)
+
+TIMEOUT_SECONDS = 30
+MINE_BLOCKS = 10
+EXTRA_BLOCKS = 5
+# Fields where florestad diverges from bitcoind:
+#   - `pruned` is always True (Utreexo discards full blocks)
+#   - `size_on_disk` reports mmap capacity, not blk*.dat size; checked below.
+FLORESTA_SPECIFIC_FIELDS = ("pruned", "size_on_disk")
+
+
+def _wait_for_size_growth(node, baseline):
+    end = time.time() + TIMEOUT_SECONDS
+    current = baseline
+    while time.time() < end:
+        current = node.rpc.get_blockchain_info()["size_on_disk"]
+        if current > baseline:
+            return current
+        time.sleep(0.5)
+    return current
 
 
 @pytest.mark.rpc
-def test_get_blockchain_info(florestad_node):
+def test_get_blockchain_info(florestad_bitcoind_utreexod_with_chain):
     """
-    Test `getblockchaininfo` with a fresh node and its first block
+    Compare florestad's getblockchaininfo response against bitcoind's after a
+    small chain extension. Iterates bitcoind's keys so any new field added in
+    a future Core release fails the test until florestad implements it.
     """
+    florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
 
-    response = florestad_node.rpc.get_blockchain_info()
-    assert response["best_block"] == GENESIS_BLOCK_HASH
-    assert response["difficulty"] == GENESIS_BLOCK_DIFFICULTY_INT
-    assert response["height"] == GENESIS_BLOCK_HEIGHT
-    assert response["ibd"] is True
-    assert response["latest_block_time"] == 1296688602
-    assert (
-        response["latest_work"]
-        == "0000000000000000000000000000000000000000000000000000000000000002"
+    end = time.time() + TIMEOUT_SECONDS
+    while time.time() < end:
+        if (
+            florestad.rpc.get_block_count()
+            == bitcoind.rpc.get_block_count()
+            == utreexod.rpc.get_block_count()
+            == MINE_BLOCKS
+        ):
+            break
+        time.sleep(0.5)
+
+    floresta_info = florestad.rpc.get_blockchain_info()
+    bitcoind_info = bitcoind.rpc.get_blockchain_info()
+
+    for key, bval in bitcoind_info.items():
+        if key in FLORESTA_SPECIFIC_FIELDS:
+            continue
+        fval = floresta_info[key]
+        if key == "difficulty":
+            # Allow float rounding noise.
+            assert round(fval, 3) == round(bval, 3)
+        else:
+            assert fval == bval, f"{key}: floresta={fval} bitcoind={bval}"
+
+    # size_on_disk: well-formed, stable without new blocks, grows after mining.
+    size_before = floresta_info["size_on_disk"]
+    assert isinstance(size_before, int)
+    assert florestad.rpc.get_blockchain_info()["size_on_disk"] == size_before
+
+    utreexod.rpc.generate(EXTRA_BLOCKS)
+    # Poll for growth: get_block_count moves on header receipt, but acc roots
+    # are only written post-validation.
+    size_after = _wait_for_size_growth(florestad, size_before)
+    assert size_after > size_before, (
+        f"size_on_disk did not grow after mining {EXTRA_BLOCKS} blocks: "
+        f"before={size_before} after={size_after}"
     )
-    assert response["leaf_count"] == 0
-    assert response["progress"] == 0
-    assert response["root_count"] == 0
-    assert response["root_hashes"] == []
-    assert response["validated"] == 0

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -62,6 +62,11 @@ def test_get_blockchain_info(florestad_bitcoind_utreexod_with_chain):
         if key == "difficulty":
             # Allow float rounding noise.
             assert round(fval, 3) == round(bval, 3)
+        elif key == "verificationprogress":
+            # Floresta computes time-based progress; bitcoind computes
+            # tx-weighted. Both converge at endpoints but drift mid-sync
+            # and at the tip (block timestamps lag `now` by seconds).
+            assert abs(fval - bval) < 1e-3
         else:
             assert fval == bval, f"{key}: floresta={fval} bitcoind={bval}"
 

--- a/tests/floresta-cli/gettxout.py
+++ b/tests/floresta-cli/gettxout.py
@@ -39,11 +39,11 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain):
     while time.time() < timeout:
         floresta_info = florestad.rpc.get_blockchain_info()
         if (
-            floresta_info["height"]
+            floresta_info["headers"]
             == utreexod.rpc.get_block_count()
             == bitcoind.rpc.get_block_count()
             == blocks
-            and not floresta_info["ibd"]
+            and not floresta_info["initialblockdownload"]
         ):
             break
 
@@ -55,7 +55,9 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain):
         except Exception as e:
             log.error(f"Error fetching block from peer: {e}")
 
-    assert floresta_info["height"] == blocks and not floresta_info["ibd"]
+    assert (
+        floresta_info["headers"] == blocks and not floresta_info["initialblockdownload"]
+    )
 
     log.info("Comparing gettxout results between Floresta and Bitcoind...")
     for height in range(2, blocks):

--- a/tests/florestad/reorg_chain.py
+++ b/tests/florestad/reorg_chain.py
@@ -66,8 +66,8 @@ class ChainReorgTest:
 
         florestad_info = self.florestad.rpc.get_blockchain_info()
         utreexod_info = self.utreexod.rpc.get_blockchain_info()
-        assert florestad_info["best_block"] == utreexod_info["bestblockhash"]
-        assert florestad_info["height"] == utreexod_info["blocks"]
+        assert florestad_info["bestblockhash"] == utreexod_info["bestblockhash"]
+        assert florestad_info["headers"] == utreexod_info["blocks"]
 
     def mine_blocks(self, blocks):
         """Request Utreexod to generate blocks and wait for Florestad to sync."""


### PR DESCRIPTION
## Summary

Replaces `validated / height` (which sticks at 1.0 when the chain store stalls) with a time-based formula using wall clock and block timestamps as external references the daemon cannot fudge.

When validated freezes for any reason, `now` keeps advancing, the denominator grows, and progress visibly falls instead of falsely reporting fully synced.

## Why time-based instead of tx-weighted

Bitcoin Core's formula uses per-block cumulative tx counts and a baked-in `ChainTxData` checkpoint. Both require a chainstore schema migration, which is out of scope for an RPC bugfix. Time-based progress uses two external references Floresta already has (wall clock + block timestamps) and resolves the bug as filed.

## Trade-off

Numerically diverges from Bitcoin Core's value mid-sync (Floresta reads slightly higher because it weights early empty blocks the same as full modern blocks). Both converge at endpoints (0 at genesis, 1 at tip).


## Test plan
- [x] `cargo test -p floresta-node --lib` (11/11 pass)
- [x] CI functional tests

## Dependency

Stacked on #948 (v30 compliance). Diff will reduce to the two formula commits once #948 merges. While #948 is still open, please review only:

- `fix(rpc): make verificationprogress tip-aware`
- `test(rpc): allow drift on verificationprogress parity check`

## Out of scope

#1015 raises three issues. This PR addresses only the `verificationprogress = 1.0` half. The other two (`ibd` flipping false on a stalled chain store, surfacing `FullIndex` / `BlockNotPresent` as more than ERROR logs) need separate, narrower changes and are not bundled here.

Partial fix for #1015.