### PR TITLE
[RPCSAGA]: `getaddrmaninfo`rpc command

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -137,6 +137,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::GetDeploymentInfo { blockhash } => {
             serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
         }
+        Methods::GetAddrManInfo => serde_json::to_string_pretty(&client.get_addrman_info()?)?,
     })
 }
 
@@ -447,4 +448,12 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetNetworkInfo,
+    #[doc = include_str!("../../../doc/rpc/getaddrmaninfo.md")]
+    #[command(
+        name = "getaddrmaninfo",
+        about = "Returns address manager statistics broken down by network type",
+        long_about = Some(include_str!("../../../doc/rpc/getaddrmaninfo.md")),
+        disable_help_subcommand = true
+    )]
+    GetAddrManInfo,
 }

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -4,13 +4,17 @@
 
 use core::net::IpAddr;
 use core::net::SocketAddr;
+use std::collections::BTreeMap;
 
 use bitcoin::Network;
+use corepc_types::v26::AddrManInfoNetwork;
+use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
 use corepc_types::v30::GetNetworkInfoNetwork;
 use floresta_common::PROTOCOL_VERSION;
 use floresta_common::advertised_services;
 use floresta_common::service_flags_strings;
+use floresta_wire::address_man::NetworkStats;
 use floresta_wire::address_man::ReachableNetworks;
 use floresta_wire::node_interface::PeerInfo;
 use serde_json::Value;
@@ -150,6 +154,40 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .get_connection_count()
             .await
             .map_err(|_| JsonRpcError::Node("Failed to get connection count".to_string()))
