### PR TITLE
feat(rpc): implement getdeploymentinfo for buried deployments

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -134,6 +134,9 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::ListDescriptors => serde_json::to_string_pretty(&client.list_descriptors()?)?,
         Methods::Ping => serde_json::to_string_pretty(&client.ping()?)?,
         Methods::GetNetworkInfo => serde_json::to_string_pretty(&client.get_network_info()?)?,
+        Methods::GetDeploymentInfo { blockhash } => {
+            serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
+        }
     })
 }
 
@@ -285,6 +288,15 @@ pub enum Methods {
         hash: BlockHash,
         verbosity: Option<bool>,
     },
+
+    #[doc = include_str!("../../../doc/rpc/getdeploymentinfo.md")]
+    #[command(
+        name = "getdeploymentinfo",
+        about = "Returns data regarding deployments of consensus changes.",
+        long_about = Some(include_str!("../../../doc/rpc/getdeploymentinfo.md")),
+        disable_help_subcommand = true
+    )]
+    GetDeploymentInfo { blockhash: Option<BlockHash> },
 
     /// Loads a new descriptor to the watch only wallet
     #[doc = include_str!("../../../doc/rpc/loaddescriptor.md")]

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -439,3 +439,60 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
 
     seeds
 }
+
+/// Returns the buried deployment list for a network, as `(name, activation_height)` pairs.
+///
+/// Heights are sourced from Bitcoin Core's `chainparams.cpp` at v30.2
+/// (commit `4d7d5f6b79d4c11c47e7a828d81296918fd11d4d`):
+/// <https://github.com/bitcoin/bitcoin/blob/4d7d5f6b79d4c11c47e7a828d81296918fd11d4d/src/kernel/chainparams.cpp>
+//
+// TODO: also emit BIP9 deployments (`taproot`, `testdummy`); requires the versionbits state machine.
+pub fn buried_deployments_for(network: Network) -> &'static [(&'static str, u32)] {
+    const BITCOIN_BURIED: &[(&str, u32)] = &[
+        ("bip34", 227_931),
+        ("bip66", 363_725),
+        ("bip65", 388_381),
+        ("csv", 419_328),
+        ("segwit", 481_824),
+    ];
+
+    const TESTNET_BURIED: &[(&str, u32)] = &[
+        ("bip34", 21_111),
+        ("bip66", 330_776),
+        ("bip65", 581_885),
+        ("csv", 770_112),
+        ("segwit", 834_624),
+    ];
+
+    const TESTNET4_BURIED: &[(&str, u32)] = &[
+        ("bip34", 1),
+        ("bip66", 1),
+        ("bip65", 1),
+        ("csv", 1),
+        ("segwit", 1),
+    ];
+
+    const SIGNET_BURIED: &[(&str, u32)] = &[
+        ("bip34", 1),
+        ("bip66", 1),
+        ("bip65", 1),
+        ("csv", 1),
+        ("segwit", 1),
+    ];
+
+    const REGTEST_BURIED: &[(&str, u32)] = &[
+        ("bip34", 1),
+        ("bip66", 1),
+        ("bip65", 1),
+        ("csv", 1),
+        ("segwit", 0),
+    ];
+
+    match network {
+        Network::Bitcoin => BITCOIN_BURIED,
+        Network::Testnet => TESTNET_BURIED,
+        Network::Testnet4 => TESTNET4_BURIED,
+        Network::Signet => SIGNET_BURIED,
+        Network::Regtest => REGTEST_BURIED,
+    }
+}

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::BTreeMap;
+
 use bitcoin::Address;
 use bitcoin::Block;
 use bitcoin::BlockHash;
@@ -16,8 +18,11 @@ use bitcoin::constants::genesis_block;
 use bitcoin::hashes::Hash;
 use corepc_types::ScriptPubkey;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::DeploymentInfo;
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
+use corepc_types::v30::GetDeploymentInfo;
+use floresta_chain::buried_deployments_for;
 use floresta_chain::extensions::HeaderExt;
 use floresta_chain::extensions::WorkExt;
 use miniscript::descriptor::checksum;
@@ -311,7 +316,45 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     // getchainstates
     // getchaintips
     // getchaintxstats
+
     // getdeploymentinfo
