### PR TITLE
fix(rpc): make verificationprogress tip-aware

### DIFF
--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::BTreeMap;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bitcoin::Address;
 use bitcoin::Block;
@@ -270,11 +272,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .calculate_chain_work(&self.chain)?
             .to_string_hex();
 
-        let verification_progress = if height != 0 {
-            f64::from(validated) / f64::from(height)
-        } else {
-            0.0
-        };
+        let verification_progress = self.verification_progress()?;
 
         let blocks = i64::from(validated);
         let headers = i64::from(height);
@@ -730,5 +728,46 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .get_descriptors()
             .map_err(|e| JsonRpcError::Wallet(e.to_string()))?;
         Ok(descriptors)
+    }
+
+    /// Time-based estimate of validated-tip progress in `[0.0, 1.0]`.
+    ///
+    /// Ratio of chain-time elapsed between genesis and the validated block,
+    /// over chain-time between genesis and the later of `now` or
+    /// `header_tip_time`. Returns `0.0` for cold start, clamps to `1.0` at tip.
+    fn verification_progress(&self) -> Result<f64, JsonRpcError> {
+        let (_, tip_hash) = self
+            .chain
+            .get_best_block()
+            .map_err(|_| JsonRpcError::Chain)?;
+        let header_tip_time = self
+            .chain
+            .get_block_header(&tip_hash)
+            .map_err(|_| JsonRpcError::Chain)?
+            .time;
+
+        let validated = self
+            .chain
+            .get_validation_index()
+            .map_err(|_| JsonRpcError::Chain)?;
+        let validated_block_time = self
+            .chain
+            .get_block_hash(validated)
+            .and_then(|hash| self.chain.get_block_header(&hash))
+            .map_err(|_| JsonRpcError::Chain)?
+            .time;
+
+        let genesis_time = genesis_block(self.network).header.time;
+        let now: u32 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is before unix epoch")
+            .as_secs()
+            .try_into()
+            .expect("unix timestamp overflows u32 in year 2106");
+
+        let elapsed_validated = validated_block_time - genesis_time;
+        let elapsed_total = now.max(header_tip_time) - genesis_time;
+
+        Ok((f64::from(elapsed_validated) / f64::from(elapsed_total)).clamp(0.0, 1.0))
     }
 }

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::BTreeMap;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bitcoin::Address;
 use bitcoin::Block;
@@ -270,11 +272,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .calculate_chain_work(&self.chain)?
             .to_string_hex();
 
-        let verification_progress = if height != 0 {
-            f64::from(validated) / f64::from(height)
-        } else {
-            0.0
-        };
+        let verification_progress = self.verification_progress(validated, &latest_header)?;
 
         let blocks = i64::from(validated);
         let headers = i64::from(height);
@@ -737,5 +735,44 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .get_descriptors()
             .map_err(|e| JsonRpcError::Wallet(e.to_string()))?;
         Ok(descriptors)