+    }
+
+    pub(crate) async fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
+        let stats = self
+            .node
+            .get_addrman_info()
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        let to_info = |ns: NetworkStats| AddrManInfoNetwork {
+            new: ns.new,
+            tried: ns.tried,
+            total: ns.total(),
+        };
+
+        let mut map = BTreeMap::new();
+        map.insert("ipv4".to_string(), to_info(stats.ipv4));
+        map.insert("ipv6".to_string(), to_info(stats.ipv6));
+        map.insert("onion".to_string(), to_info(stats.onion));
+        map.insert("i2p".to_string(), to_info(stats.i2p));
+        map.insert("cjdns".to_string(), to_info(stats.cjdns));
+
+        let all_new: u64 = map.values().map(|n| n.new).sum();
+        let all_tried: u64 = map.values().map(|n| n.tried).sum();
+        map.insert(
+            "all_networks".to_string(),
+            AddrManInfoNetwork {
+                new: all_new,
+                tried: all_tried,
+                total: all_new + all_tried,
+            },
+        );
+
+        Ok(GetAddrManInfo(map))
     }
 
     pub(crate) async fn get_network_info(&self) -> Result<GetNetworkInfo> {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -365,6 +365,11 @@ async fn handle_json_rpc_request(
             .await
             .map(|v| serde_json::to_value(v).unwrap()),
 
+        "getaddrmaninfo" => state
+            .get_addrman_info()
+            .await
+            .map(|v| serde_json::to_value(v).unwrap()),
+
         "addnode" => {
             let node = get_string(&params, 0, "node")?;
             let command = get_string(&params, 1, "command")?;

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use std::vec;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetDeploymentInfo;
 use serde_json::Number;
 use serde_json::Value;
@@ -152,6 +153,8 @@ pub trait FlorestaRPC {
     fn list_descriptors(&self) -> Result<Vec<String>>;
     #[doc = include_str!("../../../doc/rpc/ping.md")]
     fn ping(&self) -> Result<()>;
+    /// Returns address manager statistics broken down by network.
+    fn get_addrman_info(&self) -> Result<GetAddrManInfo>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -371,5 +374,9 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn ping(&self) -> Result<()> {
         self.call("ping", &[])
+    }
+
+    fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
+        self.call("getaddrmaninfo", &[])
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -107,6 +107,34 @@ impl Display for ReachableNetworks {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+/// Per-network address manager statistics.
+pub struct NetworkStats {
+    /// Number of new (untried) addresses.
+    pub new: u64,
+
+    /// Number of tried addresses.
+    pub tried: u64,
+}
+
+impl NetworkStats {
+    pub const fn total(&self) -> u64 {
+        self.new + self.tried
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+/// Address manager statistics broken down by network.
+///
+/// Differently from
+pub struct ConnectionStats {
+    pub ipv4: NetworkStats,
+    pub ipv6: NetworkStats,
+    pub onion: NetworkStats,
+    pub i2p: NetworkStats,
+    pub cjdns: NetworkStats,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 /// How do we store peers locally
 pub struct LocalAddress {
@@ -503,6 +531,30 @@ impl AddressMan {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    /// Returns address manager statistics broken down by network type.
+    pub(crate) fn get_connection_stats(&self) -> ConnectionStats {
+        let mut stats = ConnectionStats::default();
+
+        for addr in self.addresses.values() {
+            let bucket = match &addr.address {
+                AddrV2::Ipv4(_) => &mut stats.ipv4,
+                AddrV2::Ipv6(_) => &mut stats.ipv6,
+                AddrV2::TorV3(_) => &mut stats.onion,
+                AddrV2::I2p(_) => &mut stats.i2p,
+                AddrV2::Cjdns(_) => &mut stats.cjdns,
+                _ => continue,
+            };
+
+            match addr.state {
+                AddressState::Banned(_) => continue,
+                AddressState::Tried(_) | AddressState::Connected => bucket.tried += 1,
+                AddressState::NeverTried | AddressState::Failed(_) => bucket.new += 1,
+            }
+        }
+
+        stats
     }
 
     /// Check if we have enough addresses on the address manager.

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -160,6 +160,12 @@ where
                 return;
             }
 
+            UserRequest::GetAddrManInfo => {
+                let info = self.address_man.get_connection_stats();
+                try_and_log!(responder.send(NodeResponse::GetAddrManInfo(info)));
+                return;
+            }
+
             UserRequest::SendTransaction(transaction) => {
                 let txid = transaction.compute_txid();
                 let mut mempool = self.mempool.lock().await;

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -17,12 +17,14 @@ use rustreexo::proof::Proof;
 use serde::Serialize;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::RecvError;
 
 use super::UtreexoNodeConfig;
 use super::node::ConnectionKind;
 use super::node::NodeNotification;
 use super::node::PeerStatus;
 use super::transport::TransportProtocol;
+use crate::address_man::ConnectionStats;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// A request to addnode that can be made to the node.
@@ -96,6 +98,9 @@ pub enum UserRequest {
 
     /// Adds a transaction to mempool and advertises it
     SendTransaction(Transaction),
+
+    /// Return address manager statistics.
+    GetAddrManInfo,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -157,6 +162,9 @@ pub enum NodeResponse {
 
     /// Transaction broadcast
     TransactionBroadcastResult(Result<Txid, MempoolError>),
+
+    /// Address manager statistics.
+    GetAddrManInfo(ConnectionStats),
 }
 
 #[derive(Debug, Clone)]
@@ -326,6 +334,13 @@ impl NodeInterface {
         let val = self.send_request(UserRequest::Ping).await?;
 
         extract_variant!(Ping, val)
+    }
+
+    /// Returns address manager statistics broken down by network.
+    pub async fn get_addrman_info(&self) -> Result<ConnectionStats, RecvError> {
+        let val = self.send_request(UserRequest::GetAddrManInfo).await?;
+
+        extract_variant!(GetAddrManInfo, val)
     }
 }
 

--- a/doc/rpc/getaddrmaninfo.md
+++ b/doc/rpc/getaddrmaninfo.md
@@ -1,0 +1,49 @@
+# `getaddrmaninfo`
+
+Return address statistics from the node's address manager, broken down by network type.
+
+## Usage
+
+### Synopsis
+
+```
+floresta-cli getaddrmaninfo
+```
+
+### Examples
+
+```bash
+floresta-cli getaddrmaninfo
+```
+
+## Arguments
+
+None.
+
+## Returns
+
+### Ok Response
+
+A JSON object with one key per network plus an `all_networks` summary. Each value is an object with:
+
+- `total` - (numeric) Total number of addresses known for this network
+- `new` - (numeric) Number of addresses that have never been tried
+- `tried` - (numeric) Number of addresses that have been successfully connected to
+
+Top-level keys:
+
+- `all_networks` - Aggregate counts across all networks
+- `ipv4` - IPv4 addresses
+- `ipv6` - IPv6 addresses
+- `onion` - Tor v3 addresses
+- `i2p` - I2P addresses
+- `cjdns` - CJDNS addresses
+
+### Error Response
+
+- `Node` - Failed to retrieve statistics from the address manager
+
+## Notes
+
+- An address is counted as `tried` if its state is `Tried` or `Connected`; all other states count as `new`.
+- `total` equals `new + tried` for each network.

--- a/tests/floresta-cli/getaddrmaninfo.py
+++ b/tests/floresta-cli/getaddrmaninfo.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getaddrmaninfo.py
+
+This functional test verifies the `getaddrmaninfo` RPC method.
+
+Note on test coverage: the address manager only tracks publicly routable
+addresses (see ``AddressMan::push_addresses`` and ``LocalAddress::is_routable``
+in ``address_man.rs``).  In regtest every peer runs on 127.0.0.1, which is
+rejected by the routability filter, so connecting peers in this environment
+does **not** change the addrman statistics.
+"""
+
+import pytest
+
+
+@pytest.mark.rpc
+def test_get_addrman_info(florestad_node):
+    """
+    Test `getaddrmaninfo` returns address manager statistics by network,
+    including schema validation matching Bitcoin Core's response format.
+    """
+    info = florestad_node.rpc.get_addrman_info()
+    assert info is not None
+
+    # Verify structure has all expected network keys
+    for key in ["all_networks", "ipv4", "ipv6", "onion", "i2p", "cjdns"]:
+        assert key in info
+        assert "total" in info[key]
+        assert "new" in info[key]
+        assert "tried" in info[key]
+        assert isinstance(info[key]["total"], int)
+        assert isinstance(info[key]["new"], int)
+        assert isinstance(info[key]["tried"], int)
+        # Invariant: total == new + tried
+        assert info[key]["total"] == info[key]["new"] + info[key]["tried"]

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -8,18 +8,18 @@ Define a base class for making RPC calls to a
 """
 
 import json
+import re
 import socket
 import time
-import re
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
-from abc import ABC, abstractmethod
 
 from requests import post
 from requests.exceptions import HTTPError
 from requests.models import HTTPBasicAuth
-from test_framework.rpc.exceptions import JSONRPCError
 from test_framework.rpc import ConfigRPC
+from test_framework.rpc.exceptions import JSONRPCError
 
 
 # pylint: disable=too-many-public-methods
@@ -365,3 +365,9 @@ class BaseRPC(ABC):
         List all loaded descriptors
         """
         return self.perform_request("listdescriptors")
+
+    def get_addrman_info(self) -> dict:
+        """
+        Get address manager statistics broken down by network
+        """
+        return self.perform_request("getaddrmaninfo")


### PR DESCRIPTION
### Description and Notes

Split of #916 

This pr is solely implementing `getaddrmaninfo` rpc command

The rpc is a read-only getter for connection statistics from the address manager, it needed some plumbing on floresta-wire but is most about data transport.

This pr adds the rpc-server internal handler, the docs and entry for the cli and integration tests.

### How to verify the changes you have done?

Run the tests and the command locally, you should see something similar as:
```Bash
/Floresta (rpcsaga/getaddrmaninfo) $ fcli getaddrmaninfo
   Compiling floresta-rpc v0.5.0 (/Users/jaoleal/Floresta/crates/floresta-rpc)
   Compiling floresta-cli v0.5.0 (/Users/jaoleal/Floresta/bin/floresta-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.72s
     Running `target/debug/floresta-cli getaddrmaninfo`
{
  "all_networks": {
    "total": 44190,
    "new": 43450,
    "tried": 740
  },
  "ipv4": {
    "total": 35255,
    "new": 34573,
    "tried": 682
  },
  "ipv6": {
    "total": 8935,
    "new": 8877,
    "tried": 58
  },
  "onion": {
    "total": 0,
    "new": 0,
    "tried": 0
  },
  "i2p": {
    "total": 0,
    "new": 0,
    "tried": 0
  },
  "cjdns": {
    "total": 0,
    "new": 0,
    "tried": 0
  }
}
```
