### PR TITLE
feat(rpc): implement `getnetworkinfo`

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -131,6 +131,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::Uptime => serde_json::to_string_pretty(&client.uptime()?)?,
         Methods::ListDescriptors => serde_json::to_string_pretty(&client.list_descriptors()?)?,
         Methods::Ping => serde_json::to_string_pretty(&client.ping()?)?,
+        Methods::GetNetworkInfo => serde_json::to_string_pretty(&client.get_network_info()?)?,
     })
 }
 
@@ -409,4 +410,13 @@ pub enum Methods {
     /// Result: json null
     #[command(name = "ping")]
     Ping,
+
+    #[doc = include_str!("../../../doc/rpc/getnetworkinfo.md")]
+    #[command(
+        name = "getnetworkinfo",
+        about = "Returns information about the network and connected peers",
+        long_about = Some(include_str!("../../../doc/rpc/getnetworkinfo.md")),
+        disable_help_subcommand = true
+    )]
+    GetNetworkInfo,
 }

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -12,10 +12,17 @@
 )]
 #![no_std]
 
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
 use bitcoin::consensus::encode;
 use bitcoin::consensus::Decodable;
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::Hash;
+use bitcoin::p2p::ServiceFlags;
 use bitcoin::ScriptBuf;
 use bitcoin::VarInt;
 use sha2::Digest;
@@ -80,6 +87,39 @@ pub mod service_flags {
     /// `UTREEXO_ARCHIVE`: the node is capable of serving historical
     /// inclusion proofs for all blocks, but not necessarily historical blocks.
     pub const UTREEXO_ARCHIVE: u64 = 1 << 13;
+}
+
+/// The P2P protocol version Floresta speaks.
+pub const PROTOCOL_VERSION: u32 = 70016;
+
+/// The services advertised by this node.
+///
+///   - `WITNESS`: SegWit blocks and transactions (BIP-0144).
+///   - `P2P_V2`: Encrypted transport (BIP-0324).
+///   - `UTREEXO`: Utreexo inclusion proofs (BIP-0183).
+pub fn advertised_services() -> ServiceFlags {
+    ServiceFlags::WITNESS | ServiceFlags::P2P_V2 | ServiceFlags::from(service_flags::UTREEXO)
+}
+
+/// Returns string names for all known service flags that are set in `flags`.
+pub fn service_flags_strings(flags: &ServiceFlags) -> Vec<String> {
+    let known_flags = [
+        (ServiceFlags::NETWORK, "NETWORK"),
+        (ServiceFlags::GETUTXO, "GETUTXO"),
+        (ServiceFlags::BLOOM, "BLOOM"),
+        (ServiceFlags::WITNESS, "WITNESS"),
+        (ServiceFlags::COMPACT_FILTERS, "COMPACT_FILTERS"),
+        (ServiceFlags::NETWORK_LIMITED, "NETWORK_LIMITED"),
+        (ServiceFlags::P2P_V2, "P2P_V2"),
+        (service_flags::UTREEXO.into(), "UTREEXO"),
+        (service_flags::UTREEXO_ARCHIVE.into(), "UTREEXO_ARCHIVE"),
+    ];
+
+    known_flags
+        .iter()
+        .filter(|(flag, _)| flags.has(*flag))
+        .map(|(_, name)| name.to_string())
+        .collect()
 }
 
 #[cfg(not(feature = "std"))]

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -965,7 +965,7 @@ mod test {
     use floresta_watch_only::merkle::MerkleProof;
     use floresta_watch_only::AddressCache;
     use floresta_wire::address_man::AddressMan;
-    use floresta_wire::address_man::SUPPORTED_NETWORKS;
+    use floresta_wire::address_man::ReachableNetworks;
     use floresta_wire::node::running_ctx::RunningNode;
     use floresta_wire::node::UtreexoNode;
     use floresta_wire::UtreexoNodeConfig;
@@ -1113,7 +1113,7 @@ mod test {
                 Arc::new(Mutex::new(Mempool::new(MEMPOOL_SIZE))),
                 None,
                 Arc::new(RwLock::new(false)),
-                AddressMan::new(None, SUPPORTED_NETWORKS),
+                AddressMan::new(None, &ReachableNetworks::SUPPORTED),
             )
             .unwrap();
 

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -479,6 +479,8 @@ impl Florestad {
                     .to_str()
                     .expect("infallible")
                     .to_owned(),
+                self.config.user_agent.clone(),
+                proxy,
             ));
 
             if self.json_rpc.set(server).is_err() {

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -36,7 +36,7 @@ use floresta_watch_only::kv_database::KvDatabase;
 use floresta_watch_only::AddressCache;
 use floresta_watch_only::WatchOnlyError;
 use floresta_wire::address_man::AddressMan;
-use floresta_wire::address_man::SUPPORTED_NETWORKS;
+use floresta_wire::address_man::ReachableNetworks;
 use floresta_wire::node::running_ctx::RunningNode;
 use floresta_wire::node::UtreexoNode;
 use floresta_wire::UtreexoNodeConfig;
@@ -435,7 +435,7 @@ impl Florestad {
             ))),
             cfilters.clone(),
             kill_signal.clone(),
