### PR TITLE
ci: don't fail on SSH signatures

### DIFF
--- a/contrib/clean_data.sh
+++ b/contrib/clean_data.sh
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-
 #!/bin/bash
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Find all 'tmp-db' directories in subdirectories
 dirs=$(find . -type d -name 'tmp-db')

--- a/contrib/commit-signatures.sh
+++ b/contrib/commit-signatures.sh
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-
 #!/usr/bin/env bash
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Check if all commits in this branch contain PGP or SSH signatures.
 # This is a presence check, not a trust/validity check.

--- a/contrib/commit-signatures.sh
+++ b/contrib/commit-signatures.sh
@@ -2,7 +2,8 @@
 
 #!/usr/bin/env bash
 
-# This script will check if all commits in this branch are PGP-signed.
+# Check if all commits in this branch contain PGP or SSH signatures.
+# This is a presence check, not a trust/validity check.
 
 set -euo pipefail
 
@@ -10,11 +11,40 @@ BASE=${1:-origin/master}
 RANGE="$BASE..HEAD"
 
 TOTAL=$(git log --pretty='tformat:%H' "$RANGE" | wc -l | tr -d ' ')
-UNSIGNED=$(git log --pretty='tformat:%H %G?' "$RANGE" | awk '$2 == "N" {count++} END {print count+0}')
+
+UNSIGNED=$(
+    for COMMIT in $(git log --pretty='tformat:%H' "$RANGE"); do
+        # Avoid %G? on SSH signatures; it requires gpg.ssh.allowedSignersFile.
+        # Only inspect commit headers, not the commit message.
+        if git cat-file commit "$COMMIT" | awk '
+            BEGIN { in_headers = 1; in_ssh_sig = 0; found = 0 }
+
+            /^$/ {
+                in_headers = 0
+            }
+
+            in_headers && /^gpgsig(-sha256)? -----BEGIN SSH SIGNATURE-----$/ {
+                in_ssh_sig = 1
+            }
+
+            in_headers && in_ssh_sig && /^ -----END SSH SIGNATURE-----$/ {
+                found = 1
+            }
+
+            END {
+                exit found ? 0 : 1
+            }
+        '; then
+            continue
+        fi
+
+        git log -1 --pretty='tformat:%H %G?' "$COMMIT"
+    done | awk '$2 == "N" {count++} END {print count+0}'
+)
 
 if [ "$UNSIGNED" -gt 0 ]; then
     echo "⚠️  Unsigned commits in this branch [$UNSIGNED/$TOTAL]"
     exit 1
 else
-    echo "🔏 All commits in this branch are signed [$TOTAL/$TOTAL]"
+    echo "🔏 All commits in this branch contain a signature [$TOTAL/$TOTAL]"
 fi

--- a/contrib/dist/gen_manpages.sh
+++ b/contrib/dist/gen_manpages.sh
@@ -1,6 +1,7 @@
+#!/usr/bin/env bash
+
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-#!/usr/bin/env bash
 # Convert all markdown files in /doc/rpc/ to man pages in /doc/rpc_man/
 # Must have pandoc installed
 

--- a/contrib/feature_matrix.sh
+++ b/contrib/feature_matrix.sh
@@ -1,6 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-#!/bin/sh
 # Exit immediately if any command fails
 set -e
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-
 #!/usr/bin/env bash
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 if [ "$EUID" -eq 0 ]; then
     echo "❌ Do not run this script as root or with sudo. It's too dangerous."

--- a/contrib/make_seeds.py
+++ b/contrib/make_seeds.py
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-
 #!/usr/bin/python3
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 """
     A tool that takes DNS seeds dump data and formats it for floresta's json


### PR DESCRIPTION
### Description and Notes

The new version of the `commit-signatures.sh` script accepts SSH-signed commits if they contain a SSH signature block.

I just extended the script to treat SSH as a special case, while keeping PGP behavior the same. In both cases the signature may be bad, we are just checking presence.

### How to verify the changes you have done?

This CI run must pass for my SSH signature, but the hidden merge commit from GitHub is PGP-signed, and it also passes. In the CI logs you can see the two commits contain a signature.