+    pub(super) fn get_deployment_info(
+        &self,
+        hash: Option<BlockHash>,
+    ) -> Result<GetDeploymentInfo, JsonRpcError> {
+        let tip = self
+            .chain
+            .get_best_block()
+            .map_err(|_| JsonRpcError::Chain)?
+            .1;
+        let target_hash = hash.unwrap_or(tip);
+
+        let height = self
+            .chain
+            .get_block_height(&target_hash)
+            .map_err(|_| JsonRpcError::Chain)?
+            .ok_or(JsonRpcError::BlockNotFound)?;
+
+        let mut deployments = BTreeMap::new();
+
+        for &(name, activation_height) in buried_deployments_for(self.network) {
+            deployments.insert(
+                name.to_string(),
+                DeploymentInfo {
+                    deployment_type: "buried".to_string(),
+                    height: Some(activation_height),
+                    active: height >= activation_height,
+                    bip9: None,
+                },
+            );
+        }
+
+        Ok(GetDeploymentInfo {
+            hash: target_hash.to_string(),
+            height,
+            deployments,
+        })
+    }
 
     // getdifficulty
     pub(super) fn get_difficulty(&self) -> Result<f64, JsonRpcError> {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -265,6 +265,13 @@ async fn handle_json_rpc_request(
                 .map(|h| serde_json::to_value(h).unwrap())
         }
 
+        "getdeploymentinfo" => {
+            let blockhash = get_optional_field(&params, 0, "blockhash", get_hash)?;
+            state
+                .get_deployment_info(blockhash)
+                .map(|info| serde_json::to_value(info).unwrap())
+        }
+
         "getdifficulty" => state
             .get_difficulty()
             .map(|v| serde_json::to_value(v).unwrap()),

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use std::vec;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::GetDeploymentInfo;
 use serde_json::Number;
 use serde_json::Value;
 
@@ -48,6 +49,10 @@ pub trait FlorestaRPC {
         hash: BlockHash,
         verbosity: Option<bool>,
     ) -> Result<GetBlockHeaderRes>;
+
+    #[doc = include_str!("../../../doc/rpc/getdeploymentinfo.md")]
+    fn get_deployment_info(&self, blockhash: Option<BlockHash>) -> Result<GetDeploymentInfo>;
+
     /// Gets a transaction from the blockchain
     ///
     /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
@@ -260,6 +265,14 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_block_count(&self) -> Result<u32> {
         self.call("getblockcount", &[])
+    }
+
+    fn get_deployment_info(&self, blockhash: Option<BlockHash>) -> Result<GetDeploymentInfo> {
+        let params = match blockhash {
+            Some(h) => vec![Value::String(h.to_string())],
+            None => vec![],
+        };
+        self.call("getdeploymentinfo", &params)
     }
 
     fn get_difficulty(&self) -> Result<f64> {

--- a/doc/rpc/getdeploymentinfo.md
+++ b/doc/rpc/getdeploymentinfo.md
@@ -1,0 +1,50 @@
+# `getdeploymentinfo`
+
+Returns information about the deployment of consensus changes (softforks) at a given block.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getdeploymentinfo [blockhash]
+```
+
+### Examples
+
+```bash
+# Query deployment info at the current chain tip
+floresta-cli getdeploymentinfo
+
+# Query deployment info at a specific block
+floresta-cli getdeploymentinfo "0000000000000000000123abc..."
+```
+
+## Arguments
+
+- `blockhash` - (string, optional) Block hash to query. Defaults to the current chain tip.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON object describing the activation state of every known consensus deployment at the queried block.
+
+- `hash` - (string) Hash of the block at which deployment state was queried.
+- `height` - (numeric) Height of that block.
+- `deployments` - (object) Map of deployment name to deployment state. Each entry contains:
+  - `type` - (string) `"buried"` for deployments locked-in at fixed heights, `"bip9"` for versionbits deployments.
+  - `height` - (numeric) The activation height of the deployment.
+  - `active` - (boolean) Whether the deployment is active at the queried block.
+  - `bip9` - (object, nullable) BIP9 state information when `type` is `"bip9"`; currently always `null` since Floresta only emits buried deployments.
+
+### Error Enum
+
+* `JsonRpcError::BlockNotFound` - The requested block hash was not found in the blockchain
+* `JsonRpcError::Chain` - If there's an error accessing blockchain data
+
+## Notes
+
+- If `blockhash` is omitted, the current chain tip is used.
+- Floresta currently reports the five buried deployments tracked by Bitcoin Core: `bip34`, `bip66`, `bip65`, `csv`, and `segwit`. BIP9 deployments (`taproot`, `testdummy`) require the versionbits state machine and are not yet emitted.
+- Supported networks: mainnet, testnet, testnet4, signet, and regtest.

--- a/tests/floresta-cli/getdeploymentinfo.py
+++ b/tests/floresta-cli/getdeploymentinfo.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getdeploymentinfo.py
+
+Functional test for `getdeploymentinfo`. Mines blocks via utreexod, then
+compares florestad's response against bitcoind's for each buried deployment.
+
+Floresta currently emits only buried deployments (bip34, bip66, bip65, csv,
+segwit). Bitcoin Core also emits BIP9 deployments (taproot, testdummy) which
+require the versionbits state machine; those keys are present in bitcoind's
+response but skipped on the floresta side.
+"""
+
+import time
+import pytest
+
+TIMEOUT_SECONDS = 30
+MINE_BLOCKS = 10
+
+# Five buried deployments per Bitcoin Core's deploymentinfo.cpp enum
+# (DEPLOYMENT_HEIGHTINCB, DEPLOYMENT_DERSIG, DEPLOYMENT_CLTV, DEPLOYMENT_CSV,
+# DEPLOYMENT_SEGWIT). Anything else in bitcoind's output is BIP9 and intentionally
+# absent on floresta.
+BURIED_DEPLOYMENTS = ("bip34", "bip66", "bip65", "csv", "segwit")
+
+
+# pylint: disable=too-many-locals
+@pytest.mark.rpc
+def test_get_deployment_info(florestad_bitcoind_utreexod_with_chain):
+    """
+    Compare florestad's getdeploymentinfo response against bitcoind's after a
+    small chain extension. Each buried deployment must match by type, height
+    and active flag. BIP9 entries are validated by absence on the floresta side.
+    """
+    florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_chain(MINE_BLOCKS)
+
+    end = time.time() + TIMEOUT_SECONDS
+    while time.time() < end:
+        if (
+            florestad.rpc.get_block_count()
+            == bitcoind.rpc.get_block_count()
+            == utreexod.rpc.get_block_count()
+            == MINE_BLOCKS
+        ):
+            break
+        time.sleep(0.5)
+
+    floresta_info = florestad.rpc.get_deployment_info()
+    bitcoind_info = bitcoind.rpc.get_deployment_info()
+
+    # Top-level fields: hash and height must match.
+    assert floresta_info["hash"] == bitcoind_info["hash"], (
+        f"hash mismatch: floresta={floresta_info['hash']} "
+        f"bitcoind={bitcoind_info['hash']}"
+    )
+    assert floresta_info["height"] == bitcoind_info["height"], (
+        f"height mismatch: floresta={floresta_info['height']} "
+        f"bitcoind={bitcoind_info['height']}"
+    )
+
+    floresta_deps = floresta_info["deployments"]
+    bitcoind_deps = bitcoind_info["deployments"]
+
+    # Every buried deployment bitcoind emits must also be in floresta's output,
+    # with matching type, height and active flag.
+    for name in BURIED_DEPLOYMENTS:
+        assert name in bitcoind_deps, (
+            f"bitcoind unexpectedly missing buried deployment '{name}': "
+            f"{bitcoind_deps.keys()}"
+        )
+        assert name in floresta_deps, f"floresta missing buried deployment '{name}'"
+
+        b_entry = bitcoind_deps[name]
+        f_entry = floresta_deps[name]
+
+        assert (
+            f_entry["type"] == "buried"
+        ), f"floresta did not classify '{name}' as buried: {f_entry['type']}"
+        assert (
+            f_entry["height"] == b_entry["height"]
+        ), f"{name}: floresta height {f_entry['height']} != bitcoind {b_entry['height']}"
+        assert (
+            f_entry["active"] == b_entry["active"]
+        ), f"{name}: floresta active {f_entry['active']} != bitcoind {b_entry['active']}"
+
+    # Sanity check: floresta should not be emitting any deployment outside the
+    # buried set yet (no BIP9 state machine).
+    extra = set(floresta_deps.keys()) - set(BURIED_DEPLOYMENTS)
+    assert not extra, f"floresta emitted unexpected non-buried deployments: {extra}"
+
+    # Pre-activation contract: at genesis, deployments with height > 0 must be inactive.
+    genesis_hash = florestad.rpc.get_blockhash(0)
+    floresta_genesis = florestad.rpc.get_deployment_info(genesis_hash)
+
+    assert floresta_genesis["height"] == 0
+    for name in BURIED_DEPLOYMENTS:
+        f_entry = floresta_genesis["deployments"][name]
+        expected_active = f_entry["height"] <= 0
+        assert (
+            f_entry["active"] == expected_active
+        ), f"genesis {name}: active={f_entry['active']} but height={f_entry['height']}"
+
+    # Mid-chain blockhash: exercises the `Some(blockhash)` branch of the handler.
+    # Activation heights are network constants already checked at the tip, so
+    # only the active flag is compared here.
+    mid_height = MINE_BLOCKS // 2
+    mid_hash = florestad.rpc.get_blockhash(mid_height)
+    floresta_mid = florestad.rpc.get_deployment_info(mid_hash)
+    bitcoind_mid = bitcoind.rpc.get_deployment_info(mid_hash)
+
+    assert floresta_mid["height"] == bitcoind_mid["height"] == mid_height
+    assert floresta_mid["hash"] == bitcoind_mid["hash"]
+
+    for name in BURIED_DEPLOYMENTS:
+        f_entry = floresta_mid["deployments"][name]
+        b_entry = bitcoind_mid["deployments"][name]
+        assert (
+            f_entry["active"] == b_entry["active"]
+        ), f"mid {name}: floresta active {f_entry['active']} != bitcoind {b_entry['active']}"

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -278,6 +278,15 @@ class BaseRPC(ABC):
 
         return self.perform_request("getblockheader", params=params)
 
+    def get_deployment_info(self, blockhash: str | None = None) -> dict:
+        """
+        Get information about consensus deployment activation state at a block.
+
+        `blockhash` is optional; if omitted the node uses the current chain tip.
+        """
+        params = [blockhash] if blockhash is not None else []
+        return self.perform_request("getdeploymentinfo", params=params)
+
     def get_block(self, blockhash: str, verbosity: int = 1):
         """
         Get a full block, given its hash performing


### PR DESCRIPTION
## Summary

Implements `getdeploymentinfo` for the five buried softforks defined in Bitcoin Core: `bip34`, `bip66`, `bip65`, `csv`, and `segwit`.

The RPC accepts an optional `blockhash` argument (defaulting to the chain tip) and reports, for each deployment, its activation height and whether it is active at the queried block.

```json
{
  "hash": "<block hash>",
  "height": <number>,
  "deployments": {
    "<name>": {
      "type": "buried",
      "height": <activation height>,
      "active": <true|false>,
      "bip9": null
    }
  }
}
```

## Activation heights (source: Bitcoin Core)

Heights are sourced from Bitcoin Core's `chainparams.cpp` at v30.2 (commit `4d7d5f6b79d4c11c47e7a828d81296918fd11d4d`).

| Network   | bip34   | bip66   | bip65   | csv     | segwit  |
|-----------|--------:|--------:|--------:|--------:|--------:|
| mainnet   | 227,931 | 363,725 | 388,381 | 419,328 | 481,824 |
| testnet   |  21,111 | 330,776 | 581,885 | 770,112 | 834,624 |
| testnet4  |       1 |       1 |       1 |       1 |       1 |
| signet    |       1 |       1 |       1 |       1 |       1 |
| regtest   |       1 |       1 |       1 |       1 |       0 |

## Out of scope (future work)

BIP9 deployments (`taproot`, `testdummy`) require the versionbits state machine. That means walking back from a queried block in 2016-block windows, tracking `defined`, `started`, `locked_in`, `active`, and `failed` transitions, and computing per-window signalling statistics. That's substantially larger work and not included here.

## Test plan

- [x] Functional test (`tests/floresta-cli/getdeploymentinfo.py`) passes on regtest, comparing florestad's response against bitcoind's for:
  - Tip parity (all 5 buried deployments match by type/height/active)
  - Pre-activation contract (`active` correctly false at genesis when activation height > 0)
  - Mid-chain parity (`Some(blockhash)` branch for a non-tip, non-genesis block)
  - Absence of BIP9 entries on floresta's side
- [x] Manual smoke test against a live signet florestad: tip query and historical (genesis) query both return the expected output

Refs #654