-            AddressMan::new(None, SUPPORTED_NETWORKS),
+            AddressMan::new(None, &ReachableNetworks::SUPPORTED),
         )
         .map_err(|e| FlorestadError::CouldNotCreateChainProvider(format!("{e}")))?;
 

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -6,6 +6,12 @@ use core::net::IpAddr;
 use core::net::SocketAddr;
 
 use bitcoin::Network;
+use corepc_types::v30::GetNetworkInfo;
+use corepc_types::v30::GetNetworkInfoNetwork;
+use floresta_common::advertised_services;
+use floresta_common::service_flags_strings;
+use floresta_common::PROTOCOL_VERSION;
+use floresta_wire::address_man::ReachableNetworks;
 use floresta_wire::node_interface::PeerInfo;
 use serde_json::json;
 use serde_json::Value;
@@ -15,6 +21,26 @@ use super::server::RpcChain;
 use super::server::RpcImpl;
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
+
+/// Encode a `CARGO_PKG_VERSION` string (`"<major>.<minor>.<patch>"`) as Bitcoin Core's
+/// numeric `MMmmpp` version. Returns `0` for malformed input.
+fn parse_mmmmpp(version: &str) -> usize {
+    let mut parts = version.splitn(3, '.');
+
+    let major = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    let patch = parts
+        .next()
+        .map(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+        })
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    major * 10_000 + minor * 100 + patch
+}
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     pub(crate) async fn ping(&self) -> Result<bool> {
@@ -124,5 +150,72 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .get_connection_count()
             .await
             .map_err(|_| JsonRpcError::Node("Failed to get connection count".to_string()))
+    }
+
+    pub(crate) async fn get_network_info(&self) -> Result<GetNetworkInfo> {
+        // Floresta does not listen for inbound connections, so every peer is outbound.
+        let connections_in = 0;
+        let connections_out = self
+            .node
+            .get_connection_count()
+            .await
+            .map_err(|_| JsonRpcError::Node("Failed to get connection count".to_string()))?;
+
+        let advertised_services = advertised_services();
+        let local_services = format!("{:016x}", advertised_services.to_u64());
+        let local_services_names = service_flags_strings(&advertised_services);
+
+        let proxy_str = self.proxy.map(|addr| addr.to_string()).unwrap_or_default();
+        let proxy_set = self.proxy.is_some();
+
+        let networks = ReachableNetworks::ALL
+            .into_iter()
+            .map(|net| {
+                let reachable = ReachableNetworks::SUPPORTED.contains(&net);
+
+                GetNetworkInfoNetwork {
+                    name: net.to_string(),
+                    limited: !reachable,
+                    reachable,
+                    proxy: proxy_str.clone(),
+                    proxy_randomize_credentials: proxy_set,
+                }
+            })
+            .collect();
+
+        let version = parse_mmmmpp(env!("CARGO_PKG_VERSION"));
+
+        Ok(GetNetworkInfo {
+            version,
+            subversion: self.user_agent.clone(),
+            protocol_version: PROTOCOL_VERSION as usize,
+            local_services,
+            local_services_names,
+            local_relay: false,
+            time_offset: 0,
+            connections: connections_in + connections_out,
+            connections_in,
+            connections_out,
+            network_active: true,
+            networks,
+            // Since Floresta has no mempool, relay_fee and incremental_fee are hardcoded to 0.
+            relay_fee: 0.0,
+            incremental_fee: 0.0,
+            local_addresses: Vec::new(), // Floresta doesn't track local addresses since it does not accept inbound connections
+            warnings: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_mmmmpp;
+
+    #[test]
+    fn parse_mmmmpp_encodes_semver_correctly() {
+        assert_eq!(parse_mmmmpp("0.9.0-rc1"), 900);
+        assert_eq!(parse_mmmmpp("23.1.5"), 230_105);
+        assert_eq!(parse_mmmmpp("1.2"), 10_200);
+        assert_eq!(parse_mmmmpp("1"), 10_000);
     }
 }

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -81,6 +81,8 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
     pub(super) log_path: String,
     pub(super) start_time: Instant,
+    pub(super) user_agent: String,
+    pub(super) proxy: Option<SocketAddr>,
 }
 
 type Result<T> = std::result::Result<T, JsonRpcError>;
@@ -342,6 +344,11 @@ async fn handle_json_rpc_request(
 
         "getconnectioncount" => state
             .get_connection_count()
+            .await
+            .map(|v| serde_json::to_value(v).unwrap()),
+
+        "getnetworkinfo" => state
+            .get_network_info()
             .await
             .map(|v| serde_json::to_value(v).unwrap()),
 
@@ -735,6 +742,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         address: Option<SocketAddr>,
         log_path: String,
+        user_agent: String,
+        proxy: Option<SocketAddr>,
     ) {
         let address = address.unwrap_or_else(|| {
             format!("127.0.0.1:{}", Self::get_port(&network))
@@ -775,6 +784,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 inflight: Arc::new(RwLock::new(HashMap::new())),
                 log_path,
                 start_time: Instant::now(),
+                user_agent,
+                proxy,
             }));
 
         axum::serve(listener, router)

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -258,4 +258,43 @@ mod tests {
                 .unwrap()
         );
     }
