### PR TITLE
node/florestad: use `PathBuf` and `impl AsRef<Path>`

### DIFF
--- a/bin/florestad/src/cli.rs
+++ b/bin/florestad/src/cli.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::path::PathBuf;
+
 use bitcoin::BlockHash;
 use bitcoin::Network;
 #[cfg(unix)]
@@ -21,7 +23,7 @@ pub struct Cli {
 
     #[arg(short, long, value_name = "FILE")]
     /// Sets a custom config file
-    pub config_file: Option<String>,
+    pub config_file: Option<PathBuf>,
 
     #[arg(short, long, default_value_t=Network::Bitcoin)]
     /// Which network should we use
@@ -41,7 +43,7 @@ pub struct Cli {
     /// Where should we store data. This is the directory where we'll store the chainstate,
     /// the wallet, the logs, the compact block filters, the Utreexo state, etc.
     /// Defaults to `~/.floresta`. The passed value should be an absolute path.
-    pub data_dir: Option<String>,
+    pub data_dir: Option<PathBuf>,
 
     #[arg(long)]
     /// Whether Compact Block Filters should be disabled
@@ -146,7 +148,7 @@ pub struct Cli {
     /// ```shell
     /// openssl genpkey -algorithm RSA -out key.pem -pkeyopt rsa_keygen_bits:2048
     /// ```
-    pub tls_key_path: Option<String>,
+    pub tls_key_path: Option<PathBuf>,
 
     #[arg(long, value_name = "PATH")]
     /// TLS certificate path (defaults to `{data_dir}/tls/cert.pem`).
@@ -155,7 +157,7 @@ pub struct Cli {
     /// ```shell
     /// openssl req -x509 -new -key key.pem -out cert.pem -days 365 -subj "/CN=localhost"
     /// ```
-    pub tls_cert_path: Option<String>,
+    pub tls_cert_path: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
     /// Whether we should try to connect with peers using the old, unencrypted V1 P2P protocol,
@@ -174,7 +176,7 @@ pub struct Cli {
     /// In case you're using the daemon option, and you want to know the process ID, you can
     /// write it to a file. This option should be an absolute path to a file. Usually, you'd
     /// write it to `$DATA_DIR/florestad.pid`.
-    pub pid_file: Option<String>,
+    pub pid_file: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
     /// Whether backfill should be disabled

--- a/bin/florestad/src/logger.rs
+++ b/bin/florestad/src/logger.rs
@@ -18,6 +18,7 @@
 use core::fmt;
 use std::fs;
 use std::io;
+use std::path::Path;
 use std::process::exit;
 
 use tracing::Level;
@@ -246,11 +247,13 @@ where
 /// Panics if a global [`tracing`] subscriber has already been
 /// installed (e.g. if this function is called more than once).
 pub fn start_logger(
-    data_directory: &String,
+    datadir: impl AsRef<Path>,
     log_to_file: bool,
     log_to_stdout: bool,
     log_level: Level,
 ) -> Result<Option<WorkerGuard>, io::Error> {
+    let datadir = datadir.as_ref();
+
     let is_debug = log_level >= Level::DEBUG;
     let make_filter = || {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level.to_string()))
@@ -267,17 +270,17 @@ pub fn start_logger(
     });
 
     if log_to_file {
-        let file_path = format!("{}/{}", data_directory, LOG_FILE);
+        let log_file_path = datadir.join(LOG_FILE);
 
-        // Validate the log file path (`<data_directory>/<LOG_FILE>`).
+        // Validate the log file path (`<datadir>/<LOG_FILE>`).
         let _ = fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&file_path)
+            .open(&log_file_path)
             .map_err(|e| {
                 eprintln!(
-                    "Failed to create log file at {}/{LOG_FILE}: {e}",
-                    data_directory
+                    "Failed to create log file at path={}: {e}",
+                    log_file_path.display()
                 );
                 exit(1)
             });
@@ -286,7 +289,7 @@ pub fn start_logger(
     // Formatter for events destined to the log file.
     let mut guard = None;
     let fmt_layer_logfile = log_to_file.then(|| {
-        let file_appender = tracing_appender::rolling::never(data_directory, LOG_FILE);
+        let file_appender = tracing_appender::rolling::never(datadir, LOG_FILE);
         let (non_blocking, file_guard) = tracing_appender::non_blocking(file_appender);
         guard = Some(file_guard);
         layer()

--- a/bin/florestad/src/main.rs
+++ b/bin/florestad/src/main.rs
@@ -23,6 +23,7 @@ mod logger;
 
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::exit;
 use std::sync::Arc;
@@ -47,17 +48,18 @@ fn main() {
     let params = Cli::parse();
     params.validate();
 
-    // If not provided defaults to `$HOME/.floresta`. Uses a subdirectory for non-mainnet networks.
-    let data_dir = data_dir_path(params.data_dir, params.network);
+    // If not provided, defaults to `$HOME/.floresta`.
+    // Uses a subdirectory for non-mainnet networks.
+    let datadir = datadir_path(params.data_dir, params.network);
 
     // Create the data directory if it doesn't exist
-    fs::create_dir_all(&data_dir).unwrap_or_else(|e| {
-        eprintln!("Could not create data dir {data_dir:?}: {e}");
+    fs::create_dir_all(&datadir).unwrap_or_else(|e| {
+        eprintln!("Could not create data dir {datadir:?}: {e}");
         exit(1);
     });
 
     let config = Config {
-        data_dir,
+        datadir,
         disable_dns_seeds: params.connect.is_some() || params.disable_dns_seeds,
         network: params.network,
         debug: params.debug,
@@ -96,7 +98,7 @@ fn main() {
 
     #[cfg(unix)]
     if params.daemon {
-        let mut daemon = Daemon::new(&config.data_dir);
+        let mut daemon = Daemon::new(&config.datadir);
         if let Some(pid_file) = params.pid_file {
             daemon = daemon.pid_file(pid_file);
         }
@@ -111,7 +113,7 @@ fn main() {
 
     // The guard must stay alive until the end of `main` to flush file logs when dropped.
     let _logger_guard = start_logger(
-        &config.data_dir,
+        &config.datadir,
         config.log_to_file,
         config.log_to_stdout,
         log_level,
@@ -166,27 +168,38 @@ fn main() {
     drop(_logger_guard);
 }
 
-fn data_dir_path(dir: Option<String>, network: Network) -> String {
-    // base dir: provided `dir` or $HOME/.floresta or "./.floresta"
-    let mut base: PathBuf = dir
-        .as_ref()
-        .map(|s| s.trim_end_matches(['/', '\\']).into())
+/// Assemble the data directory [`PathBuf`] for the given [`Network`].
+///
+/// The data directory path is determined in this order:
+/// - If `base_dir` is provided, it is used as-is.
+/// - If `base_dir` is not provided and the `$HOME` environment
+///   variable is set, `$HOME/.floresta` is used.
+/// - If `base_dir` is not provided and the `$HOME` environment
+///   variable is not set, the current directory is used.
+///
+/// For non-mainnet networks, the data directory is suffixed with
+/// the network name (e.g. `<base_dir>/signet`).
+///
+/// Paths with redundant slashes are automatically normalized.
+fn datadir_path(base_dir: Option<impl AsRef<Path>>, network: Network) -> PathBuf {
+    let base_dir = base_dir
+        .map(|p| {
+            let s = p.as_ref().to_string_lossy().replace('\\', "/");
+            Path::new(&s).components().collect::<PathBuf>()
+        })
         .unwrap_or_else(|| {
             dirs::home_dir()
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join(".floresta")
         });
 
-    // network-specific subdir
     match network {
-        Network::Bitcoin => {} // no subdir
-        Network::Signet => base.push("signet"),
-        Network::Testnet => base.push("testnet3"),
-        Network::Testnet4 => base.push("testnet4"),
-        Network::Regtest => base.push("regtest"),
+        Network::Bitcoin => base_dir,
+        Network::Signet => base_dir.join("signet"),
+        Network::Testnet => base_dir.join("testnet3"),
+        Network::Testnet4 => base_dir.join("testnet4"),
+        Network::Regtest => base_dir.join("regtest"),
     }
-
-    base.to_string_lossy().into_owned()
 }
 
 #[cfg(test)]
@@ -194,45 +207,42 @@ mod tests {
     use super::*;
 
     #[test]
+    /// Test that `datadir_path` returns the expected path for the given [`Network`].
     fn test_data_dir_path() {
-        let net = Network::Bitcoin;
+        // (<input path>, <normalized path>)
+        let paths: &[(&str, &str)] = &[
+            ("path/to/dir", "path/to/dir"),
+            ("path/to/dir/", "path/to/dir"),
+            ("path///", "path"),
+            ("path//to//dir//", "path/to/dir"),
+            ("path\\to\\dir", "path/to/dir"),
+        ];
+        let networks: &[(Network, Option<&str>)] = &[
+            (Network::Bitcoin, None),
+            (Network::Signet, Some("signet")),
+            (Network::Testnet, Some("testnet3")),
+            (Network::Testnet4, Some("testnet4")),
+            (Network::Regtest, Some("regtest")),
+        ];
+
+        for &(input_path, normalized_path) in paths {
+            for &(network, suffix) in networks {
+                let expected_path = match suffix {
+                    Some(s) => PathBuf::from(normalized_path).join(s),
+                    None => PathBuf::from(normalized_path),
+                };
+                assert_eq!(datadir_path(Some(input_path), network), expected_path);
+            }
+        }
+
+        // Default path when none is provided
         let default_expected = dirs::home_dir()
             .unwrap_or(PathBuf::from("."))
             .join(".floresta");
 
         assert_eq!(
-            data_dir_path(None, net),
-            default_expected.display().to_string(),
+            datadir_path(None::<&str>, Network::Bitcoin),
+            default_expected
         );
-
-        // Using other made-up directories
-        let mut path = Some("path/to/dir".into());
-        assert_eq!(data_dir_path(path, net), "path/to/dir");
-
-        path = Some("path/to/dir/".into());
-        assert_eq!(data_dir_path(path, net), "path/to/dir");
-
-        // Test removing the '\' separator
-        path = Some(format!("path{}", '\\'));
-        assert_eq!(data_dir_path(path, net), "path");
-
-        // Test removing many separators
-        path = Some("path///".into());
-        assert_eq!(data_dir_path(path, net), "path");
-
-        // Using other networks
-        for &(net, suffix) in &[
-            (Network::Testnet, "testnet3"),
-            (Network::Testnet4, "testnet4"),
-            (Network::Signet, "signet"),
-            (Network::Regtest, "regtest"),
-        ] {
-            let expected = PathBuf::from("path").join(suffix);
-
-            assert_eq!(
-                data_dir_path(Some("path///".into()), net),
-                expected.display().to_string(),
-            );
-        }
     }
 }

--- a/crates/floresta-node/src/config_file.rs
+++ b/crates/floresta-node/src/config_file.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fs;
+use std::path::Path;
+
 use serde::Deserialize;
 
 use crate::error::FlorestadError;
@@ -17,8 +20,9 @@ pub struct ConfigFile {
 }
 
 impl ConfigFile {
-    pub fn from_file(filename: &str) -> Result<Self, FlorestadError> {
-        let file = std::fs::read_to_string(filename)?;
-        Ok(toml::from_str(&file)?)
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, FlorestadError> {
+        let config_file = fs::read_to_string(path.as_ref())?;
+
+        Ok(toml::from_str(&config_file)?)
     }
 }

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::net::AddrParseError;
+use std::path::PathBuf;
 
 use bitcoin::consensus::encode;
 use floresta_chain::BlockValidationErrors;
@@ -73,10 +74,10 @@ pub enum FlorestadError {
     CouldNotGenerateSelfSignedCert(rcgen::Error),
 
     /// Writing a file to the filesystem.
-    CouldNotWriteFile(String, std::io::Error),
+    CouldNotWriteFile(PathBuf, std::io::Error),
 
     /// Data directory doesn't exist or is not writable.
-    InvalidDataDir(String),
+    InvalidDataDir(PathBuf),
 
     /// Obtaining a lock on the data directory.
     CouldNotOpenKvDatabase(KvDatabaseError),
@@ -101,7 +102,7 @@ pub enum FlorestadError {
     FailedToBindElectrumServer(std::io::Error),
 
     /// Failed to create the TLS data directory.
-    CouldNotCreateTLSDataDir(String, std::io::Error),
+    CouldNotCreateTLSDataDir(PathBuf, std::io::Error),
 
     /// Failed to obtain the wallet cache.
     CouldNotObtainWalletCache(WatchOnlyError<KvDatabaseError>),
@@ -162,10 +163,18 @@ impl Display for FlorestadError {
                 write!(f, "Error while generating self-signed certificate: {err}")
             }
             FlorestadError::CouldNotWriteFile(path, err) => {
-                write!(f, "Error while creating file {path}: {err}")
+                write!(
+                    f,
+                    "Error while creating file at path={}: {err}",
+                    path.display()
+                )
             }
             FlorestadError::InvalidDataDir(path) => {
-                write!(f, "Data directory doesn't exist or is not writable: {path}")
+                write!(
+                    f,
+                    "Data directory at path={} doesn't exist or is not writable",
+                    path.display()
+                )
             }
             FlorestadError::CouldNotOpenKvDatabase(err) => {
                 write!(f, "Cannot open a key-value database: {err}")
@@ -192,7 +201,11 @@ impl Display for FlorestadError {
                 write!(f, "Failed to bind Electrum server: {err}")
             }
             FlorestadError::CouldNotCreateTLSDataDir(path, err) => {
-                write!(f, "Could not create TLS data directory {path}: {err}")
+                write!(
+                    f,
+                    "Could not create TLS data directory at path={}: {err}",
+                    path.display()
+                )
             }
             FlorestadError::CouldNotObtainWalletCache(err) => {
                 write!(f, "Could not obtain wallet cache: {err}")

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -88,7 +88,7 @@ pub struct Config {
     /// This directory must be readable and writable by our process. We'll use this dir to store
     /// both chain and wallet data, so this should be kept in a non-volatile medium. We are not
     /// particularly aggressive in disk usage, so we don't need a fast disk to work.
-    pub data_dir: String,
+    pub datadir: PathBuf,
 
     /// Assume that all blocks prior to and including this block have valid scripts.
     ///
@@ -121,7 +121,7 @@ pub struct Config {
     /// used:
     ///     - For vectors, we use the combination of both vectors
     ///     - for mutually exclusive options, this struct has precedence over the config file
-    pub config_file: Option<String>,
+    pub config_file: Option<PathBuf>,
 
     /// A proxy that we should use to connect with others
     ///
@@ -198,7 +198,7 @@ pub struct Config {
     /// ```shell
     /// openssl genpkey -algorithm RSA -out key.pem -pkeyopt rsa_keygen_bits:2048
     /// ```
-    pub tls_key_path: Option<String>,
+    pub tls_key_path: Option<PathBuf>,
 
     /// TLS certificate path (defaults to `{data_dir}/tls/cert.pem`).
     /// It must be PKCS#8-encoded. You can use `openssl` to generate it from a PKCS#8-encoded private key:
@@ -206,7 +206,7 @@ pub struct Config {
     /// ```shell
     /// openssl req -x509 -new -key key.pem -out cert.pem -days 365 -subj "/CN=localhost"
     /// ```
-    pub tls_cert_path: Option<String>,
+    pub tls_cert_path: Option<PathBuf>,
 
     /// Whether to create self signed certificate for `tls_key_path` and `tls_cert_path`.
     pub generate_cert: bool,
@@ -223,10 +223,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(network: Network, data_dir: String) -> Self {
+    pub fn new(network: Network, datadir: impl AsRef<Path>) -> Self {
         Self {
             disable_dns_seeds: false,
-            data_dir,
+            datadir: datadir.as_ref().into(),
             assume_valid: AssumeValidArg::Hardcoded,
             wallet_xpub: None,
             wallet_descriptor: None,
@@ -354,24 +354,23 @@ impl Florestad {
         Ok(sock)
     }
 
-    // TODO(@luisschwab): update `datadir.to_str().expect("infallible")` when modifying `floresta-node`'s methods
     /// Actually runs florestad, spawning all modules and waiting until
     /// someone asks to stop.
     ///
     /// This function will return an error if the configured data directory path is not an
     /// **existing and writable directory**, or cannot be validated as such.
     pub async fn start(&self) -> Result<(), FlorestadError> {
-        let datadir = PathBuf::from(&self.config.data_dir);
+        let datadir: &Path = self.config.datadir.as_ref();
 
         // Check that the directory exists and is writable
-        Florestad::validate_data_dir(datadir.to_str().expect("infallible"))?;
+        Florestad::validate_data_dir(datadir)?;
 
         info!("Loading watch-only wallet");
         let wallet = self.setup_wallet()?;
 
         info!("Loading blockchain database");
         let blockchain_state = Arc::new(Self::load_chain_state(
-            datadir.to_str().expect("infallible").to_owned(),
+            datadir,
             self.config.network,
             self.config.assume_valid,
         )?);
@@ -413,7 +412,7 @@ impl Florestad {
             network: self.config.network,
             pow_fraud_proofs: false,
             proxy,
-            datadir: datadir.clone(),
+            datadir: datadir.into(),
             fixed_peer: self.config.connect.clone(),
             compact_filters: self.config.cfilters,
             assume_utreexo: self.config.assumeutreexo_value.clone().or(assume_utreexo),
@@ -474,11 +473,7 @@ impl Florestad {
                     .as_ref()
                     .map(|x| Self::resolve_hostname(x, 8332))
                     .transpose()?,
-                datadir
-                    .join("debug.log")
-                    .to_str()
-                    .expect("infallible")
-                    .to_owned(),
+                datadir.join("debug.log"),
                 self.config.user_agent.clone(),
                 proxy,
             ));
@@ -549,28 +544,21 @@ impl Florestad {
             // Generate self-signed TLS certificate, if enabled.
             if self.config.generate_cert {
                 // Create TLS directory, if it does not exist.
-                let tls_dir = datadir.join("tls").to_str().expect("infallible").to_owned();
+                let tls_dir = datadir.join("tls");
                 if !Path::new(&tls_dir).exists() {
                     fs::create_dir_all(&tls_dir).map_err(|e| {
                         FlorestadError::CouldNotCreateTLSDataDir(tls_dir.clone(), e)
                     })?;
-                    info!("Created TLS directory at {tls_dir}");
+                    info!("Created TLS directory at path={}", tls_dir.display());
                 }
 
                 // Create information for the self-signed certificate about the current node.
                 let subject_alt_names = vec!["localhost".to_string()];
 
                 // Define file paths
-                let tls_key_path = datadir
-                    .join("tls/key.pem")
-                    .to_str()
-                    .expect("infallible")
-                    .to_owned();
-                let tls_cert_path = datadir
-                    .join("tls/cert.pem")
-                    .to_str()
-                    .expect("infallible")
-                    .to_owned();
+                let tls_key_path = datadir.join("tls").join("key.pem");
+
+                let tls_cert_path = datadir.join("tls").join("cert.pem");
 
                 // Create the certificate.
                 Self::generate_self_signed_certificate(
@@ -579,12 +567,12 @@ impl Florestad {
                     subject_alt_names,
                 )?;
 
-                info!("TLS private key saved to {tls_key_path}");
-                info!("TLS certificate saved to {tls_cert_path}");
+                info!("TLS private key saved to path={}", tls_key_path.display());
+                info!("TLS certificate saved to path={}", tls_cert_path.display());
             }
 
             // Assemble TLS configuration from file.
-            let tls_config = self.create_tls_config(datadir.to_str().expect("infallible"))?;
+            let tls_config = self.create_tls_config(datadir)?;
 
             // Electrum TLS accept loop.
             let tls_listener = TcpListener::bind(electrum_addr_tls)
@@ -642,20 +630,20 @@ impl Florestad {
         Self::from(config)
     }
 
-    pub fn new(network: Network, data_dir: String) -> Self {
-        Self::from_config(Config::new(network, data_dir))
+    pub fn new(network: Network, datadir: impl AsRef<Path>) -> Self {
+        Self::from_config(Config::new(network, datadir))
     }
 
-    fn validate_data_dir(path: &str) -> Result<(), FlorestadError> {
-        let p = Path::new(path);
+    fn validate_data_dir(path: impl AsRef<Path>) -> Result<(), FlorestadError> {
+        let path = path.as_ref();
 
-        let md = fs::metadata(p).map_err(|_| FlorestadError::InvalidDataDir(path.into()))?;
+        let md = fs::metadata(path).map_err(|_| FlorestadError::InvalidDataDir(path.into()))?;
         if !md.is_dir() {
-            return Err(FlorestadError::InvalidDataDir(path.into()));
+            return Err(FlorestadError::InvalidDataDir(path.to_path_buf()));
         }
 
         // Reliable cross-platform writability test:
-        let probe = p.join(".perm_probe");
+        let probe = path.join(".perm_probe");
         if OpenOptions::new()
             .create(true)
             .write(true)
@@ -673,9 +661,12 @@ impl Florestad {
     /// Load config from disk; prefer explicit `config_file`, otherwise use `{data_dir}/config.toml`.
     /// Returns default if it cannot load it
     fn get_config_file(&self) -> ConfigFile {
-        let path = match &self.config.config_file {
+        let datadir = &self.config.datadir;
+        let config_file = self.config.config_file.as_ref();
+
+        let path = match config_file {
             Some(path) => path.clone(),
-            None => format!("{}/config.toml", self.config.data_dir),
+            None => datadir.join("config.toml"),
         };
 
         let data = ConfigFile::from_file(&path);
@@ -713,20 +704,22 @@ impl Florestad {
     }
 
     fn load_chain_state(
-        data_dir: String,
+        datadir: impl AsRef<Path>,
         network: Network,
         assume_valid: AssumeValidArg,
     ) -> Result<ChainState<ChainStore>, FlorestadError> {
-        let config = FlatChainStoreConfig::new(data_dir + "/chaindata");
-        let store = ChainStore::new(config)
+        let chain_store_config = FlatChainStoreConfig::new(datadir.as_ref().join("chaindata"));
+
+        let chain_store = ChainStore::new(chain_store_config)
             .map_err(|e| FlorestadError::CouldNotLoadFlatChainStore(e.into()))?;
-        ChainState::open(store, network, assume_valid)
+
+        ChainState::open(chain_store, network, assume_valid)
             .map_err(FlorestadError::CouldNotLoadFlatChainStore)
     }
 
     /// Setup the wallet by initializing the database and adding descriptors, xpubs, and addresses.
     fn setup_wallet(&self) -> Result<AddressCache<KvDatabase>, FlorestadError> {
-        let database = KvDatabase::new(self.config.data_dir.clone())
+        let database = KvDatabase::new(&self.config.datadir)
             .map_err(FlorestadError::CouldNotOpenKvDatabase)?;
 
         let wallet = AddressCache::new(database);
@@ -832,8 +825,8 @@ impl Florestad {
 
     /// Generate a self-signed TLS certificate from a random private key.
     pub fn generate_self_signed_certificate(
-        tls_key_path: String,
-        tls_cert_path: String,
+        tls_key_path: impl AsRef<Path>,
+        tls_cert_path: impl AsRef<Path>,
         subject_alt_names: Vec<String>,
     ) -> Result<(), FlorestadError> {
         // Generate a key pair
@@ -849,41 +842,35 @@ impl Florestad {
             .map_err(FlorestadError::CouldNotGenerateSelfSignedCert)?;
 
         // Create files
-        fs::write(&tls_key_path, tls_key_pair.serialize_pem())
-            .map_err(|err| FlorestadError::CouldNotWriteFile(tls_key_path, err))?;
+        fs::write(&tls_key_path, tls_key_pair.serialize_pem()).map_err(|err| {
+            FlorestadError::CouldNotWriteFile(tls_key_path.as_ref().to_path_buf(), err)
+        })?;
 
-        fs::write(&tls_cert_path, certificate.pem())
-            .map_err(|err| FlorestadError::CouldNotWriteFile(tls_cert_path, err))?;
+        fs::write(&tls_cert_path, certificate.pem()).map_err(|err| {
+            FlorestadError::CouldNotWriteFile(tls_cert_path.as_ref().to_path_buf(), err)
+        })?;
 
         Ok(())
     }
 
     /// Create the TLS configuration from a PKCS#8 private key and certificate.
-    fn create_tls_config(&self, data_dir: &str) -> Result<Arc<ServerConfig>, FlorestadError> {
-        // Use an agnostic way to build paths for platforms and fix the differences
-        // in how Unix and Windows represent strings, maybe a user could use a weird
-        // string on his/her path.
-        //
-        // See more at https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_string_lossy
-        let tls_cert_path = self.config.tls_cert_path.clone().unwrap_or_else(|| {
-            PathBuf::from(&data_dir)
-                .join("tls")
-                .join("cert.pem")
-                .to_string_lossy()
-                .into_owned()
-        });
+    fn create_tls_config(
+        &self,
+        datadir: impl AsRef<Path>,
+    ) -> Result<Arc<ServerConfig>, FlorestadError> {
+        let datadir = datadir.as_ref();
 
-        let tls_key_path = self.config.tls_key_path.clone().unwrap_or_else(|| {
-            PathBuf::from(&data_dir)
-                .join("tls")
-                .join("key.pem")
-                .to_string_lossy()
-                .into_owned()
-        });
+        let tls_cert_path = self
+            .config
+            .tls_cert_path
+            .clone()
+            .unwrap_or_else(|| datadir.join("tls").join("cert.pem"));
 
-        // Convert paths to a [`Path`] for system-agnostic handling.
-        let tls_cert_path = Path::new(&tls_cert_path);
-        let tls_key_path = Path::new(&tls_key_path);
+        let tls_key_path = self
+            .config
+            .tls_key_path
+            .clone()
+            .unwrap_or_else(|| datadir.join("tls").join("key.pem"));
 
         // Parse the certificate's chain from the file.
         let tls_cert_chain =

--- a/crates/floresta-node/src/json_rpc/control.rs
+++ b/crates/floresta-node/src/json_rpc/control.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::path::PathBuf;
+
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -166,5 +168,5 @@ pub struct ActiveCommand {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetRpcInfoRes {
     active_commands: Vec<ActiveCommand>,
-    logpath: String,
+    logpath: PathBuf,
 }

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -2,6 +2,8 @@
 
 use core::net::SocketAddr;
 use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -79,7 +81,7 @@ pub struct RpcImpl<Blockchain: RpcChain> {
     pub(super) node: NodeInterface,
     pub(super) kill_signal: Arc<RwLock<bool>>,
     pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
-    pub(super) log_path: String,
+    pub(super) log_path: PathBuf,
     pub(super) start_time: Instant,
     pub(super) user_agent: String,
     pub(super) proxy: Option<SocketAddr>,
@@ -741,7 +743,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         network: Network,
         block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         address: Option<SocketAddr>,
-        log_path: String,
+        log_path: impl AsRef<Path>,
         user_agent: String,
         proxy: Option<SocketAddr>,
     ) {
@@ -782,7 +784,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 network,
                 block_filter_storage,
                 inflight: Arc::new(RwLock::new(HashMap::new())),
-                log_path,
+                log_path: log_path.as_ref().into(),
                 start_time: Instant::now(),
                 user_agent,
                 proxy,


### PR DESCRIPTION
Closes #939 

## Changelog
```
# `crates/floresta-node`
- `ConfigFile::from_file` takes `impl AsRef<Path>` instead of `&str`
- `FlorestadError::CouldNotWriteFile` takes `PathBuf` instead of `String`
- `FlorestadError::InvalidDataDir` takes `PathBuf` instead of `String`
- `FlorestadError::CouldNotCreateTlsDataDir` takes `PathBuf` instead of `String`
- `Config.config_file` takes `Option<PathBuf>` instead of `Option<String>`
- `Config.tls_key_path` takes `Option<PathBuf>` instead of `Option<String>`
- `Config.tls_cert_path` takes `Option<PathBuf>` instead of `Option<String>`
- `Config::new` takes in `impl AsRef<Path>` instead of `String`
- `Florestad::new` takes in `impl AsRef<Path>` instead of `String`
- `Florestad::validate_data_dir` takes in `impl AsRef<Path>` instead of `&str`
- `Florestad::generate_self_signed_certificates` takes in `impl AsRef<Path>` instead of `String`
- `Florestad::load_chain_state` takes in `impl AsRef<Path>` instead of `String`
- `Florestad::create_tls_config` takes in `impl AsRef<Path>` instead of `&str`
- `GetRpcInfoRes.logpath` uses `PathBuf` instead of `String`
- Update call sites

# `bin/florestad`
- `Cli.config_file` uses `Option<PathBuf>` instead of `Option<String>`
- `Cli.datadir` uses `Option<PathBuf>` instead of `Option<String>`
- `Cli.tls_key_path` uses `Option<PathBuf>` instead of `Option<String>`
- `Cli.tls_cert_path` uses `Option<PathBuf>` instead of `Option<String>`
- `Cli.pid_file` uses `Option<PathBuf>` instead of `Option<String>`
- `data_dir_path` takes in `Option<impl AsRef<Path>>` instead of `Option<String>`
- Update call sites
```