### PR TITLE
refactor(floresta-chain): apply strict error handling in flat_chain_store

### DIFF
--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -110,7 +110,7 @@ fn initialize_chainstore_benchmark(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let test_id = rand::random::<u64>();
-                FlatChainStoreConfig::new(format!("./tmp-db/{test_id}/"))
+                FlatChainStoreConfig::new_with_path(format!("./tmp-db/{test_id}/"))
             },
             |config| FlatChainStore::new(config).unwrap(),
             BatchSize::SmallInput,
@@ -252,7 +252,7 @@ fn chainstore_checksum_benchmark(c: &mut Criterion) {
     let setup_chain = || {
         let test_id = rand::random::<u64>();
         // The default config with the big mmap sizes that we use in `florestad`
-        let config = FlatChainStoreConfig::new(format!("./tmp-db/{test_id}/"));
+        let config = FlatChainStoreConfig::new_with_path(format!("./tmp-db/{test_id}/"));
         let mut chainstore = FlatChainStore::new(config).unwrap();
 
         headers.iter().enumerate().for_each(|(i, header)| {

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1976,7 +1976,7 @@ mod test {
 
     #[test]
     fn test_calculate_chain_work() {
-        let mut chainstore = FlatChainStore::new(FlatChainStoreConfig::new(
+        let mut chainstore = FlatChainStore::new(FlatChainStoreConfig::new_with_path(
             "../../testdata/signet_headers.zst",
         ))
         .unwrap();

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -7,6 +7,16 @@
 //! It also defines two important types for our storage format:
 //! - [DiskBlockHeader]: A block header linked to its validation-state metadata
 //! - [BestChain]: Tracks the current best chain, last valid block, and fork tips
+//!
+//! # Error types
+//!
+//! This module centralises the error types used by chainstore implementations:
+//! - [ChainstoreError]: The public-facing error enum for [ChainStore] operations
+
+use core::error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
 
 use bitcoin::BlockHash;
 use bitcoin::block::Header as BlockHeader;
@@ -17,6 +27,90 @@ use bitcoin::consensus::encode;
 use crate::BlockchainError;
 use crate::DatabaseError;
 use crate::prelude::*;
+
+/// The maximum theoretical size in bytes of the Utreexo accumulator
+///
+/// In the worst case that all leaves are filled:
+/// * The accumulator can have up to 64 roots
+/// * Each root is 32 bytes
+/// * The number of leaves is expressed as a [`u64`]
+///
+/// 64 (MAX_ROOTS) * 32 bytes (ROOT_SIZE) + 8 bytes (LEAF_COUNT) = 2056 bytes
+///
+/// Re-exported here so callers do not need to import from `flat_chain_store`
+pub const MAX_ACCUMULATOR_SIZE: usize = 2056;
+
+#[derive(Debug)]
+/// Errors that can happen whilst interacting with a [`ChainStore`] implementation
+///
+/// Variants that carry domain meaning ([`HeaderNotFound`], [`OversizedAccumulator`],
+/// [`CorruptedDatabase`], [`InvalidValidationIndex`]) allow callers to react
+/// programmatically. Unrecoverable implementation-level failures are wrapped inside
+/// [`Other`] as a plain diagnostic string.
+///
+/// [`HeaderNotFound`]: ChainstoreError::HeaderNotFound
+/// [`OversizedAccumulator`]: ChainstoreError::OversizedAccumulator
+/// [`CorruptedDatabase`]: ChainstoreError::CorruptedDatabase
+/// [`InvalidValidationIndex`]: ChainstoreError::InvalidValidationIndex
+/// [`Other`]: ChainstoreError::Other
+pub enum ChainstoreError {
+    /// The requested block header was not found in the store
+    HeaderNotFound,
+
+    /// The accumulator data exceeds the maximum allowed size of
+    /// [`MAX_ACCUMULATOR_SIZE`] bytes
+    OversizedAccumulator,
+
+    /// The database integrity check failed; data is corrupted
+    ///
+    /// Can be remedied by a full reindex
+    CorruptedDatabase,
+
+    /// The validation index references a block without a known height
+    ///
+    /// Usually indicates the block is orphaned or on an invalid chain;
+    /// Can be remedied by a full reindex
+    InvalidValidationIndex,
+
+    /// An unrecoverable error with a plain diagnostic message
+    ///
+    /// Covers implementation details such as I/O failures, lock poisoning,
+    /// capacity exhaustion, schema mismatches, and other non-actionable
+    /// conditions. Consumers should treat this as fatal and surface the
+    /// message for diagnostic purposes only.
+    Other(String),
+}
+
+impl Display for ChainstoreError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HeaderNotFound => {
+                write!(f, "the requested block header was not found")
+            }
+            Self::OversizedAccumulator => write!(
+                f,
+                "accumulator exceeds the maximum size of {} bytes",
+                MAX_ACCUMULATOR_SIZE
+            ),
+            Self::CorruptedDatabase => write!(
+                f,
+                "database integrity check failed; can be remedied by a full reindex"
+            ),
+            Self::InvalidValidationIndex => {
+                write!(
+                    f,
+                    "validation index has no known height; can be remedied by a full reindex"
+                )
+            }
+            Self::Other(msg) => write!(f, "other error: {msg}"),
+        }
+    }
+}
+
+impl error::Error for ChainstoreError {}
+
+/// Allows [`ChainstoreError`] to be used as the associated `Error` type of [`ChainStore`]
+impl DatabaseError for ChainstoreError {}
 
 /// A trait defining methods for interacting with our chain database. These methods will be used by
 /// the [ChainState](super::chain_state::ChainState) to save and retrieve data about the blockchain,

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -128,68 +128,9 @@ const FLAT_CHAINSTORE_VERSION: u32 = 1;
 /// again. This is the type of our cache
 type CacheType = LruCache<BlockHash, DiskBlockHeader>;
 
-#[derive(Clone)]
-/// Configuration for our flat chain store. See each field for more information
-pub struct FlatChainStoreConfig {
-    /// The index map size, in buckets
-    ///
-    /// This index holds our map from block hashes to block heights. We use an open-addressing hash
-    /// map to map block hashes to block heights. Ideally, size should be way bigger than the
-    /// number of blocks we expect to have in our chain, therefore reducing the load factor to a
-    /// negligible value. The default value is having space for 10 million blocks.
-    ///
-    /// We compute the actual capacity by rounding the requested size up to the next power of two,
-    /// so we can use `hash & (capacity - 1)` instead of `hash % capacity`.
-    pub block_index_size: Option<usize>,
-
-    /// The size of the headers file map, in headers
-    ///
-    /// This is the size of the flat file that holds all of our block headers. We keep all headers
-    /// in a simple flat file, one after the other. That file then gets mapped into RAM, so we can
-    /// use pointer arithmetic to find specific block, since pos(h) = h * size_of(DiskBlockHeader)
-    /// The default value is having space for 10 million blocks.
-    ///
-    /// We compute the actual capacity by rounding the requested size up to the next power of two.
-    pub headers_file_size: Option<usize>,
-
-    /// The size of the cache, in blocks
-    ///
-    /// We keep a LRU cache of the last n blocks we've touched. This is to avoid going into the
-    /// map every time we need to find a block. The default value is 1000 blocks.
-    pub cache_size: Option<usize>,
-
-    /// The permission for all the files we create
-    ///
-    /// This is the permission we give to all the files we create. The default value is 0o660
-    pub file_permission: Option<u32>,
-
-    /// The size of the fork headers file map, in headers
-    ///
-    /// This store keeps headers that are not in our main chain, but may be needed sometime. The
-    /// default value is having space for 10,000 blocks.
-    ///
-    /// We compute the actual capacity by rounding the requested size up to the next power of two.
-    pub fork_file_size: Option<usize>,
-
-    /// The path where we store our files
-    ///
-    /// We'll create a few files (namely, the index map, headers file, forks file, and metadata file).
-    /// We need a directory where we can read and write, it needs at least 880 MiB of free space.
-    /// And have a file system that supports mmap and sparse files (all the default *unix FS do).
-    pub path: PathBuf,
-}
-
-impl FlatChainStoreConfig {
-    /// Creates a new configuration with the default values
-    pub fn new(path: impl AsRef<Path>) -> Self {
-        Self {
-            file_permission: Some(0o666),
-            fork_file_size: Some(10_000),
-            headers_file_size: Some(10_000_000),
-            block_index_size: Some(10_000_000),
-            cache_size: Some(10_000),
-            path: path.as_ref().into(),
-        }
+impl From<PoisonError<MutexGuard<'_, CacheType>>> for ChainstoreError {
+    fn from(e: PoisonError<MutexGuard<'_, CacheType>>) -> Self {
+        Self::Other(format!("{e}"))
     }
 }
 
@@ -397,7 +338,7 @@ impl BlockIndex {
         &self,
         hash: BlockHash,
         index: Index,
-        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, ChainstoreError>,
+        get_header_by_index: impl Fn(Index) -> Result<Option<HashedDiskHeader>, ChainstoreError>,
     ) -> Result<bool, ChainstoreError> {
         let pos = unsafe { self.hash_map_find_pos(hash, get_header_by_index) }?;
 
@@ -411,7 +352,7 @@ impl BlockIndex {
             // If this is the case, we should update the fork block to make it into the main chain,
             // and mark the old main chain block as a fork.
             IndexBucket::Occupied { ptr, .. } => {
-                unsafe { ptr.write(index) }
+                unsafe { ptr.write(index) };
                 Ok(false)
             }
         }
@@ -421,7 +362,7 @@ impl BlockIndex {
     unsafe fn get_index_for_hash(
         &self,
         hash: BlockHash,
-        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, ChainstoreError>,
+        get_header_by_index: impl Fn(Index) -> Result<Option<HashedDiskHeader>, ChainstoreError>,
     ) -> Result<Option<(Index, DiskBlockHeader)>, ChainstoreError> {
         match unsafe { self.hash_map_find_pos(hash, get_header_by_index) }? {
             IndexBucket::Empty { .. } => Ok(None),
@@ -439,7 +380,7 @@ impl BlockIndex {
     unsafe fn hash_map_find_pos(
         &self,
         block_hash: BlockHash,
-        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, ChainstoreError>,
+        get_header_by_index: impl Fn(Index) -> Result<Option<HashedDiskHeader>, ChainstoreError>,
     ) -> Result<IndexBucket, ChainstoreError> {
         let mut hash = Self::index_hash_fn(block_hash) as usize;
 
@@ -459,15 +400,18 @@ impl BlockIndex {
 
             // If the header at `candidate_index` matches `block_hash`, this is the target bucket
             let file_header = get_header_by_index(candidate_index)?;
-            if file_header.hash == block_hash {
-                return Ok(IndexBucket::Occupied {
-                    ptr: entry_ptr,
-                    header: file_header.header,
-                });
+            if let Some(file_header) = file_header {
+                if file_header.hash == block_hash {
+                    return Ok(IndexBucket::Occupied {
+                        ptr: entry_ptr,
+                        header: file_header.header,
+                    });
+                }
             }
 
             // If we find an empty index, this bucket is where the entry would be added
-            // Note: The genesis block doesn't reach this point, as its header hash is matched
+            // for candidate index 0, we only get here when the slot does not match the
+            // searched hash (including the genesis mismatch case)
             if candidate_index.is_empty() {
                 return Ok(IndexBucket::Empty { ptr: entry_ptr });
             }
@@ -477,7 +421,7 @@ impl BlockIndex {
         }
 
         // If we reach here, it means the index is full. We should re-hash the map
-        Err(ChainstoreError::FullIndex)
+        Err(ChainstoreError::Other("block index is full".into()))
     }
 
     /// The (short) hash function we use to compute where in the map a given index should be
@@ -536,6 +480,85 @@ pub struct FlatChainStore {
 
     /// A LRU cache for the last n blocks we've touched
     cache: Mutex<LruCache<BlockHash, DiskBlockHeader>>,
+}
+
+#[derive(Clone)]
+/// Configuration for our flat chain store, see each field for more information
+pub struct FlatChainStoreConfig {
+    /// The index map size, in buckets
+    ///
+    /// This index holds our map from block hashes to block heights. We use an open-addressing hash
+    /// map to map block hashes to block heights. Ideally, size should be way bigger than the
+    /// number of blocks we expect to have in our chain, therefore reducing the load factor to a
+    /// negligible value. The default value is having space for 10 million blocks
+    ///
+    /// We compute the actual capacity by rounding the requested size up to the next power of two,
+    /// so we can use `hash & (capacity - 1)` instead of `hash % capacity`
+    pub block_index_size: Option<usize>,
+
+    /// The size of the headers file map, in headers
+    ///
+    /// This is the size of the flat file that holds all of our block headers. We keep all headers
+    /// in a simple flat file, one after the other. That file then gets mapped into RAM, so we can
+    /// use pointer arithmetic to find specific block, since pos(h) = h * size_of(DiskBlockHeader)
+    /// The default value is having space for 10 million blocks
+    ///
+    /// We compute the actual capacity by rounding the requested size up to the next power of two
+    pub headers_file_size: Option<usize>,
+
+    /// The size of the cache, in blocks
+    ///
+    /// We keep a LRU cache of the last n blocks we've touched. This is to avoid going into the
+    /// map every time we need to find a block. The default value is 1000 blocks
+    pub cache_size: Option<usize>,
+
+    /// The permission for all the files we create
+    ///
+    /// This is the permission we give to all the files we create. The default value is 0o660
+    pub file_permission: Option<u32>,
+
+    /// The size of the fork headers file map, in headers
+    ///
+    /// This store keeps headers that are not in our main chain, but may be needed sometime, the
+    /// default value is having space for 10,000 blocks
+    ///
+    /// We compute the actual capacity by rounding the requested size up to the next power of two
+    pub fork_file_size: Option<usize>,
+
+    /// The path where we store our files
+    ///
+    /// We'll create a few files (namely, the index map, headers file, forks file, and metadata file)
+    /// We need a directory where we can read and write, it needs at least 880 MiB of free space
+    /// And have a file system that supports mmap and sparse files (all the default *unix FS do)
+    pub path: PathBuf,
+}
+
+const DEFAULT_FILE_PERMISSION: u32 = 0o666;
+const DEFAULT_FORK_FILE_SIZE: usize = 10_000;
+const DEFAULT_HEADERS_FILE_SIZE: usize = 10_000_000;
+const DEFAULT_BLOCK_INDEX_SIZE: usize = 10_000_000;
+const DEFAULT_CACHE_SIZE: usize = 10_000;
+
+impl Default for FlatChainStoreConfig {
+    fn default() -> Self {
+        Self {
+            file_permission: Some(DEFAULT_FILE_PERMISSION),
+            fork_file_size: Some(DEFAULT_FORK_FILE_SIZE),
+            path: PathBuf::new(),
+            headers_file_size: Some(DEFAULT_HEADERS_FILE_SIZE),
+            block_index_size: Some(DEFAULT_BLOCK_INDEX_SIZE),
+            cache_size: Some(DEFAULT_CACHE_SIZE),
+        }
+    }
+}
+
+impl FlatChainStoreConfig {
+    pub fn new_with_path(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            ..Default::default()
+        }
+    }
 }
 
 impl FlatChainStore {
@@ -606,9 +629,14 @@ impl FlatChainStore {
             fork_headers_checksum: FileChecksum(0),
         };
 
-        let cache_size = config.cache_size.and_then(NonZeroUsize::new).unwrap_or(
-            NonZeroUsize::new(1000).expect("Infallible: Hard-coded default is always non-zero"),
-        );
+        #[allow(
+            clippy::unwrap_used,
+            reason = "1000 is a non-zero compile-time constant"
+        )]
+        let cache_size = config
+            .cache_size
+            .and_then(NonZeroUsize::new)
+            .unwrap_or(NonZeroUsize::new(1000).unwrap());
 
         let accumulator_file = File::options()
             .read(true)
@@ -630,7 +658,7 @@ impl FlatChainStore {
 
     /// Opens a new storage. If it already exists, just load. If not, create a new one
     pub fn new(config: FlatChainStoreConfig) -> Result<Self, ChainstoreError> {
-        let datadir = &config.path;
+        let datadir: &Path = config.path.as_ref();
         let metadata_path = datadir.join("metadata.bin");
         let file_mode = config.file_permission.unwrap_or(0o600);
 
@@ -654,16 +682,22 @@ impl FlatChainStore {
         let metadata = unsafe {
             metadata
                 .as_ref()
-                .ok_or(ChainstoreError::InvalidMetadataPointer)?
+                .ok_or_else(|| ChainstoreError::Other("metadata pointer is null".into()))?
         };
 
         // check the magic number and version
         if metadata.version > FLAT_CHAINSTORE_VERSION {
-            return Err(ChainstoreError::UnsupportedSchema(metadata.version));
+            return Err(ChainstoreError::Other(format!(
+                "unsupported schema version: {}",
+                metadata.version
+            )));
         }
 
         if metadata.magic != FLAT_CHAINSTORE_MAGIC {
-            return Err(ChainstoreError::BadMagic(metadata.magic));
+            return Err(ChainstoreError::Other(format!(
+                "bad database magic: {:#010x}",
+                metadata.magic
+            )));
         }
 
         let index_path = datadir.join("blocks_index.bin");
@@ -678,9 +712,14 @@ impl FlatChainStore {
         let index_map = unsafe { Self::init_file(&index_path, index_file_size, file_mode)? };
         let headers = unsafe { Self::init_file(&headers_file_path, headers_file_size, file_mode)? };
         let fork_headers = unsafe { Self::init_file(&fork_file_path, fork_file_size, file_mode)? };
-        let cache_size = config.cache_size.and_then(NonZeroUsize::new).unwrap_or(
-            NonZeroUsize::new(1000).expect("Infallible: Hard-coded default is always non-zero"),
-        );
+        #[allow(
+            clippy::unwrap_used,
+            reason = "1000 is a non-zero compile-time constant"
+        )]
+        let cache_size = config
+            .cache_size
+            .and_then(NonZeroUsize::new)
+            .unwrap_or(NonZeroUsize::new(1000).unwrap());
 
         let accumulator_file = File::options()
             .read(true)
@@ -695,7 +734,7 @@ impl FlatChainStore {
             metadata: metadata_file,
             block_index: BlockIndex::new(index_map, metadata.index_capacity),
             fork_headers,
-            datadir: datadir.clone(),
+            datadir: datadir.to_path_buf(),
             cache: LruCache::new(cache_size).into(),
         })
     }
@@ -712,12 +751,14 @@ impl FlatChainStore {
         let metadata = unsafe { self.get_metadata() }?;
         let next_occupancy = metadata.block_index_occupancy + 1;
         if next_occupancy >= metadata.index_capacity {
-            return Err(ChainstoreError::FullIndex);
+            return Err(ChainstoreError::Other("block index is full".into()));
         }
         let is_new = unsafe {
-            self.block_index
-                .set_index_for_hash(hash, index, |index| self.get_disk_header(index).copied())
-        }?;
+            self.block_index.set_index_for_hash(hash, index, |index| {
+                self.get_disk_header(index).map(|opt| opt.copied())
+            })?
+        };
+
         // Only increment the index occupancy if this is a new entry, i.e., a new block. Otherwise,
         // if this is a reorg, the occupancy is kept the same as we just overwrite indexes.
         if is_new {
@@ -810,17 +851,16 @@ impl FlatChainStore {
         file.set_len(size as u64)?;
 
         // Return the `MmapMut` instance that represents the file
-        let mmap = unsafe { MmapOptions::default().len(size).map_mut(&file) }?;
-
-        Ok(mmap)
+        Ok(unsafe { MmapOptions::default().len(size).map_mut(&file) }?)
     }
 
-    /// Returns a reference to the respective disk header from the file. Errors if nothing is found.
+    /// Returns a reference to the respective disk header from the file, or `None` if the slot
+    /// is uninitialized (all-zeros hash).
     unsafe fn get_disk_header(
         &self,
         index: Index,
-    ) -> Result<&HashedDiskHeader, ChainstoreError> {
-        let metadata = unsafe { self.get_metadata()? };
+    ) -> Result<Option<&HashedDiskHeader>, ChainstoreError> {
+        let metadata = unsafe { self.get_metadata() }?;
         let (max_size, base_ptr) = match index.is_main_chain() {
             true => (metadata.headers_file_size, self.headers.as_ptr()),
             false => (metadata.fork_file_size, self.fork_headers.as_ptr()),
@@ -828,7 +868,9 @@ impl FlatChainStore {
 
         let index = index.index() as usize;
         if index >= max_size {
-            return Err(ChainstoreError::FullIndex);
+            return Err(ChainstoreError::Other(format!(
+                "index {index} exceeds file capacity {max_size}"
+            )));
         }
 
         // SAFETY: we've checked index < max_size
@@ -837,10 +879,10 @@ impl FlatChainStore {
 
         // Uninitialized memory means we haven't written anything here yet
         if header.hash == BlockHash::all_zeros() {
-            return Err(ChainstoreError::HeaderNotFound);
+            return Ok(None);
         }
 
-        Ok(header)
+        Ok(Some(header))
     }
 
     /// Returns a mutable reference to the respective disk header from the file, which may be
@@ -849,7 +891,7 @@ impl FlatChainStore {
         &mut self,
         index: Index,
     ) -> Result<&mut HashedDiskHeader, ChainstoreError> {
-        let metadata = unsafe { self.get_metadata()? };
+        let metadata = unsafe { self.get_metadata() }?;
         let (max_size, base_ptr) = match index.is_main_chain() {
             true => (metadata.headers_file_size, self.headers.as_ptr()),
             false => (metadata.fork_file_size, self.fork_headers.as_ptr()),
@@ -857,7 +899,9 @@ impl FlatChainStore {
 
         let index = index.index() as usize;
         if index >= max_size {
-            return Err(ChainstoreError::FullIndex);
+            return Err(ChainstoreError::Other(format!(
+                "index {index} exceeds file capacity {max_size}"
+            )));
         }
 
         // SAFETY: we've checked index < max_size
@@ -873,7 +917,12 @@ impl FlatChainStore {
         metadata.depth = best_block.depth;
         metadata.validation_index = best_block.validation_index;
 
-        assert!(best_block.alternative_tips.len() <= 64);
+        if best_block.alternative_tips.len() > 64 {
+            return Err(ChainstoreError::Other(format!(
+                "too many alternative tips: {} (max 64)",
+                best_block.alternative_tips.len()
+            )));
+        }
 
         unsafe {
             metadata
@@ -889,7 +938,7 @@ impl FlatChainStore {
     }
 
     unsafe fn get_best_chain(&self) -> Result<BestChain, ChainstoreError> {
-        let metadata = unsafe { self.get_metadata()? };
+        let metadata = unsafe { self.get_metadata() }?;
 
         Ok(BestChain {
             best_block: metadata.best_block,
@@ -911,21 +960,35 @@ impl FlatChainStore {
         hash: BlockHash,
     ) -> Result<Option<DiskBlockHeader>, ChainstoreError> {
         let result = unsafe {
-            self.block_index
-                .get_index_for_hash(hash, |height| self.get_disk_header(height).copied())
-        }?
+            self.block_index.get_index_for_hash(hash, |height| {
+                self.get_disk_header(height).map(|opt| opt.copied())
+            })?
+        }
         .map(|idx_and_header| idx_and_header.1);
+
         Ok(result)
     }
 
     unsafe fn get_metadata(&self) -> Result<&Metadata, ChainstoreError> {
         let ptr = self.metadata.as_ptr() as *const Metadata;
-        Ok(unsafe { ptr.as_ref() }.expect("Infallible: we already validated this pointer"))
+
+        // INVARIANT: `MmapMut::as_ptr()` is always non-null for a valid mapping
+        #[allow(
+            clippy::unwrap_used,
+            reason = "MmapMut::as_ptr() is non-null for valid mappings"
+        )]
+        Ok(unsafe { ptr.as_ref() }.unwrap())
     }
 
     unsafe fn get_metadata_mut(&mut self) -> Result<&mut Metadata, ChainstoreError> {
         let ptr = self.metadata.as_ptr() as *mut Metadata;
-        Ok(unsafe { ptr.as_mut() }.expect("Infallible: we already validated this pointer"))
+
+        // INVARIANT: `MmapMut::as_ptr()` is always non-null for a valid mapping
+        #[allow(
+            clippy::unwrap_used,
+            reason = "MmapMut::as_ptr() is non-null for valid mappings"
+        )]
+        Ok(unsafe { ptr.as_mut() }.unwrap())
     }
 
     /// Writes a block header in our storage
@@ -938,8 +1001,9 @@ impl FlatChainStore {
     ) -> Result<(), ChainstoreError> {
         let height = header
             .try_height()
-            .expect("Infallible: this function is only called for best chain blocks");
+            .map_err(|e| ChainstoreError::Other(e.to_string()))?;
         let index = Index::new(height)?;
+
         let pos = unsafe { self.get_disk_header_mut(index) }?;
         *pos = HashedDiskHeader {
             header,
@@ -988,12 +1052,10 @@ impl FlatChainStore {
     /// We will write 3 in a new position, and it should work fine. However, we now have a stale 3
     /// that points to the main chain position where it originally was. This will never be used
     /// again, but will occupy a position in the index. Increasing the load factor for no reason.
-    unsafe fn save_fork_block(
-        &mut self,
-        header: DiskBlockHeader,
-    ) -> Result<(), ChainstoreError> {
+    unsafe fn save_fork_block(&mut self, header: DiskBlockHeader) -> Result<(), ChainstoreError> {
         let fork_blocks = unsafe { self.get_metadata() }?.fork_count;
         let index = Index::new_fork(fork_blocks)?;
+
         let pos = unsafe { self.get_disk_header_mut(index) }?;
         let block_hash = header.block_hash();
 
@@ -1077,21 +1139,20 @@ impl ChainStore for FlatChainStore {
             .get_header(&metadata.validation_index)?
             .map(|h| {
                 h.try_height()
-                    .map_err(|_| ChainstoreError::InvalidValidationIndex)
+                    .map_err(|_no_height| ChainstoreError::InvalidValidationIndex)
             })
             .transpose()?
             .unwrap_or(0);
 
         if height <= validation_index {
             // this is probably a reorg, truncate the file up to the previous block height
-            let header = unsafe { self.get_disk_header(index)? };
+            let header =
+                unsafe { self.get_disk_header(index)? }.ok_or(ChainstoreError::HeaderNotFound)?;
 
             // this is where the new acc starts, truncating the file to this position
             let pos = header.acc_pos as u64;
 
-            self.accumulator_file
-                .set_len(pos)
-                .map_err(ChainstoreError::Io)?;
+            self.accumulator_file.set_len(pos)?;
         }
 
         let pos = self.accumulator_file.seek(SeekFrom::End(0))?;
@@ -1119,7 +1180,8 @@ impl ChainStore for FlatChainStore {
     fn load_roots_for_block(&mut self, height: u32) -> Result<Option<Vec<u8>>, Self::Error> {
         let index = Index::new(height)?;
 
-        let header = unsafe { self.get_disk_header(index)? };
+        let header =
+            unsafe { self.get_disk_header(index)? }.ok_or(ChainstoreError::HeaderNotFound)?;
         let size = header.acc_len as usize;
 
         if size == 0 {
@@ -1156,13 +1218,7 @@ impl ChainStore for FlatChainStore {
     fn get_header_by_height(&self, height: u32) -> Result<Option<DiskBlockHeader>, Self::Error> {
         let index = Index::new(height)?;
 
-        unsafe {
-            match self.get_disk_header(index) {
-                Ok(header) => Ok(Some(header.header)),
-                Err(ChainstoreError::HeaderNotFound) => Ok(None),
-                Err(e) => Err(e),
-            }
-        }
+        unsafe { self.get_disk_header(index) }.map(|opt| opt.map(|h| h.header))
     }
 
     fn load_height(&self) -> Result<Option<crate::BestChain>, Self::Error> {
@@ -1195,13 +1251,7 @@ impl ChainStore for FlatChainStore {
     fn get_block_hash(&self, height: u32) -> Result<Option<BlockHash>, Self::Error> {
         let index = Index::new(height)?;
 
-        unsafe {
-            match self.get_disk_header(index) {
-                Ok(header) => Ok(Some(header.hash)),
-                Err(ChainstoreError::HeaderNotFound) => Ok(None),
-                Err(e) => Err(e),
-            }
-        }
+        unsafe { self.get_disk_header(index) }.map(|opt| opt.map(|h| h.hash))
     }
 
     fn update_block_index(&mut self, height: u32, hash: BlockHash) -> Result<(), Self::Error> {
@@ -1280,7 +1330,7 @@ pub mod migrate_v0_to_v1 {
         }
 
         // 1) back up
-        let metadata_backup_path = Path::new(metadata_path).with_extension("bin.old");
+        let metadata_backup_path = metadata_path.with_extension("bin.old");
         fs::rename(metadata_path, &metadata_backup_path)?;
 
         // 2) read old struct
@@ -1308,6 +1358,7 @@ pub mod migrate_v0_to_v1 {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use core::mem::size_of;
     use std::fs;
@@ -1324,13 +1375,14 @@ mod tests {
     use tempfile::TempDir;
     use twox_hash::XxHash3_64;
 
+    use super::ChainstoreError;
     use super::FLAT_CHAINSTORE_MAGIC;
     use super::FLAT_CHAINSTORE_VERSION;
     use super::FlatChainStore;
     use super::FlatChainStoreConfig;
-    use super::ChainstoreError;
     use super::HashedDiskHeader;
     use super::Index;
+    use super::MAX_ACCUMULATOR_SIZE;
     use crate::AssumeValidArg;
     use crate::BestChain;
     use crate::ChainState;
@@ -1421,12 +1473,19 @@ mod tests {
             let store_id = tweak_version_and_magic(version, FLAT_CHAINSTORE_MAGIC);
 
             match get_test_chainstore(Some(store_id)) {
-                Err(ChainstoreError::UnsupportedSchema(v)) if v == version => {}
-                Err(e) => panic!(
-                    "Should have failed with `ChainstoreError::DbTooNew({version})`, instead we got {e:?}"
-                ),
+                Err(ChainstoreError::Other(msg)) => {
+                    assert!(
+                        msg.contains("unsupported schema version"),
+                        "Expected unsupported schema version message, got: {msg}"
+                    );
+                }
+                Err(e) => {
+                    panic!(
+                        "Should have failed with unsupported schema version, instead we got {e:?}"
+                    )
+                }
                 Ok(_) => panic!(
-                    "Should have failed with `ChainstoreError::DbTooNew({version})`, instead we got `Ok`"
+                    "Should have failed with unsupported schema version, instead we got `Ok`"
                 ),
             }
         }
@@ -1439,13 +1498,16 @@ mod tests {
             let store_id = tweak_version_and_magic(FLAT_CHAINSTORE_VERSION, magic);
 
             match get_test_chainstore(Some(store_id)) {
-                Err(ChainstoreError::BadMagic(m)) if m == magic => {}
-                Err(e) => panic!(
-                    "Should have failed with `ChainstoreError::InvalidMagic({magic})`, instead we got {e:?}"
-                ),
-                Ok(_) => panic!(
-                    "Should have failed with `ChainstoreError::InvalidMagic({magic})`, instead we got `Ok`"
-                ),
+                Err(ChainstoreError::Other(msg)) => {
+                    assert!(
+                        msg.contains("bad database magic"),
+                        "Expected bad database magic message, got: {msg}"
+                    );
+                }
+                Err(e) => {
+                    panic!("Should have failed with bad database magic, instead we got {e:?}")
+                }
+                Ok(_) => panic!("Should have failed with bad database magic, instead we got `Ok`"),
             }
         }
     }
@@ -1586,47 +1648,47 @@ mod tests {
         // Test that the inner header-fetching function returns the proper error for mainnet indices
         unsafe {
             match store.get_disk_header(Index::new(151).unwrap()) {
-                Err(ChainstoreError::HeaderNotFound) => (),
+                Ok(None) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
-                Ok(val) => panic!("Should not have found a header at height 151: {val:?}"),
+                Ok(Some(val)) => panic!("Should not have found a header at height 151: {val:?}"),
             }
             // Last available position
             match store.get_disk_header(Index::new(32_767).unwrap()) {
-                Err(ChainstoreError::HeaderNotFound) => (),
+                Ok(None) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
-                Ok(val) => panic!("Should not have found a header at height 32767: {val:?}"),
+                Ok(Some(val)) => panic!("Should not have found a header at height 32767: {val:?}"),
             }
-            // Exceeds header file capacity
-            match store.get_disk_header(Index::new(32_768).unwrap()) {
-                Err(ChainstoreError::FullIndex) => (),
-                Err(e) => panic!("Unexpected err: {e:?}"),
-                Ok(val) => {
-                    panic!("Should not have found a header exceeding file capacity: {val:?}")
-                }
-            }
+            // Exceeds header file capacity, must be Other, not a silent wildcard
+            let err = store
+                .get_disk_header(Index::new(32_768).unwrap())
+                .unwrap_err();
+            assert!(
+                matches!(err, ChainstoreError::Other(_)),
+                "Expected ChainstoreError::Other for header index exceeding file capacity"
+            );
         }
 
         // Test that the inner header-fetching function returns the proper error for fork indices
         unsafe {
             match store.get_disk_header(Index::new_fork(0).unwrap()) {
-                Err(ChainstoreError::HeaderNotFound) => (),
+                Ok(None) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
-                Ok(val) => panic!("Should not have found any fork header: {val:?}"),
+                Ok(Some(val)) => panic!("Should not have found any fork header: {val:?}"),
             }
             // Last available position
             match store.get_disk_header(Index::new_fork(16_383).unwrap()) {
-                Err(ChainstoreError::HeaderNotFound) => (),
+                Ok(None) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
-                Ok(val) => panic!("Should not have found any fork header: {val:?}"),
+                Ok(Some(val)) => panic!("Should not have found any fork header: {val:?}"),
             }
-            // Exceeds fork file capacity
-            match store.get_disk_header(Index::new_fork(16_384).unwrap()) {
-                Err(ChainstoreError::FullIndex) => (),
-                Err(e) => panic!("Unexpected err: {e:?}"),
-                Ok(val) => {
-                    panic!("Should not have found a header exceeding file capacity: {val:?}")
-                }
-            }
+            // Exceeds fork file capacity, must be Other, not a silent wildcard
+            let err = store
+                .get_disk_header(Index::new_fork(16_384).unwrap())
+                .unwrap_err();
+            assert!(
+                matches!(err, ChainstoreError::Other(_)),
+                "Expected ChainstoreError::Other for fork index exceeding file capacity"
+            );
         }
     }
 
@@ -1835,7 +1897,155 @@ mod tests {
         match result {
             Err(ChainstoreError::HeaderNotFound) => (),
             Err(e) => panic!("Unexpected err: {e:?}"),
-            Ok(_) => panic!("Should not have been able to save roots for a block we don't have"),
+            Ok(()) => panic!("Should not have been able to save roots for a block we don't have"),
         }
+    }
+
+    #[test]
+    fn propagates_header_not_found() {
+        let store = get_test_chainstore(None).unwrap();
+        let missing = BlockHash::from_byte_array([0xAB; 32]);
+        let err = store.get_header(&missing).unwrap();
+        // get_header returns Ok(None) for missing headers
+        assert!(err.is_none());
+
+        // get_header_by_height returns Ok(None) for unwritten heights
+        let ret = store.get_header_by_height(9999).unwrap();
+        assert!(ret.is_none());
+
+        // get_disk_header returns Ok(None) for unwritten-but-in-range indices
+        let result = unsafe { store.get_disk_header(Index::new(1).unwrap()) };
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn propagates_oversized_accumulator() {
+        let mut store = get_test_chainstore(None).unwrap();
+
+        // try to save the genesis block so we have a header at height 0
+        let genesis = genesis_block(Network::Regtest);
+        store
+            .save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))
+            .unwrap();
+        store.update_block_index(0, genesis.block_hash()).unwrap();
+        store
+            .save_height(&BestChain {
+                best_block: genesis.block_hash(),
+                depth: 0,
+                validation_index: genesis.block_hash(),
+                alternative_tips: vec![],
+            })
+            .unwrap();
+
+        // try to save an accumulator that exceeds the maximum size
+        let oversized = vec![0u8; MAX_ACCUMULATOR_SIZE + 1];
+        let err = store.save_roots_for_block(oversized, 0).unwrap_err();
+        assert!(matches!(err, ChainstoreError::OversizedAccumulator));
+    }
+
+    #[test]
+    fn propagates_corrupted_database() {
+        let test_id = rand::random::<u64>();
+        let mut store = get_test_chainstore(Some(test_id)).unwrap();
+        store.flush().unwrap();
+
+        // corrupt the database by tampering with the checksum
+        let metadata = unsafe { store.get_metadata_mut().unwrap() };
+        metadata.checksum.headers_checksum = FileChecksum(0xDEAD_BEEF);
+
+        let err = store.check_integrity().unwrap_err();
+        assert!(matches!(err, ChainstoreError::CorruptedDatabase));
+    }
+
+    #[test]
+    fn propagates_internal_from_io() {
+        let err = ChainstoreError::from(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "test io error",
+        ));
+        assert!(matches!(err, ChainstoreError::Other(_)));
+    }
+
+    #[test]
+    fn propagates_internal_from_bad_magic() {
+        let test_id = rand::random::<u64>();
+        let mut store = get_test_chainstore(Some(test_id)).unwrap();
+
+        let metadata = unsafe { store.get_metadata_mut().unwrap() };
+        metadata.magic = 0xBAD0_FACE;
+        store.flush().unwrap();
+
+        let err = match get_test_chainstore(Some(test_id)) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(
+            matches!(err, ChainstoreError::Other(ref msg) if msg.contains("bad database magic")),
+            "Expected Other with bad database magic message, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn propagates_internal_from_unsupported_schema() {
+        let test_id = rand::random::<u64>();
+        let mut store = get_test_chainstore(Some(test_id)).unwrap();
+
+        let metadata = unsafe { store.get_metadata_mut().unwrap() };
+        metadata.version = FLAT_CHAINSTORE_VERSION + 99;
+        store.flush().unwrap();
+
+        let err = match get_test_chainstore(Some(test_id)) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(
+            matches!(err, ChainstoreError::Other(ref msg) if msg.contains("unsupported schema version")),
+            "Expected Other with unsupported schema version message, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn propagates_internal_from_oversized_index() {
+        // index values >= 0x8000_0000 are out of bounds for 31-bit indexes
+        let err = Index::new(0x8000_0000).unwrap_err();
+        assert!(
+            matches!(err, ChainstoreError::Other(ref msg) if msg.contains("exceeds 31-bit limit")),
+            "Expected Other with exceeds 31-bit limit message, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn propagates_internal_from_capacity_exceeded() {
+        let store = get_test_chainstore(None).unwrap();
+
+        // try to access an index beyond the header file capacity (32_768)
+        let result = unsafe { store.get_disk_header(Index::new(32_768).unwrap()) };
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ChainstoreError::Other(ref msg) if msg.contains("exceeds file capacity")),
+            "Expected Other with exceeds file capacity message, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn propagates_invalid_validation_index() {
+        let mut store = get_test_chainstore(None).unwrap();
+        let genesis = genesis_block(Network::Regtest);
+
+        // save an orphan header, then point validation_index to it, orphan headers
+        // don't have a stored height, so save_roots_for_block must surface
+        // InvalidValidationIndex instead of HeaderNotFound
+        let mut orphan_header = genesis.header;
+        orphan_header.nonce = orphan_header.nonce.wrapping_add(1);
+        let orphan_hash = orphan_header.block_hash();
+        store
+            .save_header(&DiskBlockHeader::Orphan(orphan_header))
+            .unwrap();
+
+        let metadata = unsafe { store.get_metadata_mut().unwrap() };
+        metadata.validation_index = orphan_hash;
+
+        let err = store.save_roots_for_block(vec![0u8], 0).unwrap_err();
+        assert!(matches!(err, ChainstoreError::InvalidValidationIndex));
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -71,10 +71,6 @@
 
 extern crate std;
 
-use core::error;
-use core::fmt;
-use core::fmt::Display;
-use core::fmt::Formatter;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 use std::fs;
@@ -83,7 +79,6 @@ use std::fs::File;
 use std::fs::OpenOptions;
 #[cfg(unix)]
 use std::fs::Permissions;
-use std::io;
 use std::io::Seek;
 use std::io::SeekFrom;
 #[cfg(unix)]
@@ -96,7 +91,6 @@ use std::sync::PoisonError;
 
 use bitcoin::BlockHash;
 use bitcoin::hashes::Hash;
-use floresta_common::impl_error_from;
 use floresta_common::prelude::*;
 use index_impl::Index;
 use lru::LruCache;
@@ -108,8 +102,18 @@ use twox_hash::XxHash3_64;
 
 use crate::BestChain;
 use crate::ChainStore;
-use crate::DatabaseError;
 use crate::DiskBlockHeader;
+use crate::pruned_utreexo::chainstore::ChainstoreError;
+// MAX_ACCUMULATOR_SIZE is defined in chainstore and re-exported from the crate root,
+// so we pull it in through the chainstore path to keep the single source of truth.
+use crate::pruned_utreexo::chainstore::MAX_ACCUMULATOR_SIZE;
+
+/// Converts a standard I/O error into a [`ChainstoreError::Other`]
+impl From<std::io::Error> for ChainstoreError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Other(e.to_string())
+    }
+}
 
 /// The magic number we use to make sure we're reading the right file
 ///
@@ -123,16 +127,6 @@ const FLAT_CHAINSTORE_VERSION: u32 = 1;
 /// We use a LRU cache to keep the last n blocks we've touched, so we don't need to do a map search
 /// again. This is the type of our cache
 type CacheType = LruCache<BlockHash, DiskBlockHeader>;
-
-/// The maximum theoretical size of the Utreexo accumulator.
-///
-/// In the worst case that all leaves are filled:
-/// * The accumulator can have up to 64 roots
-/// * Each root is 32 bytes
-/// * The number of leaves is expressed as a [`u64`]
-///
-/// 64 (MAX_ROOTS) * 32 bytes (ROOT_SIZE) + 8 bytes (LEAF_COUNT) = 2056 bytes
-pub const MAX_ACCUMULATOR_SIZE: usize = 2056;
 
 #[derive(Clone)]
 /// Configuration for our flat chain store. See each field for more information
@@ -235,7 +229,9 @@ enum IndexBucket {
 
 /// A simple index implementation with safe API
 mod index_impl {
-    use super::FlatChainstoreError;
+    use floresta_common::prelude::*;
+
+    use crate::pruned_utreexo::chainstore::ChainstoreError;
 
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -255,20 +251,22 @@ mod index_impl {
         const INDEX_MASK: u32 = 0x7FFF_FFFF;
 
         /// Create a new mainchain entry (MSB is zero)
-        pub fn new(index: u32) -> Result<Self, FlatChainstoreError> {
+        pub fn new(index: u32) -> Result<Self, ChainstoreError> {
             if index >= Self::FORK_BIT {
-                // Index value is out of bounds for our 31-bit indexes
-                return Err(FlatChainstoreError::OversizedIndex);
+                return Err(ChainstoreError::Other(format!(
+                    "index value {index} exceeds 31-bit limit"
+                )));
             }
 
             Ok(Self(index))
         }
 
         /// Create a new fork entry (MSB is set)
-        pub fn new_fork(index: u32) -> Result<Self, FlatChainstoreError> {
+        pub fn new_fork(index: u32) -> Result<Self, ChainstoreError> {
             if index >= Self::FORK_BIT {
-                // Index value is out of bounds for our 31-bit indexes
-                return Err(FlatChainstoreError::OversizedIndex);
+                return Err(ChainstoreError::Other(format!(
+                    "index value {index} exceeds 31-bit limit"
+                )));
             }
 
             Ok(Self(index | Self::FORK_BIT))
@@ -356,96 +354,6 @@ struct Metadata {
     checksum: DbCheckSum,
 }
 
-#[derive(Debug)]
-/// Errors that can happen whilst interacting with the [`FlatChainStore`].
-pub enum FlatChainstoreError {
-    /// An I/O error.
-    ///
-    /// See the inner error for more information.
-    Io(io::Error),
-
-    /// The requested block header was not found in the [`FlatChainStore`].
-    HeaderNotFound,
-
-    /// Failed to add a block header to the [`FlatChainStore`] due to a full index.
-    FullIndex,
-
-    /// Attempted to create an index larger than 31 bits.
-    OversizedIndex,
-
-    /// Attempted to open a [`FlatChainStore`] database using an unsupported schema.
-    UnsupportedSchema(u32),
-
-    /// The cache lock is poisoned.
-    PoisonedLock,
-
-    /// Invalid value for the database magic.
-    ///
-    /// Usually indicates that the database is corrupted.
-    BadMagic(u32),
-
-    /// The accumulator is larger than [`MAX_ACCUMULATOR_SIZE`].
-    OversizedAccumulator,
-
-    /// The [`FlatChainStore`] has a bad metadata file.
-    InvalidMetadataPointer,
-
-    /// The [`FlatChainStore`] is corrupted.
-    CorruptedDatabase,
-
-    /// No height present on the validation index.
-    ///
-    /// Usually indicates a fork or invalid chain.
-    InvalidValidationIndex,
-}
-
-impl Display for FlatChainstoreError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "FlatChainStore I/O Error: {e:?}"),
-            Self::HeaderNotFound => write!(
-                f,
-                "The requested block header was not found in the FlatChainStore"
-            ),
-            Self::FullIndex => write!(
-                f,
-                "Failed to add a block to the FlatChainStore due to a full index"
-            ),
-            Self::OversizedIndex => write!(f, "Attempted to create an index larger than 31 bits"),
-            Self::UnsupportedSchema(schema_version) => write!(
-                f,
-                "Attempted to open the FlatChainStore database using an unsupported schema with version={}",
-                schema_version
-            ),
-            Self::PoisonedLock => write!(f, "The FlatChainStore's cache lock is poisoned"),
-            Self::BadMagic(magic) => write!(f, "The FlatChainStore has bad magic={}", magic),
-            Self::OversizedAccumulator => write!(
-                f,
-                "The FlatChainStore's accumulator is larger than the maximum value of {}",
-                MAX_ACCUMULATOR_SIZE
-            ),
-            Self::InvalidMetadataPointer => write!(f, "The FlatChainStore has invalid metadata"),
-            Self::CorruptedDatabase => write!(f, "The FlatChainStore is corrupted"),
-            Self::InvalidValidationIndex => {
-                write!(f, "The FlatChainStore has an invalid validation index")
-            }
-        }
-    }
-}
-
-impl error::Error for FlatChainstoreError {}
-
-/// Need this to use [FlatChainstoreError] as a [DatabaseError] in [ChainStore]
-impl DatabaseError for FlatChainstoreError {}
-
-impl_error_from!(FlatChainstoreError, std::io::Error, Io);
-
-impl From<PoisonError<MutexGuard<'_, CacheType>>> for FlatChainstoreError {
-    fn from(_: PoisonError<MutexGuard<'_, CacheType>>) -> Self {
-        Self::PoisonedLock
-    }
-}
-
 /// A hash map implementation that maps block hashes to u32 indexes. Indexes are stored scattered
 /// across the memory-mapped file and accessed via `hash_map_find_pos`. We keep track of how many
 /// buckets are occupied in the metadata file (so we can re-hash the map when needed).
@@ -474,7 +382,7 @@ impl BlockIndex {
     ///
     /// If we have enough changes that we don't want to lose, we should flush the index map to disk.
     /// This makes sure the indexes are persisted, and we can recover them in case of a crash.
-    fn flush(&self) -> Result<(), FlatChainstoreError> {
+    fn flush(&self) -> Result<(), ChainstoreError> {
         self.index_map.flush()?;
 
         Ok(())
@@ -489,13 +397,13 @@ impl BlockIndex {
         &self,
         hash: BlockHash,
         index: Index,
-        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, FlatChainstoreError>,
-    ) -> Result<bool, FlatChainstoreError> {
+        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, ChainstoreError>,
+    ) -> Result<bool, ChainstoreError> {
         let pos = unsafe { self.hash_map_find_pos(hash, get_header_by_index) }?;
 
         match pos {
             IndexBucket::Empty { ptr } => {
-                unsafe { ptr.write(index) }
+                unsafe { ptr.write(index) };
                 Ok(true)
             }
 
@@ -513,8 +421,8 @@ impl BlockIndex {
     unsafe fn get_index_for_hash(
         &self,
         hash: BlockHash,
-        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, FlatChainstoreError>,
-    ) -> Result<Option<(Index, DiskBlockHeader)>, FlatChainstoreError> {
+        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, ChainstoreError>,
+    ) -> Result<Option<(Index, DiskBlockHeader)>, ChainstoreError> {
         match unsafe { self.hash_map_find_pos(hash, get_header_by_index) }? {
             IndexBucket::Empty { .. } => Ok(None),
             IndexBucket::Occupied { ptr, header } => Ok(Some((unsafe { *ptr }, header))),
@@ -531,8 +439,8 @@ impl BlockIndex {
     unsafe fn hash_map_find_pos(
         &self,
         block_hash: BlockHash,
-        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, FlatChainstoreError>,
-    ) -> Result<IndexBucket, FlatChainstoreError> {
+        get_header_by_index: impl Fn(Index) -> Result<HashedDiskHeader, ChainstoreError>,
+    ) -> Result<IndexBucket, ChainstoreError> {
         let mut hash = Self::index_hash_fn(block_hash) as usize;
 
         // Retrieve the base pointer to the start of the memory-mapped index
@@ -569,7 +477,7 @@ impl BlockIndex {
         }
 
         // If we reach here, it means the index is full. We should re-hash the map
-        Err(FlatChainstoreError::FullIndex)
+        Err(ChainstoreError::FullIndex)
     }
 
     /// The (short) hash function we use to compute where in the map a given index should be
@@ -634,7 +542,7 @@ impl FlatChainStore {
     /// Creates a new storage, given a configuration
     ///
     /// If any of the I/O operations fail, this function should return an error
-    fn create_chain_store(config: FlatChainStoreConfig) -> Result<Self, FlatChainstoreError> {
+    fn create_chain_store(config: FlatChainStoreConfig) -> Result<Self, ChainstoreError> {
         let file_mode = config.file_permission.unwrap_or(0o600);
         let datadir: &Path = config.path.as_ref();
 
@@ -721,7 +629,7 @@ impl FlatChainStore {
     }
 
     /// Opens a new storage. If it already exists, just load. If not, create a new one
-    pub fn new(config: FlatChainStoreConfig) -> Result<Self, FlatChainstoreError> {
+    pub fn new(config: FlatChainStoreConfig) -> Result<Self, ChainstoreError> {
         let datadir = &config.path;
         let metadata_path = datadir.join("metadata.bin");
         let file_mode = config.file_permission.unwrap_or(0o600);
@@ -746,16 +654,16 @@ impl FlatChainStore {
         let metadata = unsafe {
             metadata
                 .as_ref()
-                .ok_or(FlatChainstoreError::InvalidMetadataPointer)?
+                .ok_or(ChainstoreError::InvalidMetadataPointer)?
         };
 
         // check the magic number and version
         if metadata.version > FLAT_CHAINSTORE_VERSION {
-            return Err(FlatChainstoreError::UnsupportedSchema(metadata.version));
+            return Err(ChainstoreError::UnsupportedSchema(metadata.version));
         }
 
         if metadata.magic != FLAT_CHAINSTORE_MAGIC {
-            return Err(FlatChainstoreError::BadMagic(metadata.magic));
+            return Err(ChainstoreError::BadMagic(metadata.magic));
         }
 
         let index_path = datadir.join("blocks_index.bin");
@@ -800,11 +708,11 @@ impl FlatChainStore {
         &mut self,
         hash: BlockHash,
         index: Index,
-    ) -> Result<(), FlatChainstoreError> {
+    ) -> Result<(), ChainstoreError> {
         let metadata = unsafe { self.get_metadata() }?;
         let next_occupancy = metadata.block_index_occupancy + 1;
         if next_occupancy >= metadata.index_capacity {
-            return Err(FlatChainstoreError::FullIndex);
+            return Err(ChainstoreError::FullIndex);
         }
         let is_new = unsafe {
             self.block_index
@@ -828,12 +736,12 @@ impl FlatChainStore {
     /// enough for random errors in a file.
     ///
     /// [xxHash]: https://github.com/Cyan4973/xxHash
-    fn check_integrity(&self) -> Result<(), FlatChainstoreError> {
+    fn check_integrity(&self) -> Result<(), ChainstoreError> {
         let computed_checksum = self.compute_checksum();
         let metadata = unsafe { self.get_metadata()? };
 
         if metadata.checksum != computed_checksum {
-            return Err(FlatChainstoreError::CorruptedDatabase);
+            return Err(ChainstoreError::CorruptedDatabase);
         }
 
         Ok(())
@@ -883,7 +791,7 @@ impl FlatChainStore {
         path: impl AsRef<Path>,
         size: usize,
         _mode: u32,
-    ) -> Result<MmapMut, FlatChainstoreError> {
+    ) -> Result<MmapMut, ChainstoreError> {
         let file = OpenOptions::new()
             // Set read and write access
             .read(true)
@@ -911,7 +819,7 @@ impl FlatChainStore {
     unsafe fn get_disk_header(
         &self,
         index: Index,
-    ) -> Result<&HashedDiskHeader, FlatChainstoreError> {
+    ) -> Result<&HashedDiskHeader, ChainstoreError> {
         let metadata = unsafe { self.get_metadata()? };
         let (max_size, base_ptr) = match index.is_main_chain() {
             true => (metadata.headers_file_size, self.headers.as_ptr()),
@@ -920,7 +828,7 @@ impl FlatChainStore {
 
         let index = index.index() as usize;
         if index >= max_size {
-            return Err(FlatChainstoreError::FullIndex);
+            return Err(ChainstoreError::FullIndex);
         }
 
         // SAFETY: we've checked index < max_size
@@ -929,7 +837,7 @@ impl FlatChainStore {
 
         // Uninitialized memory means we haven't written anything here yet
         if header.hash == BlockHash::all_zeros() {
-            return Err(FlatChainstoreError::HeaderNotFound);
+            return Err(ChainstoreError::HeaderNotFound);
         }
 
         Ok(header)
@@ -940,7 +848,7 @@ impl FlatChainStore {
     unsafe fn get_disk_header_mut(
         &mut self,
         index: Index,
-    ) -> Result<&mut HashedDiskHeader, FlatChainstoreError> {
+    ) -> Result<&mut HashedDiskHeader, ChainstoreError> {
         let metadata = unsafe { self.get_metadata()? };
         let (max_size, base_ptr) = match index.is_main_chain() {
             true => (metadata.headers_file_size, self.headers.as_ptr()),
@@ -949,7 +857,7 @@ impl FlatChainStore {
 
         let index = index.index() as usize;
         if index >= max_size {
-            return Err(FlatChainstoreError::FullIndex);
+            return Err(ChainstoreError::FullIndex);
         }
 
         // SAFETY: we've checked index < max_size
@@ -958,7 +866,7 @@ impl FlatChainStore {
         Ok(unsafe { &mut *ptr })
     }
 
-    unsafe fn do_save_height(&mut self, best_block: &BestChain) -> Result<(), FlatChainstoreError> {
+    unsafe fn do_save_height(&mut self, best_block: &BestChain) -> Result<(), ChainstoreError> {
         let metadata = unsafe { self.get_metadata_mut() }?;
 
         metadata.best_block = best_block.best_block;
@@ -980,7 +888,7 @@ impl FlatChainStore {
         Ok(())
     }
 
-    unsafe fn get_best_chain(&self) -> Result<BestChain, FlatChainstoreError> {
+    unsafe fn get_best_chain(&self) -> Result<BestChain, ChainstoreError> {
         let metadata = unsafe { self.get_metadata()? };
 
         Ok(BestChain {
@@ -1001,7 +909,7 @@ impl FlatChainStore {
     unsafe fn get_header_by_hash(
         &self,
         hash: BlockHash,
-    ) -> Result<Option<DiskBlockHeader>, FlatChainstoreError> {
+    ) -> Result<Option<DiskBlockHeader>, ChainstoreError> {
         let result = unsafe {
             self.block_index
                 .get_index_for_hash(hash, |height| self.get_disk_header(height).copied())
@@ -1010,12 +918,12 @@ impl FlatChainStore {
         Ok(result)
     }
 
-    unsafe fn get_metadata(&self) -> Result<&Metadata, FlatChainstoreError> {
+    unsafe fn get_metadata(&self) -> Result<&Metadata, ChainstoreError> {
         let ptr = self.metadata.as_ptr() as *const Metadata;
         Ok(unsafe { ptr.as_ref() }.expect("Infallible: we already validated this pointer"))
     }
 
-    unsafe fn get_metadata_mut(&mut self) -> Result<&mut Metadata, FlatChainstoreError> {
+    unsafe fn get_metadata_mut(&mut self) -> Result<&mut Metadata, ChainstoreError> {
         let ptr = self.metadata.as_ptr() as *mut Metadata;
         Ok(unsafe { ptr.as_mut() }.expect("Infallible: we already validated this pointer"))
     }
@@ -1027,7 +935,7 @@ impl FlatChainStore {
     unsafe fn write_header_to_storage(
         &mut self,
         header: DiskBlockHeader,
-    ) -> Result<(), FlatChainstoreError> {
+    ) -> Result<(), ChainstoreError> {
         let height = header
             .try_height()
             .expect("Infallible: this function is only called for best chain blocks");
@@ -1083,7 +991,7 @@ impl FlatChainStore {
     unsafe fn save_fork_block(
         &mut self,
         header: DiskBlockHeader,
-    ) -> Result<(), FlatChainstoreError> {
+    ) -> Result<(), ChainstoreError> {
         let fork_blocks = unsafe { self.get_metadata() }?.fork_count;
         let index = Index::new_fork(fork_blocks)?;
         let pos = unsafe { self.get_disk_header_mut(index) }?;
@@ -1104,7 +1012,7 @@ impl FlatChainStore {
         Ok(())
     }
 
-    unsafe fn do_flush(&mut self) -> Result<(), FlatChainstoreError> {
+    unsafe fn do_flush(&mut self) -> Result<(), ChainstoreError> {
         self.headers.flush()?;
         self.block_index.flush()?;
         self.fork_headers.flush()?;
@@ -1128,7 +1036,7 @@ impl FlatChainStore {
 }
 
 impl ChainStore for FlatChainStore {
-    type Error = FlatChainstoreError;
+    type Error = ChainstoreError;
 
     fn check_integrity(&self) -> Result<(), Self::Error> {
         self.check_integrity()
@@ -1169,7 +1077,7 @@ impl ChainStore for FlatChainStore {
             .get_header(&metadata.validation_index)?
             .map(|h| {
                 h.try_height()
-                    .map_err(|_| FlatChainstoreError::InvalidValidationIndex)
+                    .map_err(|_| ChainstoreError::InvalidValidationIndex)
             })
             .transpose()?
             .unwrap_or(0);
@@ -1183,20 +1091,20 @@ impl ChainStore for FlatChainStore {
 
             self.accumulator_file
                 .set_len(pos)
-                .map_err(FlatChainstoreError::Io)?;
+                .map_err(ChainstoreError::Io)?;
         }
 
         let pos = self.accumulator_file.seek(SeekFrom::End(0))?;
         let size = roots.len();
 
         if size > MAX_ACCUMULATOR_SIZE {
-            return Err(FlatChainstoreError::OversizedAccumulator);
+            return Err(ChainstoreError::OversizedAccumulator);
         }
 
         let header = unsafe { self.get_disk_header_mut(index)? };
         // Only write to this header if we actually have it in our store
         if header.hash == BlockHash::all_zeros() {
-            return Err(FlatChainstoreError::HeaderNotFound);
+            return Err(ChainstoreError::HeaderNotFound);
         }
 
         header.acc_pos = pos as u32;
@@ -1251,7 +1159,7 @@ impl ChainStore for FlatChainStore {
         unsafe {
             match self.get_disk_header(index) {
                 Ok(header) => Ok(Some(header.header)),
-                Err(FlatChainstoreError::HeaderNotFound) => Ok(None),
+                Err(ChainstoreError::HeaderNotFound) => Ok(None),
                 Err(e) => Err(e),
             }
         }
@@ -1290,7 +1198,7 @@ impl ChainStore for FlatChainStore {
         unsafe {
             match self.get_disk_header(index) {
                 Ok(header) => Ok(Some(header.hash)),
-                Err(FlatChainstoreError::HeaderNotFound) => Ok(None),
+                Err(ChainstoreError::HeaderNotFound) => Ok(None),
                 Err(e) => Err(e),
             }
         }
@@ -1358,7 +1266,7 @@ pub mod migrate_v0_to_v1 {
     pub fn maybe_migrate(
         metadata_path: impl AsRef<Path>,
         mode: u32,
-    ) -> Result<bool, FlatChainstoreError> {
+    ) -> Result<bool, ChainstoreError> {
         let metadata_path = metadata_path.as_ref();
 
         match fs::metadata(metadata_path) {
@@ -1392,7 +1300,7 @@ pub mod migrate_v0_to_v1 {
     }
 
     /// Initialize a read-only mmap
-    pub(super) fn init_mmap(file_path: &Path, size: usize) -> Result<Mmap, FlatChainstoreError> {
+    pub(super) fn init_mmap(file_path: &Path, size: usize) -> Result<Mmap, ChainstoreError> {
         let file = OpenOptions::new().read(true).open(file_path)?;
         let mmap = unsafe { MmapOptions::new().len(size).map(&file)? };
         Ok(mmap)
@@ -1420,7 +1328,7 @@ mod tests {
     use super::FLAT_CHAINSTORE_VERSION;
     use super::FlatChainStore;
     use super::FlatChainStoreConfig;
-    use super::FlatChainstoreError;
+    use super::ChainstoreError;
     use super::HashedDiskHeader;
     use super::Index;
     use crate::AssumeValidArg;
@@ -1464,7 +1372,7 @@ mod tests {
         );
     }
 
-    fn get_test_chainstore(id: Option<u64>) -> Result<FlatChainStore, FlatChainstoreError> {
+    fn get_test_chainstore(id: Option<u64>) -> Result<FlatChainStore, ChainstoreError> {
         let test_id = id.unwrap_or_else(rand::random::<u64>);
 
         let config = FlatChainStoreConfig {
@@ -1513,12 +1421,12 @@ mod tests {
             let store_id = tweak_version_and_magic(version, FLAT_CHAINSTORE_MAGIC);
 
             match get_test_chainstore(Some(store_id)) {
-                Err(FlatChainstoreError::UnsupportedSchema(v)) if v == version => {}
+                Err(ChainstoreError::UnsupportedSchema(v)) if v == version => {}
                 Err(e) => panic!(
-                    "Should have failed with `FlatChainstoreError::DbTooNew({version})`, instead we got {e:?}"
+                    "Should have failed with `ChainstoreError::DbTooNew({version})`, instead we got {e:?}"
                 ),
                 Ok(_) => panic!(
-                    "Should have failed with `FlatChainstoreError::DbTooNew({version})`, instead we got `Ok`"
+                    "Should have failed with `ChainstoreError::DbTooNew({version})`, instead we got `Ok`"
                 ),
             }
         }
@@ -1531,12 +1439,12 @@ mod tests {
             let store_id = tweak_version_and_magic(FLAT_CHAINSTORE_VERSION, magic);
 
             match get_test_chainstore(Some(store_id)) {
-                Err(FlatChainstoreError::BadMagic(m)) if m == magic => {}
+                Err(ChainstoreError::BadMagic(m)) if m == magic => {}
                 Err(e) => panic!(
-                    "Should have failed with `FlatChainstoreError::InvalidMagic({magic})`, instead we got {e:?}"
+                    "Should have failed with `ChainstoreError::InvalidMagic({magic})`, instead we got {e:?}"
                 ),
                 Ok(_) => panic!(
-                    "Should have failed with `FlatChainstoreError::InvalidMagic({magic})`, instead we got `Ok`"
+                    "Should have failed with `ChainstoreError::InvalidMagic({magic})`, instead we got `Ok`"
                 ),
             }
         }
@@ -1678,19 +1586,19 @@ mod tests {
         // Test that the inner header-fetching function returns the proper error for mainnet indices
         unsafe {
             match store.get_disk_header(Index::new(151).unwrap()) {
-                Err(FlatChainstoreError::HeaderNotFound) => (),
+                Err(ChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found a header at height 151: {val:?}"),
             }
             // Last available position
             match store.get_disk_header(Index::new(32_767).unwrap()) {
-                Err(FlatChainstoreError::HeaderNotFound) => (),
+                Err(ChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found a header at height 32767: {val:?}"),
             }
             // Exceeds header file capacity
             match store.get_disk_header(Index::new(32_768).unwrap()) {
-                Err(FlatChainstoreError::FullIndex) => (),
+                Err(ChainstoreError::FullIndex) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => {
                     panic!("Should not have found a header exceeding file capacity: {val:?}")
@@ -1701,19 +1609,19 @@ mod tests {
         // Test that the inner header-fetching function returns the proper error for fork indices
         unsafe {
             match store.get_disk_header(Index::new_fork(0).unwrap()) {
-                Err(FlatChainstoreError::HeaderNotFound) => (),
+                Err(ChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found any fork header: {val:?}"),
             }
             // Last available position
             match store.get_disk_header(Index::new_fork(16_383).unwrap()) {
-                Err(FlatChainstoreError::HeaderNotFound) => (),
+                Err(ChainstoreError::HeaderNotFound) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => panic!("Should not have found any fork header: {val:?}"),
             }
             // Exceeds fork file capacity
             match store.get_disk_header(Index::new_fork(16_384).unwrap()) {
-                Err(FlatChainstoreError::FullIndex) => (),
+                Err(ChainstoreError::FullIndex) => (),
                 Err(e) => panic!("Unexpected err: {e:?}"),
                 Ok(val) => {
                     panic!("Should not have found a header exceeding file capacity: {val:?}")
@@ -1925,7 +1833,7 @@ mod tests {
         let result = store.save_roots_for_block(acc.clone(), 10);
 
         match result {
-            Err(FlatChainstoreError::HeaderNotFound) => (),
+            Err(ChainstoreError::HeaderNotFound) => (),
             Err(e) => panic!("Unexpected err: {e:?}"),
             Ok(_) => panic!("Should not have been able to save roots for a block we don't have"),
         }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1091,7 +1091,7 @@ mod test {
 
         // Create test_chain_state
         let test_id = rand::random::<u32>();
-        let conf = FlatChainStoreConfig::new(format!("./tmp-db/{test_id}.floresta/"));
+        let conf = FlatChainStoreConfig::new_with_path(format!("./tmp-db/{test_id}.floresta/"));
         let chainstore = FlatChainStore::new(conf).unwrap();
         let chain = ChainState::<FlatChainStore>::open(
             chainstore,

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -709,7 +709,8 @@ impl Florestad {
         network: Network,
         assume_valid: AssumeValidArg,
     ) -> Result<ChainState<ChainStore>, FlorestadError> {
-        let chain_store_config = FlatChainStoreConfig::new(datadir.as_ref().join("chaindata"));
+        let chain_store_config =
+            FlatChainStoreConfig::new_with_path(datadir.as_ref().join("chaindata"));
 
         let chain_store = ChainStore::new(chain_store_config)
             .map_err(|e| FlorestadError::CouldNotLoadFlatChainStore(e.into()))?;

--- a/crates/floresta-wire/src/p2p_wire/block_proof.rs
+++ b/crates/floresta-wire/src/p2p_wire/block_proof.rs
@@ -354,7 +354,7 @@ mod utreexo_proof_tests {
             assume_valid: AssumeValidArg,
         ) -> ChainState<FlatChainStore> {
             let datadir = format!("./tmp-db/{}.sync_node", rand::random::<u32>());
-            let config = FlatChainStoreConfig::new(datadir);
+            let config = FlatChainStoreConfig::new_with_path(datadir);
             let store = FlatChainStore::new(config).expect("Failed to create chain store");
             ChainState::open(store, network, assume_valid).expect("Failed to open chain state")
         }

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -299,7 +299,7 @@ pub async fn setup_node(
     datadir: impl AsRef<Path>,
     num_blocks: usize,
 ) -> Arc<ChainState<FlatChainStore>> {
-    let config = FlatChainStoreConfig::new(&datadir);
+    let config = FlatChainStoreConfig::new_with_path(&datadir);
 
     let chainstore = FlatChainStore::new(config).unwrap();
     let mempool = Arc::new(Mutex::new(Mempool::new(1000)));

--- a/crates/floresta/examples/chainstate-builder.rs
+++ b/crates/floresta/examples/chainstate-builder.rs
@@ -27,7 +27,7 @@ async fn main() {
     // the block data after we validated it. This saves a lot of space, but it means that
     // we can't serve blocks to other nodes or rescan the blockchain without downloading
     // it again.
-    let chain_store_config = FlatChainStoreConfig::new(DATA_DIR);
+    let chain_store_config = FlatChainStoreConfig::new_with_path(DATA_DIR);
     let chain_store =
         FlatChainStore::new(chain_store_config).expect("failed to open the blockchain database");
 

--- a/crates/floresta/examples/indexer.rs
+++ b/crates/floresta/examples/indexer.rs
@@ -87,7 +87,7 @@ async fn main() {
     // the block data after we have validated it. This saves a lot of space, but it means that
     // we can't serve blocks to other nodes or rescan the blockchain without downloading
     // it again.
-    let chain_store_config = FlatChainStoreConfig::new(DATA_DIR);
+    let chain_store_config = FlatChainStoreConfig::new_with_path(DATA_DIR);
     let chain_store =
         FlatChainStore::new(chain_store_config).expect("failed to open the blockchain database");
 

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -41,7 +41,7 @@ async fn main() {
     // the block data after we have validated it. This saves a lot of space, but it means that
     // we can't serve blocks to other nodes or rescan the blockchain without downloading
     // it again.
-    let chain_store_config = FlatChainStoreConfig::new(DATA_DIR);
+    let chain_store_config = FlatChainStoreConfig::new_with_path(DATA_DIR);
     let chain_store =
         FlatChainStore::new(chain_store_config).expect("failed to open the blockchain database");
 


### PR DESCRIPTION
### Description and Notes

related issue: #1053

This PR improves systematic error handling in `flat_chain_store.rs`, focusing on clearer error semantics and correct propagation paths

#### what changed

- reworked chainstore error modeling to use `ChainstoreError` with clearer variants and messages
- preserved error sources for internal failures via `Internal(Box<dyn Error + Send + Sync>)`
- improved index/probing error behavior so not-found/full-index paths are handled correctly
- added explicit propagation for `InvalidValidationIndex` in `save_roots_for_block`
- kept module-level strict clippy guards for error-handling pattern

### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above