+
+    #[test]
+    fn test_get_network_info() {
+        let (_proc, client) = start_florestad();
+
+        let info = client.get_network_info().expect("rpc not working");
+
+        // Floresta does not accept inbound connections, so these are always fixed.
+        assert_eq!(info.connections_in, 0);
+        assert!(info.local_addresses.is_empty());
+
+        // The total connection count must equal in + out.
+        assert_eq!(info.connections, info.connections_in + info.connections_out);
+
+        // P2P networking is enabled by default.
+        assert!(info.network_active);
+
+        // Floresta has no mempool, so relay-related fields are hardcoded.
+        assert!(!info.local_relay);
+        assert_eq!(info.relay_fee, 0.0);
+        assert_eq!(info.incremental_fee, 0.0);
+
+        // time_offset is hardcoded to 0.
+        assert_eq!(info.time_offset, 0);
+
+        // Protocol version is the constant from floresta-common.
+        assert_eq!(info.protocol_version, 70016);
+
+        // All five networks Floresta is aware of should be listed, in ALL order.
+        let names: Vec<&str> = info.networks.iter().map(|n| n.name.as_str()).collect();
+        assert_eq!(names, vec!["ipv4", "ipv6", "onion", "i2p", "cjdns"]);
+
+        // Only ipv4 and ipv6 are currently SUPPORTED; the rest are limited.
+        for net in &info.networks {
+            let supported = matches!(net.name.as_str(), "ipv4" | "ipv6");
+            assert_eq!(net.reachable, supported);
+            assert_eq!(net.limited, !supported);
+        }
+    }
 }

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -91,6 +91,9 @@ pub trait FlorestaRPC {
     fn get_peer_info(&self) -> Result<Vec<PeerInfo>>;
     /// Returns the number of peers currently connected to the node.
     fn get_connection_count(&self) -> Result<usize>;
+    /// Returns general state info regarding P2P networking, in a Bitcoin Core v30
+    /// compatible shape.
+    fn get_network_info(&self) -> Result<GetNetworkInfo>;
     /// Returns a block, given a block hash
     ///
     /// This method returns a block, given a block hash. If the verbosity flag is 0, the block
@@ -294,6 +297,10 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_connection_count(&self) -> Result<usize> {
         self.call("getconnectioncount", &[])
+    }
+
+    fn get_network_info(&self) -> Result<GetNetworkInfo> {
+        self.call("getnetworkinfo", &[])
     }
 
     fn get_best_block_hash(&self) -> Result<BlockHash> {

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -7,6 +7,7 @@ use core::fmt::Formatter;
 
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
+pub use corepc_types::v30::GetNetworkInfo;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -4,6 +4,7 @@
 //! metadata. This module is very important in keeping our node protected against targeted
 //! attacks, like eclipse attacks.
 
+use core::fmt::Display;
 use core::net::IpAddr;
 use core::net::Ipv4Addr;
 use core::net::Ipv6Addr;
@@ -49,10 +50,6 @@ const ASSUME_STALE: u64 = 24 * 60 * 60; // 24 hours
 /// How many addresses we keep in our address manager
 const MAX_ADDRESSES: usize = 50_000;
 
-/// The [`ReachableNetworks`] this implementation currently supports.
-pub const SUPPORTED_NETWORKS: &[ReachableNetworks] =
-    &[ReachableNetworks::IPv4, ReachableNetworks::IPv6];
-
 /// A type alias for a list of addresses to send to our peers
 type AddressToSend = Vec<(AddrV2, u64, ServiceFlags, u16)>;
 
@@ -87,6 +84,26 @@ pub enum ReachableNetworks {
     TorV3,
     I2P,
     Cjdns,
+}
+
+impl ReachableNetworks {
+    /// All networks Floresta is aware of.
+    pub const ALL: [Self; 5] = [Self::IPv4, Self::IPv6, Self::TorV3, Self::I2P, Self::Cjdns];
+
+    /// Networks this implementation currently supports.
+    pub const SUPPORTED: [Self; 2] = [Self::IPv4, Self::IPv6];
+}
+
+impl Display for ReachableNetworks {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ReachableNetworks::IPv4 => write!(f, "ipv4"),
+            ReachableNetworks::IPv6 => write!(f, "ipv6"),
+            ReachableNetworks::TorV3 => write!(f, "onion"),
+            ReachableNetworks::I2P => write!(f, "i2p"),
+            ReachableNetworks::Cjdns => write!(f, "cjdns"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1240,7 +1257,7 @@ mod test {
     use crate::address_man::AddressMan;
     use crate::address_man::DiskLocalAddress;
     use crate::address_man::ReachableNetworks;
-    use crate::address_man::SUPPORTED_NETWORKS;
+    use crate::address_man::ReachableNetworks;
 
     fn load_addresses_from_json(file_path: impl AsRef<Path>) -> io::Result<Vec<LocalAddress>> {
         let mut contents = String::new();
@@ -1699,7 +1716,7 @@ mod test {
 
     #[test]
     fn test_add_fixed_addresses() {
-        let mut address_man = AddressMan::new(None, SUPPORTED_NETWORKS);
+        let mut address_man = AddressMan::new(None, &ReachableNetworks::SUPPORTED);
         address_man.add_fixed_addresses(Network::Signet);
         assert!(!address_man.addresses.is_empty());
     }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -1257,7 +1257,6 @@ mod test {
     use crate::address_man::AddressMan;
     use crate::address_man::DiskLocalAddress;
     use crate::address_man::ReachableNetworks;
-    use crate::address_man::ReachableNetworks;
 
     fn load_addresses_from_json(file_path: impl AsRef<Path>) -> io::Result<Vec<LocalAddress>> {
         let mut contents = String::new();

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -20,6 +20,7 @@ use bitcoin::p2p::message::NetworkMessage;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::p2p::message_network::VersionMessage;
 use bitcoin::p2p::ServiceFlags;
+use bitcoin::p2p::PROTOCOL_VERSION;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
@@ -719,7 +720,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         self.blocks_only = !version.relay;
         self.current_best_block = version.start_height;
         self.services = version.services;
-        if version.version >= 70016 {
+        if version.version >= PROTOCOL_VERSION {
             self.write(NetworkMessage::SendAddrV2).await?;
         }
         self.state = State::SentVerack;
@@ -744,15 +745,12 @@ pub(super) mod peer_utils {
     use bitcoin::p2p::message::NetworkMessage;
     use bitcoin::p2p::message_network::VersionMessage;
     use bitcoin::p2p::Address;
-    use bitcoin::p2p::ServiceFlags;
-    use floresta_common::service_flags;
+    use floresta_common::advertised_services;
+    use floresta_common::PROTOCOL_VERSION;
     use rand::thread_rng;
     use rand::Rng;
 
     use crate::address_man::LocalAddress;
-
-    /// The protocol version this implementation speaks.
-    pub const PROTOCOL_VERSION: u32 = 70016;
 
     /// Build the [pong](NetworkMessage::Pong) message, which must be sent whenever a peer sends us a
     /// [ping](NetworkMessage::Ping). Note that the nonce received in the ping must be reused in the pong.
@@ -767,11 +765,8 @@ pub(super) mod peer_utils {
         best_block: u32,
         peer_address: &LocalAddress,
     ) -> NetworkMessage {
-        // Services supported by this node.
-        //   - WITNESS: this implementation supports SegWit blocks and transactions.
-        //   - P2P_V2: this implementation supports P2PV2 (BIP-0324) connections.
-        //   - UTREEXO: this implementation supports Utreexo P2P (BIP-0183) messages.
-        let services = ServiceFlags::WITNESS | ServiceFlags::P2P_V2 | service_flags::UTREEXO.into();
+        // The set of services supported by this node.
+        let services = advertised_services();
 
         // The current UNIX timestamp.
         let timestamp = SystemTime::now()

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -18,7 +18,7 @@ use floresta_chain::FlatChainStore;
 use floresta_chain::FlatChainStoreConfig;
 use floresta_mempool::Mempool;
 use floresta_wire::address_man::AddressMan;
-use floresta_wire::address_man::SUPPORTED_NETWORKS;
+use floresta_wire::address_man::ReachableNetworks;
 use floresta_wire::node::running_ctx::RunningNode;
 use floresta_wire::UtreexoNodeConfig;
 use tokio::sync::Mutex;
@@ -72,7 +72,7 @@ async fn main() {
         Arc::new(Mutex::new(Mempool::new(MEMPOOL_SIZE))),
         None,
         Arc::new(tokio::sync::RwLock::new(false)),
-        AddressMan::new(None, SUPPORTED_NETWORKS),
+        AddressMan::new(None, &ReachableNetworks::SUPPORTED),
     )
     .unwrap();
     // A handle is a simple way to interact with the node. It implements a queue of requests

--- a/doc/rpc/getnetworkinfo.md
+++ b/doc/rpc/getnetworkinfo.md
@@ -1,0 +1,74 @@
+# `getnetworkinfo`
+
+Returns information about the node's P2P networking state, including version, advertised services, connection counts, and per-network reachability.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getnetworkinfo
+```
+
+### Examples
+
+```bash
+# Get networking information for the running node
+floresta-cli getnetworkinfo
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON object with the following fields:
+
+- `version` - (numeric) The server version, encoded as Bitcoin Core's `MMmmpp` numeric scheme (e.g., `1.2.5` is encoded as `10205`).
+
+- `subversion` - (string) The User Agent string the node advertises to peers (e.g., `/Floresta:0.9.0/`).
+
+- `protocolversion` - (numeric) The P2P protocol version the node speaks.
+
+- `localservices` - (string) The services the node advertises to the network, as a hex-encoded 64-bit bitfield.
+
+- `localservicesnames` - (array of strings) Human-readable names of the advertised services (e.g., `NETWORK`, `WITNESS`, `UTREEXO`).
+
+- `localrelay` - (boolean) Whether the node requests transaction relay from peers. Always `false` in Floresta, since Floresta has no mempool.
+
+- `timeoffset` - (numeric) The time offset, in seconds. Always `0` in Floresta, since Floresta does not track peer time offsets.
+
+- `connections` - (numeric) The total number of peer connections (inbound + outbound).
+
+- `connections_in` - (numeric) The number of inbound connections. Always `0` in Floresta, since the node does not accept inbound connections.
+
+- `connections_out` - (numeric) The number of outbound connections.
+
+- `networkactive` - (boolean) Whether P2P networking is enabled. Always `true` in Floresta, since networking cannot be toggled at runtime.
+
+- `networks` - (array of objects) Information about each network the node knows of. Each entry contains:
+    * `name` - (string) The network name (e.g., `ipv4`, `ipv6`, `onion`, `i2p`, `cjdns`).
+    * `limited` - (boolean) Whether the network is unreachable from this node.
+    * `reachable` - (boolean) Whether the network is reachable from this node.
+    * `proxy` - (string) The proxy used for this network in `host:port` form, or empty if none.
+    * `proxy_randomize_credentials` - (boolean) Whether randomized credentials are used for the proxy.
+
+- `relayfee` - (numeric) The minimum relay fee rate, in BTC/kB. Always `0.0` in Floresta, since Floresta has no mempool.
+
+- `incrementalfee` - (numeric) The minimum fee rate increment for mempool limiting or replacement, in BTC/kB. Always `0.0` in Floresta, since Floresta has no mempool.
+
+- `localaddresses` - (array of objects) Local addresses the node is listening on. Always empty in Floresta, since the node does not accept inbound connections.
+
+- `warnings` - (array of strings) Any network or blockchain warnings. Always empty in Floresta, since Floresta does not emit network or blockchain warnings.
+
+### Error Enum
+
+* `JsonRpcError::Node` - If there is an internal node error preventing retrieval of the connection count (e.g., "Failed to get connection count").
+
+## Notes
+
+- This RPC mirrors Bitcoin Core's `getnetworkinfo` and reuses Bitcoin Core's response schema for compatibility. Several fields are hardcoded because Floresta is a lightweight, outbound-only node: it does not accept inbound connections (`connections_in`, `localaddresses`), does not maintain a mempool (`localrelay`, `relayfee`, `incrementalfee`), does not track peer time offsets (`timeoffset`), cannot toggle networking at runtime (`networkactive`), and does not emit network or blockchain warnings (`warnings`).
+- For per-peer details rather than node-wide networking state, see [`getpeerinfo`](getpeerinfo.md). For just the connection count, see [`getconnectioncount`](getconnectioncount.md).

--- a/fuzz/fuzz_targets/addrman.rs
+++ b/fuzz/fuzz_targets/addrman.rs
@@ -7,11 +7,11 @@ use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::ServiceFlags;
 use floresta_wire::address_man::AddressMan;
 use floresta_wire::address_man::LocalAddress;
-use floresta_wire::address_man::SUPPORTED_NETWORKS;
+use floresta_wire::address_man::ReachableNetworks;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let mut address_man = AddressMan::new(None, SUPPORTED_NETWORKS);
+    let mut address_man = AddressMan::new(None, &ReachableNetworks::SUPPORTED);
     let addrv2_msg_vec = encode::deserialize::<Vec<AddrV2Message>>(data);
     match addrv2_msg_vec {
         Err(_) => {}

--- a/tests/floresta-cli/getnetworkinfo.py
+++ b/tests/floresta-cli/getnetworkinfo.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getnetworkinfo.py
+
+This functional test exercises the `getnetworkinfo` RPC against a freshly
+started Floresta node and asserts that the response is shaped like
+Bitcoin Core's `getnetworkinfo` and reflects Floresta-specific defaults.
+"""
+
+import pytest
+
+EXPECTED_KEYS = {
+    "version",
+    "subversion",
+    "protocolversion",
+    "localservices",
+    "localservicesnames",
+    "localrelay",
+    "timeoffset",
+    "connections",
+    "connections_in",
+    "connections_out",
+    "networkactive",
+    "networks",
+    "relayfee",
+    "incrementalfee",
+    "localaddresses",
+    "warnings",
+}
+
+EXPECTED_NETWORK_NAMES = ["ipv4", "ipv6", "onion", "i2p", "cjdns"]
+
+
+@pytest.mark.rpc
+def test_get_network_info(florestad_node):
+    """
+    Test that `getnetworkinfo` returns a Core-compatible object on a
+    fresh node with no peers and no proxy configured.
+    """
+    info = florestad_node.rpc.get_networkinfo()
+
+    # All Core-mandated keys must be present.
+    assert (
+        set(info.keys()) == EXPECTED_KEYS
+    ), f"unexpected keys: {set(info.keys()) ^ EXPECTED_KEYS}"
+
+    # Protocol version is fixed at 70016.
+    assert info["protocolversion"] == 70016
+
+    # Floresta version, encoded as Core's MMmmpp, must be a positive integer.
+    assert isinstance(info["version"], int)
+    assert info["version"] > 0
+
+    # BIP-14 user-agent: slash-wrapped Floresta string.
+    assert info["subversion"].startswith("/")
+    assert info["subversion"].endswith("/")
+    assert "Floresta" in info["subversion"]
+
+    # localservices is a 16-char hex string with at least WITNESS+P2P_V2+UTREEXO bits set.
+    assert isinstance(info["localservices"], str)
+    assert len(info["localservices"]) == 16
+    int(info["localservices"], 16)  # parseable
+
+    # localservicesnames must include the Floresta-advertised flags.
+    assert "WITNESS" in info["localservicesnames"]
+    assert "P2P_V2" in info["localservicesnames"]
+    assert "UTREEXO" in info["localservicesnames"]
+
+    # Floresta does not relay txs and does not toggle networking.
+    assert info["localrelay"] is False
+    assert info["networkactive"] is True
+
+    # Fresh node => no peers, all outbound counters zero.
+    assert info["connections"] == 0
+    assert info["connections_in"] == 0
+    assert info["connections_out"] == 0
+
+    # Floresta doesn't track these — must be present, must be zero/empty.
+    assert info["timeoffset"] == 0
+    assert info["relayfee"] == 0
+    assert info["incrementalfee"] == 0
+    assert info["localaddresses"] == []
+    assert info["warnings"] == []
+
+    # All 5 Core networks must be listed, in the documented order.
+    assert [n["name"] for n in info["networks"]] == EXPECTED_NETWORK_NAMES
+
+    # No proxy configured by default => onion/i2p unreachable, ipv4/ipv6 reachable,
+    # cjdns always unreachable. proxy string must be empty for every entry.
+    expected_reachable = {
+        "ipv4": True,
+        "ipv6": True,
+        "onion": False,
+        "i2p": False,
+        "cjdns": False,
+    }
+    for net in info["networks"]:
+        assert (
+            net["reachable"] is expected_reachable[net["name"]]
+        ), f"{net['name']}: reachable={net['reachable']}"
+        assert net["limited"] is not net["reachable"]
+        assert net["proxy"] == ""
+        assert net["proxy_randomize_credentials"] is False

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -304,6 +304,12 @@ class BaseRPC(ABC):
         """
         return self.perform_request("getconnectioncount")
 
+    def get_networkinfo(self):
+        """
+        Get general state info regarding P2P networking
+        """
+        return self.perform_request("getnetworkinfo")
+
     def get_rpcinfo(self):
         """
         Returns stats about our RPC server


### PR DESCRIPTION
Adds the `getnetworkinfo` JSON-RPC method, returning a response shaped to Bitcoin Core v30's schema by reusing `corepc_types::v30::GetNetworkInfo`

Floresta-specific field semantics:
- `version`: derived from `CARGO_PKG_VERSION` as Core's `MMmmpp` (e.g. 0.9.0 -> 900).
- `subversion`: the configured user-agent, BIP-14 compliant.
- `protocolversion`: 70016, like the constant in `floresta-wire`'s peer module.
- `localservices` / `localservicesnames`: WITNESS | P2P_V2 | UTREEXO, the flags Floresta actually advertises on the wire.
- `connections_in`: always 0; `connections_out` = total.
- `networks`: all 5 Core-documented entries; `reachable` is true for ipv4/ipv6 always, false otherwise, as there is not support at the moment.
- Fields Floresta doesn't track are returned as honest zeros/empties rather than mimicked Core defaults: `timeoffset=0`, `relayfee=0`, `incrementalfee=0`, `localrelay=false`, `localaddresses=[]`, `warnings=[]`. `networkactive=true`.

Wires `user_agent` and `proxy` through `RpcImpl` so the method can render them without an extra round-trip through `NodeInterface`.

Includes a functional test (`tests/floresta-cli/getnetworkinfo.py`) that asserts shape compliance, BIP-14 subversion framing, fixed protocol version, default-no-proxy reachability matrix, and Floresta-specific zero/empty defaults.

Closes #653