### PR TITLE
feat(metrics): add a sample grafana dashboard

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -39,11 +39,16 @@ services:
       - 3000:3000
     restart: unless-stopped
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-grafana}
+      - GF_AUTH_ANONYMOUS_ENABLED=${GF_AUTH_ANONYMOUS_ENABLED:-false}
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=${GF_AUTH_ANONYMOUS_ORG_ROLE:-Viewer}
+      - GF_AUTH_DISABLE_LOGIN_FORM=${GF_AUTH_DISABLE_LOGIN_FORM:-false}
     volumes:
       - ../../metrics/grafana:/etc/grafana/provisioning/datasources
       - grafana_data:/var/lib/grafana
+      - ./metrics/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
+      - ./metrics/grafana/dashboards:/var/lib/grafana/dashboards
 
 volumes:
   floresta_data:

--- a/contrib/docker/env.docker.sample
+++ b/contrib/docker/env.docker.sample
@@ -30,3 +30,12 @@ ELECTRUM_PORT=50001
 #NETWORK=regtest
 #RPC_PORT=18442
 #ELECTRUM_PORT=20001
+
+# grafana admin credentials (default: admin/grafana)
+#GF_SECURITY_ADMIN_USER=admin
+#GF_SECURITY_ADMIN_PASSWORD=grafana
+
+# enable anonymous read-only access to the grafana dashboard
+#GF_AUTH_ANONYMOUS_ENABLED=true
+#GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+#GF_AUTH_DISABLE_LOGIN_FORM=true

--- a/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
@@ -163,6 +163,12 @@ where
             self.maybe_disconnect_slowest_peer(protected_services, always_disconnect)?;
         }
 