+    }
+
+    /// Time-based estimate of validated-tip progress in `[0.0, 1.0]`.
+    ///
+    /// Ratio of chain-time elapsed between genesis and the validated block,
+    /// over chain-time between genesis and the later of `now` or the tip
+    /// header's time. Returns `0.0` for cold start, clamps to `1.0` at tip.
+    fn verification_progress(
+        &self,
+        validated: u32,
+        latest_header: &Header,
+    ) -> Result<f64, JsonRpcError> {
+        let header_tip_time = latest_header.time;
+
+        let validated_block_time = self
+            .chain
+            .get_block_hash(validated)
+            .and_then(|hash| self.chain.get_block_header(&hash))
+            .map_err(|_| JsonRpcError::Chain)?
+            .time;
+
+        let genesis_time = genesis_block(self.network).header.time;
+        let now: u32 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| JsonRpcError::InvalidSystemTime)?
+            .as_secs()
+            .try_into()
+            .map_err(|_| JsonRpcError::InvalidSystemTime)?;
+
+        let elapsed_validated = validated_block_time.saturating_sub(genesis_time);
+        let elapsed_total = now.max(header_tip_time).saturating_sub(genesis_time);
+
+        // Cold start: the tip is still genesis and the clock has not reached
+        // genesis time, so there is no span to measure against.
+        if elapsed_total == 0 {
+            return Ok(0.0);
+        }
+
+        Ok((f64::from(elapsed_validated) / f64::from(elapsed_total)).clamp(0.0, 1.0))
     }
 }

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -232,6 +232,10 @@ pub mod jsonrpc_interface {
         /// Overflow when calculating cumulative chain work.
         ChainWorkOverflow,
 
+        /// The system clock is unusable: set before the Unix epoch, or past
+        /// the u32 timestamp range that block headers use.
+        InvalidSystemTime,
+
         /// Invalid `addnode` command or parameters.
         InvalidAddnodeCommand,
 
@@ -289,7 +293,7 @@ pub mod jsonrpc_interface {
                 | Self::PeerNotFound => StatusCode::NOT_FOUND,
 
                 // 500 Internal Server Error - server messed up
-                Self::ChainWorkOverflow | Self::ConversionOverflow(_) => {
+                Self::ChainWorkOverflow | Self::ConversionOverflow(_) | Self::InvalidSystemTime => {
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
 
@@ -403,6 +407,11 @@ pub mod jsonrpc_interface {
                 Self::ChainWorkOverflow => RpcError {
                     code: INTERNAL_ERROR,
                     message: "Chain work overflow".into(),
+                    data: None,
+                },
+                Self::InvalidSystemTime => RpcError {
+                    code: INTERNAL_ERROR,
+                    message: "System clock is outside the representable range".into(),
                     data: None,
                 },
                 Self::ConversionOverflow(msg) => RpcError {

--- a/doc/rpc/getblockchaininfo.md
+++ b/doc/rpc/getblockchaininfo.md
@@ -41,7 +41,7 @@ Returns a JSON object with the following fields:
 
 - `chain` - (string) A short string representing the blockchain network (e.g., "bitcoin", "testnet", "signet").
 
-- `verificationprogress` - (numeric) The validation progress as a decimal between 0 and 1. A value of 0 means no blocks have been validated, while 1 means all blocks are validated (headers == blocks).
+- `verificationprogress` - (numeric) An estimate of validation progress as a decimal between 0 and 1, computed from block timestamps rather than heights. It is the time from genesis to the validated block, over the time from genesis to the later of the current clock or the header tip.
 
 - `difficulty` - (numeric) The current network difficulty. On average, miners need to make `difficulty` hashes before finding one that solves a block's Proof-of-Work.
 
@@ -71,6 +71,7 @@ Returns a JSON object with the following fields:
 - `JsonRpcError::ChainWorkOverflow` - Overflow occurred while calculating accumulated chain work
 - `JsonRpcError::BlockNotFound` - The requested block hash was not found in the blockchain
 - `JsonRpcError::Chain` - If there's an error accessing blockchain data.
+- `JsonRpcError::InvalidSystemTime` - The system clock is set before the Unix epoch, or past the u32 range block timestamps use
 
 ## Notes
 
@@ -80,4 +81,5 @@ Returns a JSON object with the following fields:
 - `warnings` is hardcoded to `[]`. Floresta does not currently pipe network or node warnings here.
 - `signet_challenge` is hardcoded to `null`. Floresta does not currently expose the signet challenge script.
 - `blocks`, `headers`, `difficulty`, `mediantime`, `bits`, `target`, and `chainwork` are dynamically calculated and behave identically to Bitcoin Core.
+- `verificationprogress` is time-based, unlike Bitcoin Core's transaction-weighted estimate, so the two will not return identical values for the same chain state. Since the denominator tracks the current clock, a stalled node reports a declining value instead of holding at 1.0.
 - `size_on_disk` is the sum, in bytes, of Floresta's chainstore files: the main-chain header records, the fork-header records, the block index, the metadata file, and the accumulator file.

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -11,7 +11,7 @@ failures rather than silent drift.
 
 import pytest
 
-from test_framework.util import wait_until, compare_fields
+from test_framework.util import wait_until
 
 MINE_BLOCKS = 10
 EXTRA_BLOCKS = 5
@@ -35,11 +35,20 @@ def test_get_blockchain_info(node_manager, florestad_bitcoind_utreexod_with_chai
     floresta_info = florestad.rpc.get_blockchain_info()
     bitcoind_info = bitcoind.rpc.get_blockchain_info()
 
-    compare_fields(
-        floresta_info,
-        bitcoind_info,
-        ignore_fields=FLORESTA_SPECIFIC_FIELDS,
-    )
+    for key, bval in bitcoind_info.items():
+        if key in FLORESTA_SPECIFIC_FIELDS:
+            continue
+        fval = floresta_info[key]
+        if key == "difficulty":
+            # Allow float rounding noise.
+            assert round(fval, 3) == round(bval, 3)
+        elif key == "verificationprogress":
+            # Floresta computes time-based progress; bitcoind computes
+            # tx-weighted. Both converge at endpoints but drift mid-sync
+            # and at the tip (block timestamps lag `now` by seconds).
+            assert abs(fval - bval) < 1e-3
+        else:
+            assert fval == bval, f"{key}: floresta={fval} bitcoind={bval}"
 
     # size_on_disk: well-formed, grows after mining.
     size_before = floresta_info["size_on_disk"]

--- a/tests/floresta-cli/getblockchaininfo.py
+++ b/tests/floresta-cli/getblockchaininfo.py
@@ -35,10 +35,13 @@ def test_get_blockchain_info(node_manager, florestad_bitcoind_utreexod_with_chai
     floresta_info = florestad.rpc.get_blockchain_info()
     bitcoind_info = bitcoind.rpc.get_blockchain_info()
 
+    # `verificationprogress` is time-based here and tx-weighted in bitcoind, so
+    # it drifts past the default 1e-8.
     compare_fields(
         floresta_info,
         bitcoind_info,
         ignore_fields=FLORESTA_SPECIFIC_FIELDS,
+        float_tol=1e-3,
     )
 
     # size_on_disk: well-formed, grows after mining.


### PR DESCRIPTION
## Summary

Replaces `validated / height` (which sticks at 1.0 when the chain store stalls) with a time-based formula using wall clock and block timestamps as external references the daemon cannot fudge.

When validated freezes for any reason, `now` keeps advancing, the denominator grows, and progress visibly falls instead of falsely reporting fully synced.

## Why time-based instead of tx-weighted

Bitcoin Core's formula uses per-block cumulative tx counts and a baked-in `ChainTxData` checkpoint. Both require a chainstore schema migration, which is out of scope for an RPC bugfix. Time-based progress uses two external references Floresta already has (wall clock + block timestamps) and resolves the bug as filed.

## Formula

```
elapsed_validated = validated_block_time - genesis_time
elapsed_total     = max(now, header_tip_time) - genesis_time

verificationprogress = clamp(elapsed_validated / elapsed_total, 0.0, 1.0)
```

Two external references (`now` from the OS clock, `validated_block_time` from the block header) anchor the ratio outside daemon state, so a stalled chain store can't push the value to 1.0.

## Test plan
- [x] `cargo test -p floresta-node --lib`
- [x] CI functional tests