### PR TITLE
feat(wire): disconnect slowest peers in `SyncNode`

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -16,6 +16,7 @@ use floresta_common::Ema;
 use floresta_common::service_flags;
 use floresta_common::try_and_log;
 use floresta_mempool::Mempool;
+use rand::Rng;
 use tokio::net::tcp::WriteHalf;
 use tokio::spawn;
 use tokio::sync::Mutex;
@@ -644,6 +645,62 @@ where
         }
 
         Ok(())
+    }
+
+    /// Try disconnecting the slowest non-protected-service peer.
+    ///
+    /// For peers that don't have any of the `protected_services`, we disconnect the
+    /// highest-latency one when any of these hold:
+    /// - Its latency is more than 1.5x the median latency across eligible peers.
+    /// - `always` is true.
+    /// - Or randomly, with 5% probability.
+    pub(crate) fn maybe_disconnect_slowest_peer(
+        &self,
+        protected_services: &[ServiceFlags],
+        always: bool,
+    ) -> Result<(), WireError> {
+        /// Require at least 5 samples to compute the median latency. Fewer samples won't
+        /// output a meaningful median value.
+        const MIN_SAMPLES: usize = 5;
+        /// If the slowest peer has higher latency than 1.5x the median latency, disconnect it.
+        /// This is the same value as the `libbitcoin` default `allowed_deviation`.
+        const ALLOWED_DEVIATION: f64 = 1.5;
+
+        // Use latency samples only from regular, non-protected-service peers.
+        let is_eligible_peer = |peer: &LocalPeerView| {
+            peer.is_regular_peer() && !peer.has_any_service(protected_services)
+        };
+
+        let mut samples: Vec<_> = self
+            .peers
+            .iter()
+            .filter_map(|(&peer_id, peer)| {
+                let latency = peer.message_times.value()?;
+
+                is_eligible_peer(peer).then_some((peer_id, latency))
+            })
+            .collect();
+
+        if samples.len() < MIN_SAMPLES {
+            return Ok(());
+        }
+
+        // Sort by latency, then get the median time and the slowest peer
+        samples.sort_by(|a, b| a.1.total_cmp(&b.1));
+
+        let (_, median_latency) = samples[samples.len() / 2];
+        let (slowest_peer_id, slowest_latency) = samples[samples.len() - 1];
+
+        let should_disconnect = always
+            || slowest_latency > ALLOWED_DEVIATION * median_latency
+            || rand::rng().random_ratio(1, 20);
+
+        if !should_disconnect {
+            return Ok(());
+        }
+
+        info!("Disconnecting slowest non-protected peer: {slowest_peer_id}");
+        self.send_to_peer(slowest_peer_id, NodeRequest::Shutdown)
     }
 
     pub(crate) fn maybe_open_connection_with_added_peers(&mut self) -> Result<(), WireError> {

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -232,6 +232,11 @@ pub struct LocalPeerView {
 }
 
 impl LocalPeerView {
+    /// Whether this peer advertises any service in `services`.
+    pub(crate) fn has_any_service(&self, services: &[ServiceFlags]) -> bool {
+        services.iter().any(|service| self.services.has(*service))
+    }
+
     /// Whether this is a manually added peer
     pub(crate) const fn is_manual_peer(&self) -> bool {
         matches!(self.kind, ConnectionKind::Manual)

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -16,6 +16,7 @@ use floresta_common::service_flags;
 use floresta_common::try_and_log;
 use rand::distr::Distribution;
 use rand::distr::weighted::WeightedIndex;
+use rand::prelude::IteratorRandom;
 use rand::seq::IndexedRandom;
 use tracing::debug;
 use tracing::error;
@@ -554,6 +555,21 @@ where
 
         self.send_to_peer(peer, NodeRequest::Shutdown)?;
         Ok(())
+    }
+
+    /// Tries to randomly disconnect up to `n` non-protected-feature peers.
+    pub(crate) fn disconnect_random_peers(&self, n: usize, protected_services: &[ServiceFlags]) {
+        let mut rng = rand::rng();
+
+        let peers = self
+            .peers
+            .values()
+            .filter(|peer| peer.is_regular_peer() && !peer.has_any_service(protected_services))
+            .choose_multiple(&mut rng, n);
+
+        for peer in peers {
+            let _ = peer.channel.send(NodeRequest::Shutdown);
+        }
     }
 
     /// Checks whether some of our inflight requests have timed out.

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -129,6 +129,15 @@ where
 
         let sync = sync.run(|_| {}).await;
 
+        // Once we are synced, peer diversity is the priority, as we must be able to discover
+        // newly mined blocks. However, the peer list that we have built during `SyncNode` is
+        // biased towards low-latency peers (often geographically close to our node).
+        //
+        // Here we try disconnecting half of our connected peers to open space for new peers.
+        let peers_to_disconnect = sync.connected_peers() / 2;
+        let protected_services = &[service_flags::UTREEXO.into()];
+        sync.disconnect_random_peers(peers_to_disconnect, protected_services);
+
         Ok(UtreexoNode {
             common: sync.common,
             context: self.context,

--- a/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
@@ -10,8 +10,6 @@ use floresta_chain::ThreadSafeChain;
 use floresta_chain::proof_util;
 use floresta_common::service_flags;
 use floresta_common::try_and_log;
-use rand::rng;
-use rand::seq::IteratorRandom;
 use tokio::time;
 use tokio::time::MissedTickBehavior;
 use tracing::debug;
@@ -20,7 +18,6 @@ use tracing::info;
 use crate::node::ConnectionKind;
 use crate::node::InflightRequests;
 use crate::node::NodeNotification;
-use crate::node::NodeRequest;
 use crate::node::UtreexoNode;
 use crate::node::periodic_job;
 use crate::node_context::LoopControl;
@@ -139,7 +136,7 @@ where
     /// This function will periodically check our connections, to ensure that:
     ///   - we have enough utreexo peers to download proofs from (at least 2)
     ///   - we have enough peers to download blocks from (at most `MAX_OUTGOING_PEERS`)
-    ///   - if some of peers are too slow, and potentially stalling our block download (TODO)
+    ///   - we disconnect from peers that are too slow, which could otherwise slow down our IBD
     fn check_connections(&mut self) -> Result<(), WireError> {
         // With `--connect`, the user pins us to a specific peer set; don't search
         // for extra utreexo or network peers. `maybe_open_connection` still
@@ -148,28 +145,24 @@ where
             return self.maybe_open_connection(service_flags::UTREEXO.into());
         }
 
-        let total_peers = self.connected_peers();
         let utreexo_peers = self
             .peer_by_service
             .get(&service_flags::UTREEXO.into())
             .map_or(0, |peers| peers.len());
 
-        if utreexo_peers < 2 && total_peers >= SyncNode::MAX_OUTGOING_PEERS {
-            // if we have more than the maximum number of outgoing peers, disconnect
-            // some non-utreexo peers.
-            //
-            // FIXME: We should actually disconnect the slowest non-utreexo peer, to
-            // make sure we can download blocks faster.
-            self.peers
-                .values()
-                .filter(|peer| {
-                    peer.is_regular_peer() && !peer.services.has(service_flags::UTREEXO.into())
-                })
-                .choose(&mut rng())
-                .and_then(|p| p.channel.send(NodeRequest::Shutdown).ok());
+        // We are looking for at least two utreexo peers to diversify our requests
+        let needs_utreexo = utreexo_peers < 2;
+
+        if self.connected_peers() >= SyncNode::MAX_OUTGOING_PEERS {
+            // If we need more utreexo peers, always disconnect the slowest peer
+            let always_disconnect = needs_utreexo;
+            // Don't disconnect from utreexo peers in any case
+            let protected_services = &[service_flags::UTREEXO.into()];
+
+            self.maybe_disconnect_slowest_peer(protected_services, always_disconnect)?;
         }
 
-        if utreexo_peers < 2 {
+        if needs_utreexo {
             info!("Not enough utreexo peers (we have {utreexo_peers}), opening a new connection");
             self.maybe_open_connection(service_flags::UTREEXO.into())?;
         }


### PR DESCRIPTION
Fairly small change, creating the `maybe_disconnect_slowest_peer` function and using it in `SyncNode` where it was leaved as TODO.

### Description and Notes

Closes #889

We now can disconnect from the slowest peer during `SyncNode` if `self.connected_peers() >= SyncNode::MAX_OUTGOING_PEERS`. We do it in three cases:
- We need to open space for `UTREEXO` peers.
- The slowest peer is more than 1.5x slower than the median peer times.
- Randomly disconnect the slowest peer with 5% probability.

This last case ensures we can get out of a situation where many of our peers have similar latency but are slow. We disconnect the slowest peer roughly once each 200s, as we check connections each 10s (so it takes us 20 tries on average to disconnect).

We choose the slow threshold to be 1.5x the median peer latency, after which we always disconnect the slow peer. This is the same value as the `libbitcoin` default `allowed_deviation` (see https://github.com/libbitcoin/libbitcoin-node/blob/476eb304779c31840f233845322dc4ad448421fd/src/settings.cpp#L40), except we use median latency and they use mean throughput. Our EMA latencies are an approximation of throughput.

### How to verify the changes you have done?

If you run this you will see each ~200s during `SyncNode` a message like:

```
INFO wire: Disconnecting slowest non-utreexo peer: 20
INFO wire: Peer disconnected: 20
```

I don't think this will make the node faster (at least notably) right now as the bottleneck is bridges, but this may help when bridges become more available and can also be used in SwiftSync to prioritize faster connections.