### PR TITLE
rpc/cli: use `PathBuf`

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::fmt::Debug;
+use std::path::PathBuf;
 mod parsers;
 
 use anyhow::Ok;
@@ -142,7 +143,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
 pub struct Cli {
     /// Sets a custom config file
     #[arg(short, long, value_name = "FILE")]
-    pub config_file: Option<String>,
+    pub config_file: Option<PathBuf>,
     /// Which network should we use
     #[arg(short, long, default_value_t=Network::Bitcoin)]
     pub network: Network,

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -4,6 +4,7 @@ use core::error;
 use core::fmt;
 use core::fmt::Display;
 use core::fmt::Formatter;
+use std::path::PathBuf;
 
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
@@ -329,7 +330,7 @@ pub struct ActiveCommand {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetRpcInfoRes {
     pub active_commands: Vec<ActiveCommand>,
-    pub logpath: String,
+    pub logpath: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Towards #939 

## Changelog
```
# `bin/floresta-cli`
- `Cli.config_file` uses `Option<PathBuf>` instead of `Option<String>`

# `crates/floresta-rpc`
- `GetRpcInfoRes.logpath` uses `PathBuf` instead of `String`
```