+        #[cfg(feature = "metrics")]
+        {
+            use metrics::get_metrics;
+            get_metrics().utreexo_peer_count.set(utreexo_peers as f64);
+        }
+
         if needs_utreexo {
             info!("Not enough utreexo peers (we have {utreexo_peers}), opening a new connection");
             self.maybe_open_connection(service_flags::UTREEXO.into())?;

--- a/metrics/grafana/dashboards.yml
+++ b/metrics/grafana/dashboards.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+apiVersion: 1
+providers:
+  - name: floresta-dashboards
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    allowUiUpdates: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      recursive: true

--- a/metrics/grafana/dashboards/floresta-dashboard.json
+++ b/metrics/grafana/dashboards/floresta-dashboard.json
@@ -157,10 +157,45 @@
       }
     },
     {
+      "type": "stat",
+      "title": "Utreexo Peer Count",
+      "description": "Number of peers that support the Utreexo protocol. At least 2 are required for block download.",
+      "id": 13,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 7 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        { "expr": "max(utreexo_peer_count{instance=~\"$instance\"})", "legendFormat": "utreexo peers", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 2 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
       "type": "row",
       "title": "Network",
       "id": 101,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
       "collapsed": false
     },
     {

--- a/metrics/grafana/dashboards/floresta-dashboard.json
+++ b/metrics/grafana/dashboards/floresta-dashboard.json
@@ -1,0 +1,419 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Node Overview",
+      "id": 100,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "Block Height",
+      "description": "The latest block height validated by this node.",
+      "id": 1,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        { "expr": "max(block_height{instance=~\"$instance\"})", "legendFormat": "height", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Peer Count",
+      "description": "Number of peers currently connected to this node.",
+      "id": 2,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        { "expr": "max(peer_count{instance=~\"$instance\"})", "legendFormat": "peers", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 3 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Avg Block Processing Time",
+      "description": "Average time taken to validate and process a block.",
+      "id": 3,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        { "expr": "avg(avg_block_processing_time{instance=~\"$instance\"})", "legendFormat": "avg", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "System Memory Usage",
+      "description": "Total memory used by the host machine (not Floresta alone).",
+      "id": 4,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        { "expr": "max(memory_usage_gigabytes{instance=~\"$instance\"})", "legendFormat": "mem", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decgbytes",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Network",
+      "id": 101,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "title": "Peers over time",
+      "description": "Number of connected peers over time.",
+      "id": 6,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "peer_count{instance=~\"$instance\"}",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Message rate (responses/s)",
+      "description": "Rate of peer message responses per second.",
+      "id": 8,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(message_times_count{instance=~\"$instance\"}[$__rate_interval]))",
+          "interval": "15s",
+          "legendFormat": "rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Message latency quantiles (s)",
+      "description": "p50/p90/p99 latency of peer message responses. Timed-out requests are excluded.",
+      "id": 7,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 2 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(message_times_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "interval": "15s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(message_times_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "interval": "15s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(message_times_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "interval": "15s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Message latency heatmap (s)",
+      "description": "Distribution of peer response latencies over time. Warmer colors indicate more messages in that latency bucket.",
+      "id": 9,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 25 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "scaleDistribution": { "type": "linear" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "calculate": false,
+        "yAxis": { "decimals": 2, "unit": "s" },
+        "color": { "mode": "scheme", "scheme": "Oranges" },
+        "legend": { "show": true },
+        "tooltip": { "show": true, "yHistogram": false }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(message_times_bucket{instance=~\"$instance\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "interval": "15s",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Performance",
+      "id": 102,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 35 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "title": "Block sync rate (blocks/s)",
+      "description": "Rate of new blocks being validated per second. Near 0 means the node is caught up with the chain tip.",
+      "id": 12,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 3 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "deriv(block_height{instance=~\"$instance\"}[$__rate_interval])",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg block processing time (s)",
+      "description": "Average time to validate a single block over time.",
+      "id": 10,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 2 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "avg_block_processing_time{instance=~\"$instance\"}",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Block Height over time",
+      "description": "Absolute block height progression over the selected time window.",
+      "id": 5,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 44 },
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "block_height{instance=~\"$instance\"}",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "System",
+      "id": 103,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 52 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "title": "System memory usage (GB)",
+      "description": "Total memory used by the host machine over time. This reflects system-wide usage, not Floresta's process alone.",
+      "id": 11,
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 53 },
+      "fieldConfig": { "defaults": { "unit": "decgbytes", "decimals": 2 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "memory_usage_gigabytes{instance=~\"$instance\"}",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["floresta", "bitcoin", "utreexo", "node"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      },
+      {
+        "name": "job",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "refresh": 2,
+        "hide": 2,
+        "query": "label_values(block_height, job)",
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      },
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "refresh": 2,
+        "query": "label_values(block_height, instance)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] }
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Floresta Node Metrics",
+  "uid": "floresta-node",
+  "version": 1
+}

--- a/metrics/grafana/datasource.yml
+++ b/metrics/grafana/datasource.yml
@@ -1,5 +1,6 @@
-apiVersion: 1
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
+apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -17,6 +17,7 @@ pub struct AppMetrics {
     pub memory_usage: Gauge<f64, AtomicU64>,
     pub block_height: Gauge,
     pub peer_count: Gauge<f64, AtomicU64>,
+    pub utreexo_peer_count: Gauge<f64, AtomicU64>,
     pub avg_block_processing_time: Gauge<f64, AtomicU64>,
     pub message_times: Histogram,
 }
@@ -27,6 +28,7 @@ impl AppMetrics {
         let memory_usage = Gauge::<f64, AtomicU64>::default();
         let block_height = Gauge::default();
         let peer_count = Gauge::<f64, AtomicU64>::default();
+        let utreexo_peer_count = Gauge::<f64, AtomicU64>::default();
         let avg_block_processing_time = Gauge::<f64, AtomicU64>::default();
         let message_times = Histogram::new([0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0]);
 
@@ -35,6 +37,11 @@ impl AppMetrics {
             "peer_count",
             "Number of connected peers",
             peer_count.clone(),
+        );
+        registry.register(
+            "utreexo_peer_count",
+            "Number of connected utreexo peers",
+            utreexo_peer_count.clone(),
         );
 
         registry.register(
@@ -60,6 +67,7 @@ impl AppMetrics {
             block_height,
             memory_usage,
             peer_count,
+            utreexo_peer_count,
             avg_block_processing_time,
             message_times,
         }


### PR DESCRIPTION
### Description and Notes

This PR adds a Grafana dashboard for local observability of a Floresta node running via Docker Compose, without any manual setup.

e.g.: https://dashboard-floresta.nicolasplusplus.xyz/d/floresta-node/floresta-node-metrics

- Adds a dashboards provider at `metrics/grafana/dashboards.yml` and an initial dashboard at `metrics/grafana/dashboards/floresta-dashboard.json`.
- Updates `docker-compose.yml` to mount Grafana provisioning and dashboards volumes and expose the UI on port 3000, keeping the Prometheus configuration as-is.
-  Adds a new `utreexo_peer_count` metric to make Utreexo peer connectivity visible in the dashboard — while testing locally, the terminal was showing "Not enough utreexo peers" errors repeatedly and there was no way to track this through the dashboard.

this PR depends on #834.
This work is based on the initial contribution by @rogeriob2br in #639.

### How to verify the changes you have done?

1. Start the stack:
```bash
docker compose up
```
2. Open Grafana at http://localhost:3000/ (user: admin, password: grafana).
3. Go to Floresta dashboard http://localhost:3000/d/floresta-node/floresta-node-metrics
