### PR TITLE
wire: use `PathBuf` and `impl AsRef<Path>`

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1101,7 +1101,7 @@ mod test {
             disable_dns_seeds: true,
             network: Network::Signet,
             pow_fraud_proofs: true,
-            datadir: "/tmp-db".to_string(),
+            datadir: "/tmp-db".into(),
             user_agent: "floresta".to_string(),
             ..Default::default()
         };

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -354,30 +354,31 @@ impl Florestad {
         Ok(sock)
     }
 
+    // TODO(@luisschwab): update `datadir.to_str().expect("infallible")` when modifying `floresta-node`'s methods
     /// Actually runs florestad, spawning all modules and waiting until
     /// someone asks to stop.
     ///
     /// This function will return an error if the configured data directory path is not an
     /// **existing and writable directory**, or cannot be validated as such.
     pub async fn start(&self) -> Result<(), FlorestadError> {
-        let data_dir = &self.config.data_dir;
+        let datadir = PathBuf::from(&self.config.data_dir);
 
         // Check that the directory exists and is writable
-        Florestad::validate_data_dir(data_dir)?;
+        Florestad::validate_data_dir(datadir.to_str().expect("infallible"))?;
 
         info!("Loading watch-only wallet");
         let wallet = self.setup_wallet()?;
 
         info!("Loading blockchain database");
         let blockchain_state = Arc::new(Self::load_chain_state(
-            data_dir.clone(),
+            datadir.to_str().expect("infallible").to_owned(),
             self.config.network,
             self.config.assume_valid,
         )?);
 
         #[cfg(feature = "compact-filters")]
         let cfilters = if self.config.cfilters {
-            let filter_store = FlatFiltersStore::new(data_dir.clone() + "/cfilters");
+            let filter_store = FlatFiltersStore::new(datadir.join("cfilters"));
             let cfilters = Arc::new(NetworkFilters::new(filter_store));
 
             let height = cfilters
@@ -412,7 +413,7 @@ impl Florestad {
             network: self.config.network,
             pow_fraud_proofs: false,
             proxy,
-            datadir: data_dir.clone(),
+            datadir: datadir.clone(),
             fixed_peer: self.config.connect.clone(),
             compact_filters: self.config.cfilters,
             assume_utreexo: self.config.assumeutreexo_value.clone().or(assume_utreexo),
@@ -473,7 +474,11 @@ impl Florestad {
                     .as_ref()
                     .map(|x| Self::resolve_hostname(x, 8332))
                     .transpose()?,
-                format!("{data_dir}/debug.log"),
+                datadir
+                    .join("debug.log")
+                    .to_str()
+                    .expect("infallible")
+                    .to_owned(),
             ));
 
             if self.json_rpc.set(server).is_err() {
@@ -542,7 +547,7 @@ impl Florestad {
             // Generate self-signed TLS certificate, if enabled.
             if self.config.generate_cert {
                 // Create TLS directory, if it does not exist.
-                let tls_dir = format!("{data_dir}/tls");
+                let tls_dir = datadir.join("tls").to_str().expect("infallible").to_owned();
                 if !Path::new(&tls_dir).exists() {
                     fs::create_dir_all(&tls_dir).map_err(|e| {
                         FlorestadError::CouldNotCreateTLSDataDir(tls_dir.clone(), e)
@@ -554,8 +559,16 @@ impl Florestad {
                 let subject_alt_names = vec!["localhost".to_string()];
 
                 // Define file paths
-                let tls_key_path = format!("{data_dir}/tls/key.pem");
-                let tls_cert_path = format!("{data_dir}/tls/cert.pem");
+                let tls_key_path = datadir
+                    .join("tls/key.pem")
+                    .to_str()
+                    .expect("infallible")
+                    .to_owned();
+                let tls_cert_path = datadir
+                    .join("tls/cert.pem")
+                    .to_str()
+                    .expect("infallible")
+                    .to_owned();
 
                 // Create the certificate.
                 Self::generate_self_signed_certificate(
@@ -569,7 +582,7 @@ impl Florestad {
             }
 
             // Assemble TLS configuration from file.
-            let tls_config = self.create_tls_config(data_dir)?;
+            let tls_config = self.create_tls_config(datadir.to_str().expect("infallible"))?;
 
             // Electrum TLS accept loop.
             let tls_listener = TcpListener::bind(electrum_addr_tls)

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -12,6 +12,7 @@ use core::str::FromStr;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs::read_to_string;
+use std::path::Path;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -714,7 +715,9 @@ impl AddressMan {
         None
     }
 
-    pub fn dump_peers(&self, datadir: &str) -> std::io::Result<()> {
+    pub fn dump_peers(&self, datadir: impl AsRef<Path>) -> std::io::Result<()> {
+        let datadir = datadir.as_ref();
+
         let peers: Vec<_> = self
             .addresses
             .values()
@@ -723,21 +726,27 @@ impl AddressMan {
             .collect::<Vec<_>>();
         let peers = serde_json::to_string(&peers);
         if let Ok(peers) = peers {
-            std::fs::write(datadir.to_owned() + "/peers.json", peers)?;
+            std::fs::write(datadir.join("peers.json"), peers)?;
         }
         Ok(())
     }
 
     /// Dumps the connected utreexo peers to a file on dir `datadir/anchors.json` in json format `
     /// inputs are the directory to save the file and the list of ids of the connected utreexo peers
-    pub fn dump_utreexo_peers(&self, datadir: &str, peers_id: &[usize]) -> std::io::Result<()> {
+    pub fn dump_utreexo_peers(
+        &self,
+        datadir: impl AsRef<Path>,
+        peers_id: &[usize],
+    ) -> std::io::Result<()> {
+        let datadir = datadir.as_ref();
+
         let addresses: Vec<DiskLocalAddress> = peers_id
             .iter()
             .filter_map(|id| Some(self.addresses.get(id)?.to_owned().into()))
             .collect();
         let addresses: Result<String, serde_json::Error> = serde_json::to_string(&addresses);
         if let Ok(addresses) = addresses {
-            std::fs::write(datadir.to_owned() + "/anchors.json", addresses)?;
+            std::fs::write(datadir.join("anchors.json"), addresses)?;
         }
         Ok(())
     }
@@ -755,8 +764,10 @@ impl AddressMan {
             .map(|(id, addr)| (*id, addr.to_owned()))
     }
 
-    pub fn start_addr_man(&mut self, datadir: String) -> Vec<LocalAddress> {
-        let persisted_peers = read_to_string(format!("{datadir}/peers.json"))
+    pub fn start_addr_man(&mut self, datadir: impl AsRef<Path>) -> Vec<LocalAddress> {
+        let datadir = datadir.as_ref();
+
+        let persisted_peers = read_to_string(datadir.join("peers.json"))
             .map(|seeds| serde_json::from_str::<Vec<DiskLocalAddress>>(&seeds));
 
         if let Ok(Ok(peers)) = persisted_peers {
@@ -768,7 +779,7 @@ impl AddressMan {
             self.push_addresses(&peers);
         }
 
-        let anchors = read_to_string(format!("{datadir}/anchors.json")).and_then(|anchors| {
+        let anchors = read_to_string(datadir.join("anchors.json")).and_then(|anchors| {
             let anchors = serde_json::from_str::<Vec<DiskLocalAddress>>(&anchors)?;
             Ok(anchors
                 .into_iter()
@@ -1225,12 +1236,13 @@ mod test {
 
     use super::AddressState;
     use super::LocalAddress;
+    use super::*;
     use crate::address_man::AddressMan;
     use crate::address_man::DiskLocalAddress;
     use crate::address_man::ReachableNetworks;
     use crate::address_man::SUPPORTED_NETWORKS;
 
-    fn load_addresses_from_json(file_path: &str) -> io::Result<Vec<LocalAddress>> {
+    fn load_addresses_from_json(file_path: impl AsRef<Path>) -> io::Result<Vec<LocalAddress>> {
         let mut contents = String::new();
         File::open(file_path)?.read_to_string(&mut contents)?;
 

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -4,6 +4,7 @@
 //! backed by p2p Bitcoin's p2p network.
 
 use core::net::SocketAddr;
+use std::path::PathBuf;
 
 use bitcoin::Network;
 use floresta_chain::AssumeUtreexoValue;
@@ -37,7 +38,7 @@ pub struct UtreexoNodeConfig {
     /// we disconnect from the peer.
     pub max_banscore: u32,
     /// Data directory for the node. Defaults to `.floresta-node`.
-    pub datadir: String,
+    pub datadir: PathBuf,
     /// A SOCKS5 proxy to use. Defaults to None.
     pub proxy: Option<SocketAddr>,
     /// If enabled, the node will assume that the provided Utreexo state is valid, and will
@@ -76,7 +77,7 @@ impl Default for UtreexoNodeConfig {
             compact_filters: false,
             fixed_peer: None,
             max_banscore: 100,
-            datadir: ".floresta-node".to_string(),
+            datadir: ".floresta-node".into(),
             proxy: None,
             backfill: false,
             assume_utreexo: None,

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -575,7 +575,7 @@ where
     }
 
     pub(crate) fn init_peers(&mut self) -> Result<(), WireError> {
-        let anchors = self.common.address_man.start_addr_man(self.datadir.clone());
+        let anchors = self.common.address_man.start_addr_man(&self.common.datadir);
         let enough_addresses = self.common.address_man.enough_addresses();
 
         if !self.config.disable_dns_seeds && !enough_addresses {

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -17,6 +17,7 @@ use core::net::IpAddr;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -287,7 +288,7 @@ pub struct NodeCommon<Chain: ChainBackend> {
 
     // 6. Configuration and Metadata
     pub(crate) config: UtreexoNodeConfig,
-    pub(crate) datadir: String,
+    pub(crate) datadir: PathBuf,
     pub(crate) network: Network,
     pub(crate) kill_signal: Arc<tokio::sync::RwLock<bool>>,
 }

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -192,7 +192,7 @@ where
     /// [halt and catch fire]: https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)
     pub fn backfill(&self, done_flag: std::sync::mpsc::Sender<()>) -> Result<bool, WireError> {
         // try finding the last state of the sync node
-        let state = std::fs::read(self.config.datadir.clone() + "/.sync_node_state");
+        let state = std::fs::read(self.config.datadir.join(".sync_node_state"));
         // try to recover from the disk state, if it exists. Otherwise, start from genesis
         let (chain, end) = match state {
             Ok(state) => {
@@ -263,13 +263,13 @@ where
                     acc.serialize(&mut ser_acc).unwrap();
                     ser_acc.extend_from_slice(&tip.to_le_bytes());
                     ser_acc.extend_from_slice(&end.to_le_bytes());
-                    std::fs::write(datadir + "/.sync_node_state", ser_acc)
+                    std::fs::write(datadir.join(".sync_node_state"), ser_acc)
                         .expect("Failed to write sync node state");
                     return;
                 }
 
                 // empty the file if we're done
-                std::fs::write(datadir + "/.sync_node_state", Vec::new())
+                std::fs::write(datadir.join(".sync_node_state"), Vec::new())
                     .expect("Failed to write sync node state");
 
                 for block in chain.list_valid_blocks() {

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -2,6 +2,7 @@
 
 use core::net::IpAddr;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -191,14 +192,14 @@ pub fn create_peer(
 }
 
 pub fn get_node_config(
-    datadir: String,
+    datadir: impl AsRef<Path>,
     network: Network,
     pow_fraud_proofs: bool,
 ) -> UtreexoNodeConfig {
     UtreexoNodeConfig {
         network,
         pow_fraud_proofs,
-        datadir,
+        datadir: datadir.as_ref().into(),
         user_agent: "node_test".to_string(),
         ..Default::default()
     }
@@ -297,10 +298,10 @@ pub async fn setup_node(
     peers: Vec<PeerData>,
     pow_fraud_proofs: bool,
     network: Network,
-    datadir: &str,
+    datadir: impl AsRef<Path>,
     num_blocks: usize,
 ) -> Arc<ChainState<FlatChainStore>> {
-    let config = FlatChainStoreConfig::new(datadir);
+    let config = FlatChainStoreConfig::new(&datadir);
 
     let chainstore = FlatChainStore::new(config).unwrap();
     let mempool = Arc::new(Mutex::new(Mempool::new(1000)));
@@ -314,7 +315,7 @@ pub async fn setup_node(
         chain.accept_header(header).unwrap();
     }
 
-    let config = get_node_config(datadir.into(), network, pow_fraud_proofs);
+    let config = get_node_config(&datadir, network, pow_fraud_proofs);
     let kill_signal = Arc::new(RwLock::new(false));
     let mut node = UtreexoNode::<Arc<ChainState<FlatChainStore>>, SyncNode>::new(
         config,


### PR DESCRIPTION
Towards #939 

## Changelog
```
- `UtreexoNodeConfig.datadir` uses `PathBuf` instead of `String`
- `NodeCommon.datadir` uses `PathBuf` instead of `String`

- `AddressMan::dump_peers` uses `impl AsRef<Path>` instead of `&str`
- `AddressMan::dump_utreexo_peers` uses `impl AsRef<Path>` instead of `&str`
- `AddressMan::start_addr_man` uses `impl AsRef<Path>` instead of `String`
- `load_addresses_from_json` uses `impl AsRef<Path>` instead of `&str`
- `get_node_config` uses `impl AsRef<Path>` instead of `String`
- `setup_node` uses `impl AsRef<Path>` instead of `&str`
- Update call sites
```

Notice to the reviewers: the `.expect()`'s will be removed once I make `floresta-node`'s version of this PR.