### PR TITLE
fix(flake): remove gcc from devshell.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,6 @@
                 typos
                 python312
                 uv
-                gcc
                 go
                 cargo-hack
                 pkg-config


### PR DESCRIPTION
Gcc was included in the package list, on macos, this puts Nix's GCC wrapper first in `$PATH`, ahead of Apple's system clang.
So when `rustc` links test binaries, it calls `cc` from PATH — which resolves to GCC instead of Apple clang. GCC on macOS doesn't properly link the unwind/exception-handling libraries that Rust needs and that break some tests on floresta.

Source:
- Claudiao da massa

Am i sure about the bug/reason/fix ? No.
Is the bug happening after the change? No, so im happy, and youre happy.

We include llvmPackages.clang anyway so gcc is redundant to offer a c compiler

Fix #1022 

