### PR TITLE
[RPCSAGA] verifyutxochaintipinclusionproof rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,8 +1091,10 @@ dependencies = [
  "arbitrary",
  "bitcoin",
  "floresta-chain",
+ "floresta-node",
  "floresta-wire",
  "libfuzzer-sys",
+ "rustreexo",
  "tempfile",
 ]
 

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -130,6 +130,13 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
         }
         Methods::GetAddrManInfo => serde_json::to_string_pretty(&client.get_addrman_info()?)?,
+        Methods::VerifyUtxoChainTipInclusionProof {
+            proof,
+            verbosity,
+            blockhash,
+        } => serde_json::to_string_pretty(
+            &client.verify_utxo_chain_tip_inclusion_proof(proof, verbosity, blockhash)?,
+        )?,
     })
 }
 
@@ -461,4 +468,19 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetAddrManInfo,
+
+    #[doc = include_str!("../../../doc/rpc/verifyutxochaintipinclusionproof.md")]
+    #[command(
+        name = "verifyutxochaintipinclusionproof",
+        about = "Verifies a Utreexo accumulator proof for the chain tip",
+        long_about = Some(include_str!("../../../doc/rpc/verifyutxochaintipinclusionproof.md")),
+        disable_help_subcommand = true
+    )]
+    VerifyUtxoChainTipInclusionProof {
+        proof: String,
+        #[arg(default_value = "0")]
+        verbosity: Option<u32>,
+        /// Optional block hash to check the proof against (defaults to current chain tip)
+        blockhash: Option<String>,
+    },
 }

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -455,7 +455,11 @@ mod tests {
             unimplemented!()
         }
 
-        fn acc(&self) -> Stump {
+        fn get_tip_acc(&self) -> Stump {
+            unimplemented!()
+        }
+
+        fn get_acc(&self, _block: BlockHash) -> Result<Option<Stump>, Self::Error> {
             unimplemented!()
         }
 

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -938,9 +938,6 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             None => Ok(true),
         }
     }
-    pub fn acc(&self) -> Stump {
-        read_lock!(self).acc.to_owned()
-    }
     /// Returns the next required work for the next block, usually it's just the last block's target
     /// but if we are in a retarget period, it's calculated from the last 2016 blocks.
     fn get_next_required_work(
@@ -1039,8 +1036,16 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         self.get_branch_work(header)
     }
 
-    fn acc(&self) -> Stump {
-        read_lock!(self).acc.to_owned()
+    fn get_tip_acc(&self) -> Stump {
+        read_lock!(self).acc.clone()
+    }
+
+    fn get_acc(&self, block: BlockHash) -> Result<Option<Stump>, Self::Error> {
+        let height = self
+            .get_block_height(&block)?
+            .ok_or(BlockchainError::BlockNotPresent)?;
+
+        self.get_roots_for_block(height)
     }
 
     fn size_on_disk(&self) -> Result<u64, Self::Error> {
@@ -1245,10 +1250,6 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
         self.reorg(new_tip)
     }
 
-    fn get_acc(&self) -> Stump {
-        self.acc()
-    }
-
     fn mark_block_as_valid(&self, block: BlockHash) -> Result<(), BlockchainError> {
         let header = self.get_disk_block_header(&block)?;
         let height = header.try_height()?;
@@ -1371,7 +1372,7 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
             .then(|| inputs.clone());
 
         self.validate_block_no_acc(block, height, inputs)?;
-        let acc = Consensus::update_acc(&self.acc(), block, height, proof, del_hashes)?;
+        let acc = Consensus::update_acc(&self.get_tip_acc(), block, height, proof, del_hashes)?;
 
         self.update_view(height, &block.header, acc)?;
 
@@ -1772,7 +1773,7 @@ mod test {
                 == bhash!("45c74beefa2a110715377e023d4260168b4cafbb0891f3b0869aea30867acc87")
             {
                 // This is the block we will reorg to
-                fork_acc = chain.acc();
+                fork_acc = chain.get_tip_acc()
             }
         }
 
@@ -1795,7 +1796,7 @@ mod test {
 
         assert_eq!(chain.get_best_block().unwrap(), expected);
         assert_eq!(
-            chain.acc(),
+            chain.get_tip_acc(),
             fork_acc,
             "The accumulator should not change when accepting headers only",
         );
@@ -2038,5 +2039,104 @@ mod test {
         assert_eq!(work.to_string_hex(), expected_hex_string);
         assert_eq!(fork_work, work);
         assert_eq!(work, expected_work);
+    }
+
+    #[test]
+    fn test_get_tip_acc() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+
+        // Initially the tip accumulator should be empty (genesis has no UTXOs processed)
+        assert_eq!(chain.get_tip_acc(), Stump::new());
+
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+        let short_chain: Vec<Block> = blocks[0]
+            .iter()
+            .map(|s| deserialize_hex(s).unwrap())
+            .collect();
+
+        let mut prev_acc = chain.get_tip_acc();
+
+        for block in &short_chain {
+            chain.accept_header(block.header).unwrap();
+            chain
+                .connect_block(block, Proof::default(), HashMap::new(), Vec::new())
+                .unwrap();
+
+            let current_acc = chain.get_tip_acc();
+            // The tip accumulator should update after each block connection
+            assert_ne!(
+                current_acc,
+                prev_acc,
+                "Tip accumulator should change after connecting block {}",
+                block.block_hash()
+            );
+            prev_acc = current_acc;
+        }
+    }
+
+    #[test]
+    fn test_get_acc() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+        let short_chain: Vec<Block> = blocks[0]
+            .iter()
+            .map(|s| deserialize_hex(s).unwrap())
+            .collect();
+
+        // Connect all blocks
+        for block in &short_chain {
+            chain.accept_header(block.header).unwrap();
+            chain
+                .connect_block(block, Proof::default(), HashMap::new(), Vec::new())
+                .unwrap();
+        }
+
+        // Each connected block should have a stored accumulator
+        for block in &short_chain {
+            let acc = chain
+                .get_acc(block.block_hash())
+                .expect("get_acc should not error for a connected block");
+            assert!(
+                acc.is_some(),
+                "Connected block {} should have a stored accumulator",
+                block.block_hash()
+            );
+        }
+
+        // The accumulator for the last connected block should match the current tip accumulator
+        let last_block = short_chain.last().unwrap();
+        let last_acc = chain.get_acc(last_block.block_hash()).unwrap().unwrap();
+        assert_eq!(
+            last_acc,
+            chain.get_tip_acc(),
+            "The last connected block's accumulator should equal the tip accumulator"
+        );
+
+        // Genesis has no saved accumulator (ChainState::new doesn't call save_roots_for_block)
+        let genesis_hash = genesis_block(Network::Regtest).block_hash();
+        let genesis_acc = chain
+            .get_acc(genesis_hash)
+            .expect("get_acc should not error for genesis");
+        assert!(
+            genesis_acc.is_none(),
+            "Genesis should have no stored accumulator"
+        );
+    }
+
+    #[test]
+    fn test_get_acc_unknown_block() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+
+        // A completely unknown block hash should return an error
+        let unknown_hash =
+            bhash!("0000000000000000000000000000000000000000000000000000000000000001");
+        let result = chain.get_acc(unknown_hash);
+        assert!(
+            matches!(result, Err(BlockchainError::BlockNotPresent)),
+            "get_acc should return BlockNotPresent for an unknown block hash, got: {result:?}"
+        );
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -50,6 +50,9 @@ pub enum BlockchainError {
     /// The Utreexo proof for this block is invalid.
     InvalidUtreexoProof,
 
+    /// A block without known utreexo acc was requested
+    UnknownUtreexoAcc,
+
     /// Error whilst interacting with the [accumulator](rustreexo::stump::Stump).
     AccumulatorError(StumpError),
 
@@ -83,6 +86,9 @@ impl Display for BlockchainError {
                 write!(f, "The block contains invalid transaction(s): {e}")
             }
             Self::InvalidUtreexoProof => write!(f, "The Utreexo proof for this block is invalid"),
+            Self::UnknownUtreexoAcc => {
+                write!(f, "A block without known utreexo acc was requested")
+            }
             Self::AccumulatorError(e) => {
                 write!(f, "Error whilst interacting with the accumulator: {e:?}")
             }

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -147,7 +147,7 @@ pub trait BlockchainInterface {
     /// Returns this chain's params
     fn get_params(&self) -> bitcoin::params::Params;
 
-    /// Returns the acc for the current tip. For arbitray accumulator retrieval, see `get_acc`.
+    /// Returns the acc for the current tip. For arbitrary accumulator retrieval, see `get_acc`.
     fn get_tip_acc(&self) -> Stump;
 
     /// Returns the acc for the given block. If you only needs the tip accumulator, see `get_tip_acc`.

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -147,8 +147,11 @@ pub trait BlockchainInterface {
     /// Returns this chain's params
     fn get_params(&self) -> bitcoin::params::Params;
 
-    /// Returns our current acc
-    fn acc(&self) -> Stump;
+    /// Returns the acc for the current tip. For arbitray accumulator retrieval, see `get_acc`.
+    fn get_tip_acc(&self) -> Stump;
+
+    /// Returns the acc for the given block. If you only needs the tip accumulator, see `get_tip_acc`.
+    fn get_acc(&self, block: BlockHash) -> Result<Option<Stump>, Self::Error>;
 
     /// Returns the amount of [`Work`] associated with a given chain tip
     fn get_work(&self, tip: BlockHash) -> Result<Work, Self::Error>;
@@ -218,8 +221,6 @@ pub trait UpdatableChainstate {
     /// This mimics the behaviour of checking every block before this block, and continues
     /// from this point
     fn mark_chain_as_assumed(&self, acc: Stump, tip: BlockHash) -> Result<bool, BlockchainError>;
-    /// Returns the current accumulator
-    fn get_acc(&self) -> Stump;
 }
 
 #[derive(Debug, Clone)]
@@ -233,10 +234,6 @@ pub enum Notification {
 impl<T: UpdatableChainstate> UpdatableChainstate for Arc<T> {
     fn flush(&self) -> Result<(), BlockchainError> {
         T::flush(self)
-    }
-
-    fn get_acc(&self) -> Stump {
-        T::get_acc(self)
     }
 
     fn update_ibd(&self, ibd_state: IBDState) {
@@ -306,8 +303,12 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
         T::get_params(self)
     }
 
-    fn acc(&self) -> Stump {
-        T::acc(self)
+    fn get_acc(&self, block: BlockHash) -> Result<Option<Stump>, Self::Error> {
+        T::get_acc(self, block)
+    }
+
+    fn get_tip_acc(&self) -> Stump {
+        T::get_tip_acc(self)
     }
 
     fn get_block(&self, hash: &BlockHash) -> Result<Block, Self::Error> {

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -274,10 +274,6 @@ impl UpdatableChainstate for PartialChainState {
         self.inner().current_acc.roots.clone()
     }
 
-    fn get_acc(&self) -> Stump {
-        self.inner().current_acc.clone()
-    }
-
     //these are no-ops, you can call them, but they won't do anything
 
     fn flush(&self) -> Result<(), BlockchainError> {
@@ -339,8 +335,12 @@ impl BlockchainInterface for PartialChainState {
         self.inner().chain_params().params
     }
 
-    fn acc(&self) -> Stump {
+    fn get_tip_acc(&self) -> Stump {
         self.inner().current_acc.clone()
+    }
+
+    fn get_acc(&self, _block: BlockHash) -> Result<Option<Stump>, Self::Error> {
+        unimplemented!("partialChainState only holds the tip acc, prefer get_tip_acc")
     }
 
     fn size_on_disk(&self) -> Result<u64, Self::Error> {

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -30,10 +30,14 @@ use floresta_chain::extensions::HeaderExt;
 use floresta_chain::extensions::WorkExt;
 use floresta_wire::node_interface::ChainMethods;
 use miniscript::descriptor::checksum;
+use rustreexo::node_hash::BitcoinNodeHash;
+use rustreexo::proof::ProofError;
+use rustreexo::stump::StumpError;
 use serde_json::Value;
 use serde_json::json;
 use tracing::debug;
 
+use super::request::TipProof;
 use super::res::GetBlockHeaderRes;
 use super::res::GetTxOutProof;
 use super::res::jsonrpc_interface::JsonRpcError;
@@ -41,6 +45,8 @@ use super::server::RpcChain;
 use super::server::RpcImpl;
 use crate::json_rpc::res::GetBlockRes;
 use crate::json_rpc::res::RescanConfidence;
+use crate::json_rpc::res::VerifyUtxoChainTipInclusionProofRes;
+use crate::json_rpc::res::VerifyUtxoChainTipInclusionProofVerbose;
 use crate::json_rpc::server::SERIALIZATION_EXPECT_MSG;
 use crate::json_rpc::server::to_core_asm_string;
 
@@ -731,5 +737,65 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .get_descriptors()
             .map_err(|e| JsonRpcError::Wallet(e.to_string()))?;
         Ok(descriptors)
+    }
+
+    pub(super) fn verify_utxo_chain_tip_inclusion_proof(
+        &self,
+        proof: TipProof,
+        verbosity: u8,
+        blockhash: Option<BlockHash>,
+    ) -> Result<VerifyUtxoChainTipInclusionProofRes, JsonRpcError> {
+        let target_hash = match blockhash {
+            Some(hash) if self.chain.get_block_header(&hash).is_err() => {
+                Err(JsonRpcError::BlockNotFound)? // This guards us from the block being unknown or unexistent
+            }
+            Some(hash) => hash,
+            None => self.get_best_block_hash()?,
+        };
+
+        let stump = self
+            .chain
+            .get_acc(target_hash)
+            .map_err(|_| JsonRpcError::Chain)?
+            .ok_or(JsonRpcError::UnknownUtreexoAcc(target_hash.to_string()))?;
+
+        let valid = match stump.verify(&proof.proof, &proof.hashes_proven) {
+            Ok(valid) => valid,
+            Err(StumpError::InvalidProof(ProofError::MissingSibling(_))) => false,
+            Err(e) => {
+                return Err(JsonRpcError::InvalidProof(format!(
+                    "Proof verification failed: {e:?}"
+                )));
+            }
+        };
+
+        // Display hashes in reversed byte order to match utreexod's
+        // convention (Bitcoin's standard display endianness).
+        let to_reversed_hex = |h: &BitcoinNodeHash| match h {
+            BitcoinNodeHash::Some(bytes) => {
+                let mut rev = *bytes;
+                rev.reverse();
+                rev.iter().fold(String::with_capacity(64), |mut s, b| {
+                    use std::fmt::Write;
+                    write!(s, "{b:02x}").expect("hex write");
+                    s
+                })
+            }
+            _ => "empty".to_string(),
+        };
+
+        match verbosity {
+            0 => Ok(VerifyUtxoChainTipInclusionProofRes::Zero(valid)),
+            1 => Ok(VerifyUtxoChainTipInclusionProofRes::One(
+                VerifyUtxoChainTipInclusionProofVerbose {
+                    valid,
+                    proved_at_hash: proof.proved_at_hash.to_string(),
+                    targets: proof.proof.targets,
+                    proof_hashes: proof.proof.hashes.iter().map(to_reversed_hex).collect(),
+                    hashes_proven: proof.hashes_proven.iter().map(to_reversed_hex).collect(),
+                },
+            )),
+            _ => Err(JsonRpcError::InvalidVerbosityLevel),
+        }
     }
 }

--- a/crates/floresta-node/src/json_rpc/request.rs
+++ b/crates/floresta-node/src/json_rpc/request.rs
@@ -3,6 +3,19 @@
 //! This module defines the structure for JSON-RPC requests and provides utility functions to
 //! extract parameters from the request.
 
+use std::str::FromStr;
+
+use bitcoin::BlockHash;
+use bitcoin::VarInt;
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::Hash;
+use bitcoin::hashes::sha256;
+use bitcoin::hex::DisplayHex;
+use bitcoin::hex::FromHex;
+use floresta_common::read_bounded_len;
+use rustreexo::node_hash::BitcoinNodeHash;
+use rustreexo::proof::Proof;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
@@ -92,5 +105,221 @@ pub mod arg_parser {
             Err(JsonRpcError::MissingParameter(_)) => Ok(default),
             Err(e) => Err(e),
         }
+    }
+}
+
+/// The maximum possible inputs you can have per block.
+///
+/// <https://bitcoin.stackexchange.com/questions/85752/maximum-number-of-inputs-per-transaction>
+const MAX_INPUTS_PER_BLOCK: usize = 24_386;
+
+/// How high the Utreexo forest can be.
+const MAX_TREE_DEPTH: usize = 64;
+
+/// The maximum number of proof hashes that can be included in a Utreexo proof.
+const MAX_PROOF_HASHES: usize = MAX_INPUTS_PER_BLOCK * MAX_TREE_DEPTH;
+
+/// Maximum serialized size of a [`TipProof`] in bytes.
+const MAX_PROOF_SIZE_BYTES: usize =
+    // block hash
+    32
+    // targets: varint count + up to MAX_INPUTS_PER_BLOCK varint-encoded targets
+    + 9 + MAX_INPUTS_PER_BLOCK * 9
+    // proof hashes: varint count + up to MAX_PROOF_HASHES 32-byte hashes
+    + 9 + MAX_PROOF_HASHES * 32
+    // proven hashes: u32 LE count + up to MAX_INPUTS_PER_BLOCK 32-byte hashes
+    + 4 + MAX_INPUTS_PER_BLOCK * 32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A chain-tip inclusion proof as serialized by utreexod.
+///
+/// Responses to `proveutxochaintipinclusion` utreexod RPC.
+pub struct TipProof {
+    /// The block hash at which this proof was generated.
+    pub proved_at_hash: BlockHash,
+
+    /// The Utreexo accumulator proof (targets + sibling hashes).
+    pub proof: Proof,
+
+    /// The raw leaf hashes that were proven.
+    pub hashes_proven: Vec<BitcoinNodeHash>,
+}
+
+impl FromStr for TipProof {
+    type Err = bitcoin::consensus::encode::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Here we expect for `s` to be a hex string, its len() returns
+        // the double of bytes.
+        if (s.len() / 2) > MAX_PROOF_SIZE_BYTES {
+            return Err(bitcoin::consensus::encode::Error::ParseFailed(
+                "Proof exceeds max size allowed",
+            ));
+        }
+
+        let proof_bytes = Vec::from_hex(s)
+            .map_err(|_| bitcoin::consensus::encode::Error::ParseFailed("Invalid hex"))?;
+
+        Self::consensus_decode(&mut proof_bytes.as_slice())
+    }
+}
+
+impl Decodable for TipProof {
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
+        reader: &mut R,
+    ) -> Result<Self, bitcoin::consensus::encode::Error> {
+        // Block hash (32 bytes)
+        let proved_at_hash = BlockHash::consensus_decode(reader)?;
+
+        // Targets (varint count + varint-encoded)
+        let num_targets = read_bounded_len(reader, MAX_INPUTS_PER_BLOCK)?;
+        let mut targets = Vec::with_capacity(num_targets);
+        for _ in 0..num_targets {
+            let target = VarInt::consensus_decode(reader)?;
+            targets.push(target.0);
+        }
+
+        // Proof sibling hashes (varint count + 32-byte hashes)
+        let num_hashes = read_bounded_len(reader, MAX_PROOF_HASHES)?;
+        let mut proof_hashes = Vec::with_capacity(num_hashes);
+        for _ in 0..num_hashes {
+            let hash = sha256::Hash::consensus_decode(reader)?;
+            proof_hashes.push(BitcoinNodeHash::Some(hash.to_byte_array()));
+        }
+
+        // Hashes proven (u32 LE count + 32-byte hashes)
+        let num_proven = u32::consensus_decode(reader)? as usize;
+        if num_proven > MAX_INPUTS_PER_BLOCK {
+            return Err(bitcoin::consensus::encode::Error::ParseFailed(
+                "Too many proven hashes",
+            ));
+        }
+        let mut hashes_proven = Vec::with_capacity(num_proven);
+        for _ in 0..num_proven {
+            let hash = sha256::Hash::consensus_decode(reader)?;
+            hashes_proven.push(BitcoinNodeHash::Some(hash.to_byte_array()));
+        }
+
+        Ok(Self {
+            proved_at_hash,
+            proof: Proof {
+                targets,
+                hashes: proof_hashes,
+            },
+            hashes_proven,
+        })
+    }
+}
+
+impl Encodable for TipProof {
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, bitcoin::io::Error> {
+        let mut len = 0;
+
+        // Block hash (32 bytes)
+        len += self.proved_at_hash.consensus_encode(writer)?;
+
+        // Targets (varint count + varint-encoded)
+        len += VarInt(self.proof.targets.len() as u64).consensus_encode(writer)?;
+        for target in &self.proof.targets {
+            len += VarInt(*target).consensus_encode(writer)?;
+        }
+
+        // Proof sibling hashes (varint count + 32-byte hashes)
+        len += VarInt(self.proof.hashes.len() as u64).consensus_encode(writer)?;
+        for hash in &self.proof.hashes {
+            len += sha256::Hash::from_byte_array(**hash).consensus_encode(writer)?;
+        }
+
+        // Hashes proven (u32 LE count + 32-byte hashes)
+        len += (self.hashes_proven.len() as u32).consensus_encode(writer)?;
+        for hash in &self.hashes_proven {
+            len += sha256::Hash::from_byte_array(**hash).consensus_encode(writer)?;
+        }
+
+        Ok(len)
+    }
+}
+
+impl Serialize for TipProof {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut buf = Vec::new();
+        self.consensus_encode(&mut buf)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&buf.as_hex().to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for TipProof {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let hex_str = String::deserialize(deserializer)?;
+        Self::from_str(&hex_str).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tip_proof_tests {
+    use bitcoin::consensus::encode::deserialize_hex;
+
+    use super::*;
+
+    /// A valid TipProof with 1 target, 3 proof hashes, and 1 proven leaf hash.
+    const TIP_PROOF_HEX: &str = "06db48a6f377f85e46c4e0b915af21c05122c72fff2a8193e19bc68a8b18116d0100030b6c7f2192b1460acf65143badad31b1f000e4940d966bdc8d41463c3049255164028cae25759e119457b059aaa6a38e5812cfd72e9fd07a6393771b4881a2fa80500750ac49f80b161c7431cc3f345a3872147b7adb432f032956eafa9fb76801000000e1e92857db1c66b3cf610e445eb006d68373d82b33398bdadd2f70cf4088dac2";
+
+    /// Just the 32-byte block hash portion of the proof above (no body).
+    const TIP_PROOF_BLOCK_HASH_HEX: &str =
+        "06db48a6f377f85e46c4e0b915af21c05122c72fff2a8193e19bc68a8b18116d";
+
+    /// Decodes a well-formed proof and checks that every field lands in the right position,
+    /// then verifies a serde JSON round-trip produces the same result.
+    #[test]
+    fn test_tip_proof_valid_deserialization() {
+        let proof: TipProof = deserialize_hex(TIP_PROOF_HEX).unwrap();
+
+        assert_eq!(
+            proof.proved_at_hash.to_string(),
+            "6d11188b8ac69be193812aff2fc72251c021af15b9e0c4465ef877f3a648db06"
+        );
+        assert_eq!(proof.proof.targets, vec![0]);
+        assert_eq!(proof.proof.hashes.len(), 3);
+        assert_eq!(proof.hashes_proven.len(), 1);
+
+        // A minimal valid structure with all counts set to zero should also decode.
+        let hex = format!("{}000000000000", TIP_PROOF_BLOCK_HASH_HEX);
+        let empty_proof: TipProof = deserialize_hex(&hex).unwrap();
+        assert!(empty_proof.proof.targets.is_empty());
+        assert!(empty_proof.proof.hashes.is_empty());
+        assert!(empty_proof.hashes_proven.is_empty());
+
+        // Serde round-trip: serialize to JSON and back, result must be identical.
+        let json = serde_json::to_value(&proof).unwrap();
+        let deserialized: TipProof = serde_json::from_value(json).unwrap();
+        assert_eq!(proof, deserialized);
+    }
+
+    /// Exercises various forms of malformed input that the decoder must reject:
+    /// trailing bytes, truncated data, oversized counts, and completely empty input.
+    #[test]
+    fn test_tip_proof_invalid_deserialization() {
+        // Extra byte appended after a valid proof
+        let trailing = format!("{}ff", TIP_PROOF_HEX);
+        assert!(deserialize_hex::<TipProof>(&trailing).is_err());
+
+        // Only the 32-byte block hash, no body at all
+        assert!(deserialize_hex::<TipProof>(TIP_PROOF_BLOCK_HASH_HEX).is_err());
+
+        // Varint claiming 24,387 targets (one over MAX_INPUTS_PER_BLOCK)
+        let oversized_targets = format!("{}fd435f", TIP_PROOF_BLOCK_HASH_HEX);
+        assert!(deserialize_hex::<TipProof>(&oversized_targets).is_err());
+
+        // u32 LE claiming 24,387 proven hashes (one over MAX_INPUTS_PER_BLOCK)
+        let oversized_proven = format!("{}0000435f0000", TIP_PROOF_BLOCK_HASH_HEX);
+        assert!(deserialize_hex::<TipProof>(&oversized_proven).is_err());
+
+        // Completely empty input
+        assert!(deserialize_hex::<TipProof>("").is_err());
     }
 }

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -253,6 +253,12 @@ pub mod jsonrpc_interface {
 
         /// The provided net address is invalid
         InvalidNetAddress(InvalidAddressError),
+
+        /// The user sent an invalid proof
+        InvalidProof(String),
+
+        /// Accumulator not found for block.
+        UnknownUtreexoAcc(String),
     }
 
     impl_error_from!(JsonRpcError, MempoolError, MempoolAccept);
@@ -280,6 +286,8 @@ pub mod jsonrpc_interface {
                 | Self::InvalidParameterStructure(_)
                 | Self::MissingParameter(_)
                 | Self::InvalidNetAddress(_)
+                | Self::InvalidProof(_)
+                | Self::UnknownUtreexoAcc(_)
                 | Self::Wallet(_) => StatusCode::BAD_REQUEST,
 
                 // 404 Not Found - resource/method doesn't exist
@@ -336,6 +344,11 @@ pub mod jsonrpc_interface {
                     message: "Invalid script".into(),
                     data: None,
                 },
+                Self::UnknownUtreexoAcc(block) => RpcError {
+                    code: INVALID_METHOD_PARAMETERS,
+                    message: format!("Utreexo accumulator for {block} is unknown"),
+                    data: None,
+                },
                 Self::InvalidDescriptor(e) => RpcError {
                     code: INVALID_METHOD_PARAMETERS,
                     message: "Invalid descriptor".into(),
@@ -349,6 +362,11 @@ pub mod jsonrpc_interface {
                 Self::InvalidTimestamp => RpcError {
                     code: INVALID_METHOD_PARAMETERS,
                     message: "Invalid timestamp".into(),
+                    data: None,
+                },
+                Self::InvalidProof(proof) => RpcError {
+                    code: INVALID_METHOD_PARAMETERS,
+                    message: format!("Invalid proof:{proof}"),
                     data: None,
                 },
                 Self::InvalidMemInfoMode => RpcError {
@@ -585,3 +603,41 @@ pub enum GetBlockHeaderRes {
 /// by Bitcoin Core.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetTxOutProof(pub String);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+/// Return type for `verifyutxochaintipinclusionproof`, supports both its verbose version and non-verbose.
+///
+/// The non-verbose version tells whether a proof is valid given the internal utreexo accumulator.
+pub enum VerifyUtxoChainTipInclusionProofRes {
+    /// No verbosity, tells whether a proof is valid.
+    Zero(bool),
+
+    /// Verbosity one, with more detailed information about the proof
+    One(VerifyUtxoChainTipInclusionProofVerbose),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+/// Return type for `verifyutxochaintipinclusionproof`
+///
+/// Field names match utreexod's `proveutxochaintipinclusion` response.
+pub struct VerifyUtxoChainTipInclusionProofVerbose {
+    /// Whether this proof is valid
+    pub valid: bool,
+
+    /// The block hash that this proof was proved.
+    #[serde(rename = "provedathash")]
+    pub proved_at_hash: String,
+
+    /// The targets that this proof is proving.
+    #[serde(rename = "prooftargets")]
+    pub targets: Vec<u64>,
+
+    /// Proof hashes.
+    #[serde(rename = "proofhashes")]
+    pub proof_hashes: Vec<String>,
+
+    /// Which of the hashes were proven.
+    #[serde(rename = "hashesproven")]
+    pub hashes_proven: Vec<String>,
+}

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -17,6 +17,7 @@ use axum::http::Response as HttpResponse;
 use axum::http::StatusCode;
 use axum::routing::post;
 use bitcoin::Address;
+use bitcoin::BlockHash;
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
@@ -53,12 +54,13 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
-use super::res::GetRawTransactionRes;
+use super::request::TipProof;
 use super::res::jsonrpc_interface::JsonRpcError;
 use crate::json_rpc::request::RpcRequest;
 use crate::json_rpc::request::arg_parser::get_at;
 use crate::json_rpc::request::arg_parser::get_with_default;
 use crate::json_rpc::request::arg_parser::try_into_optional;
+use crate::json_rpc::res::GetRawTransactionRes;
 use crate::json_rpc::res::RescanConfidence;
 use crate::json_rpc::res::jsonrpc_interface::Response;
 
@@ -448,6 +450,18 @@ async fn handle_json_rpc_request(
             state
                 .send_raw_transaction(tx)
                 .await
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
+        }
+
+        "verifyutxochaintipinclusionproof" => {
+            let proof: TipProof = get_at(&params, 0, "proof")?;
+
+            let verbosity: u8 = get_with_default(&params, 1, "verbosity", 0)?;
+
+            let blockhash: Option<BlockHash> = try_into_optional(get_at(&params, 2, "blockhash"))?;
+
+            state
+                .verify_utxo_chain_tip_inclusion_proof(proof, verbosity, blockhash)
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }
 

--- a/crates/floresta-node/src/lib.rs
+++ b/crates/floresta-node/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod florestad;
 #[cfg(feature = "json-rpc")]
 #[cfg_attr(not(test), deny(clippy::unwrap_used))]
-mod json_rpc;
+pub mod json_rpc;
 #[cfg(feature = "zmq-server")]
 mod zmq;
 

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -158,6 +158,13 @@ pub trait FlorestaRPC {
     fn ping(&self) -> Result<()>;
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> Result<GetAddrManInfo>;
+    /// Verifies a Utreexo inclusion proof for the chain tip
+    fn verify_utxo_chain_tip_inclusion_proof(
+        &self,
+        proof: String,
+        verbosity: Option<u32>,
+        blockhash: Option<String>,
+    ) -> Result<Value>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -387,5 +394,27 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+
+    fn verify_utxo_chain_tip_inclusion_proof(
+        &self,
+        proof: String,
+        verbosity: Option<u32>,
+        blockhash: Option<String>,
+    ) -> Result<Value> {
+        let mut params = vec![Value::String(proof)];
+
+        if let Some(v) = verbosity {
+            params.push(Value::Number(Number::from(v)));
+        }
+
+        if let Some(ref hash) = blockhash {
+            if verbosity.is_none() {
+                params.push(Value::Null);
+            }
+            params.push(Value::String(hash.clone()));
+        }
+
+        self.call("verifyutxochaintipinclusionproof", &params)
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/block_proof.rs
+++ b/crates/floresta-wire/src/p2p_wire/block_proof.rs
@@ -39,7 +39,7 @@ use rustreexo::node_hash::BitcoinNodeHash;
 /// stackexchange answer, but that doesn't change the max possible input value.
 ///
 /// <https://bitcoin.stackexchange.com/questions/85752/maximum-number-of-inputs-per-transaction>
-const MAX_INPUTS_PER_BLOCK: usize = 24_386;
+pub const MAX_INPUTS_PER_BLOCK: usize = 24_386;
 
 /// How high the Utreexo forest can be.
 const MAX_TREE_DEPTH: usize = 64;
@@ -49,7 +49,7 @@ const MAX_TREE_DEPTH: usize = 64;
 /// Assuming that each UTXO needs a proof, with no overlaps of any kind, the maximum number of
 /// proof hashes is the number of inputs per block multiplied by the maximum number of
 /// elements that each proof requires, in a tree with `MAX_TREE_DEPTH` depth.
-const MAX_PROOF_HASHES: usize = MAX_INPUTS_PER_BLOCK * MAX_TREE_DEPTH;
+pub const MAX_PROOF_HASHES: usize = MAX_INPUTS_PER_BLOCK * MAX_TREE_DEPTH;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A Bitmap used to request proof elements in Utreexo proofs.

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -16,7 +16,6 @@ use bitcoin::p2p::address::AddrV2Message;
 use floresta_chain::ThreadSafeChain;
 use floresta_chain::proof_util;
 use floresta_chain::pruned_utreexo::BlockchainInterface;
-use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::pruned_utreexo::partial_chain::PartialChainState;
 use floresta_common::service_flags;
 use floresta_common::try_and_log;
@@ -266,7 +265,7 @@ where
 
                 // we haven't finished the backfill yet, save the current state for the next run
                 if chain.is_in_ibd() {
-                    let acc = chain.get_acc();
+                    let acc = chain.get_tip_acc();
                     let tip = chain.get_height().unwrap();
                     let mut ser_acc = Vec::new();
                     acc.serialize(&mut ser_acc).unwrap();

--- a/crates/floresta-wire/src/p2p_wire/tests/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/chain_selector.rs
@@ -63,7 +63,7 @@ mod tests {
             ]
             .to_vec(),
         };
-        assert_eq!(chain.acc(), expected_acc);
+        assert_eq!(chain.get_tip_acc(), expected_acc);
     }
 
     #[tokio::test]
@@ -112,6 +112,6 @@ mod tests {
             ]
             .to_vec(),
         };
-        assert_eq!(chain.acc(), expected_acc);
+        assert_eq!(chain.get_tip_acc(), expected_acc);
     }
 }

--- a/doc/rpc/verifyutxochaintipinclusionproof.md
+++ b/doc/rpc/verifyutxochaintipinclusionproof.md
@@ -1,0 +1,76 @@
+# `verifyutxochaintipinclusionproof`
+
+Verifies a Utreexo accumulator inclusion proof for the chain tip.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli verifyutxochaintipinclusionproof <proof> [verbosity] [blockhash]
+```
+
+### Examples
+
+```bash
+# Verify a valid proof
+floresta-cli verifyutxochaintipinclusionproof "7be8d37f896c5679fc370f78618352758f8313267f1ad3348e32fa7d7fdb411501000678463e22379a90e33854981d711045382f5a897d578944a32625a4676472b87ea7b27aa09d99d88888dc70af5cf032afd4d3b92a77db2501ff133a46bf11780afe345534cc16c23330a6eb00f8bcc8fef9c2c48237bf6ce35cb9474a6ca93556e6b07d99729145a9eff0b40ab0401c0b38136b20498753e109fcdc869587b4565236f49e081ba525b9e100d0a73d6c734a4b7c89dcff97646f5f30f95974aaefdef19c978c859a62f3885a22424c34e657fd8170a63b13a72e3202b044d65399010000006e6d53328389a2ebf90239ee0a9884fd46fa03c471bebf37cde90f6dd49812c9"
+
+# Verify an invalid proof (returns false)
+floresta-cli verifyutxochaintipinclusionproof "7be8d37f896c5679fc370f78618352758f8313267f1ad3348e32fa7d7fdb411501000678463e22379a90e33854981d711045382f5a897d578944a32625a4676472b87ea7b27aa09d99d88888dc70af5cf032afd4d3b92a77db2501ff133a46bf11780afe345534cc16c23330a6eb00f8bcc8fef9c2c48237bf6ce35cb9474a6ca93556e6b07d99729145a9eff0b40ab0401c0b38136b20498753e109fcdc869587b4565236f49e081ba525b9e100d0a73d6c734a4b7c89dcff97646f5f30f95974aaefdef19c978c859a62f3885a22424c34e657fd8170a63b13a72e3202b044d65399010000006e6d53328389a2ebf90239ee0a9884fd46fa03c471bebf37cde90f6dd4981210"
+
+# Verify with detailed output (verbosity 1 — returns JSON object)
+floresta-cli verifyutxochaintipinclusionproof "7be8d37f...c9" 1
+```
+
+## Arguments
+
+`proof` - (String, required) Hex-encoded Utreexo chain-tip inclusion proof. The binary format is:
+
+- **proved_at_hash** (32 bytes): The block hash at which the proof was generated (little-endian).
+- **targets** (varint count + varint[]): Accumulator leaf positions being proven.
+- **proof_hashes** (varint count + 32-byte hashes): Sibling hashes needed to reconstruct the path to the roots.
+- **hashes_proven** (u32 LE count + 32-byte hashes): The leaf hashes whose inclusion is being proven.
+
+`verbosity` - (u32, optional, default=0) Level of detail in the response:
+
+- `0`: Returns `true` or `false`.
+- `1`: Returns a JSON object with `valid`, `provedathash`, `prooftargets`, `proofhashes` and `hashesproven`.
+
+`blockhash` - (String, optional) Block hash to check the proof against. Defaults to the current chain tip. Useful for testing and debugging with proofs generated at a specific block height, should not be used when you need to validate if a proof is canonically valid.
+
+## Returns
+
+### Ok Response
+
+### Verbosity 0 (default)
+
+- `true|false` - (boolean) Returns `true` if the proof is cryptographically valid, `false` if the proof is logically invalid but well-formed.
+
+### Verbosity 1
+
+```json
+{
+  "valid": true,
+  "provedathash": "6d11188b...",
+  "prooftargets": [0],
+  "proofhashes": ["a6b5a202...", "4bc79324...", "590d644e..."],
+  "hashesproven": ["e1e92857..."]
+}
+```
+
+### Error Enum
+
+- `JsonRpcError::InvalidHex` - The proof is not valid hexadecimal.
+- `JsonRpcError::Decode` - Malformed proof: too large, too short, truncated data, invalid varints, or trailing bytes.
+- `JsonRpcError::InvalidProof` - Well-formed proof but invalid: stale (wrong block height) or cryptographic verification failed.
+- `JsonRpcError::InvalidVerbosityLevel` - Verbosity value is not 0 or 1.
+- `JsonRpcError::UnknownUtreexoAcc` - A block without known utreexo acc was requested.
+
+## Notes
+
+- The proof must match the expected block hash: the current chain tip by default, or the `blockhash` argument if provided. Mismatched proofs will return `InvalidProof` error.
+- To generate a proof, use the `proveutxochaintipinclusion` RPC from `utreexod` with transaction IDs and output index.
+- Related RPCs: `getbestblockhash` (to verify current chain tip hash).
+- The blockhash argument is useful for testing, debugging and precise understanding of the internal utreexo accumulator and to understand how much staled a stale proof is, and should not be used to validate if a proof is canonically valid, each proof is only valid given a unique set of utreexo roots, each block have its own set of roots.
+- A proof not being valid means that its cryptographically invalid, a possibly stale proof can be updated to become valid again.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,6 +9,10 @@ edition.workspace = true
 [package.metadata]
 cargo-fuzz = true
 
+[features]
+default = ["json-rpc"]
+json-rpc = ["floresta-node/json-rpc"]
+
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 arbitrary = { version = "=1.4.2", features = ["derive"] }
@@ -18,7 +22,9 @@ tempfile = { workspace = true }
 
 # Local dependencies
 floresta-chain = { workspace = true, features = ["flat-chainstore"] }
+floresta-node = { workspace = true }
 floresta-wire = { workspace = true }
+rustreexo = { workspace = true }
 
 [[bin]]
 name = "local_address_str"
@@ -96,6 +102,30 @@ path = "fuzz_targets/onion_address_str_parse.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "tip_proof_des"
+path = "fuzz_targets/tip_proof_des.rs"
+test = false
+doc = false
+bench = false
+required-features = ["json-rpc"]
+
+[[bin]]
+name = "tip_proof_from_str"
+path = "fuzz_targets/tip_proof_from_str.rs"
+test = false
+doc = false
+bench = false
+required-features = ["json-rpc"]
+
+[[bin]]
+name = "tip_proof_roundtrip"
+path = "fuzz_targets/tip_proof_roundtrip.rs"
+test = false
+doc = false
+bench = false
+required-features = ["json-rpc"]
 
 [lints]
 workspace = true

--- a/fuzz/fuzz_targets/tip_proof_des.rs
+++ b/fuzz/fuzz_targets/tip_proof_des.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use bitcoin::consensus::deserialize;
+use floresta_node::json_rpc::request::TipProof;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = deserialize::<TipProof>(data);
+});

--- a/fuzz/fuzz_targets/tip_proof_from_str.rs
+++ b/fuzz/fuzz_targets/tip_proof_from_str.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use core::str;
+use core::str::FromStr;
+
+use floresta_node::json_rpc::request::TipProof;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = match str::from_utf8(data) {
+        Ok(s) => TipProof::from_str(s),
+        Err(_) => return,
+    };
+});

--- a/fuzz/fuzz_targets/tip_proof_roundtrip.rs
+++ b/fuzz/fuzz_targets/tip_proof_roundtrip.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use std::io::Cursor;
+
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use bitcoin::BlockHash;
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::Hash;
+use floresta_node::json_rpc::request::TipProof;
+use libfuzzer_sys::fuzz_target;
+use rustreexo::node_hash::BitcoinNodeHash;
+use rustreexo::proof::Proof;
+
+fn gen_blockhash(u: &mut Unstructured<'_>) -> arbitrary::Result<BlockHash> {
+    let bytes: [u8; 32] = Arbitrary::arbitrary(u)?;
+    Ok(BlockHash::from_byte_array(bytes))
+}
+
+const MAX_TARGETS: usize = 64;
+const MAX_HASHES: usize = 64;
+
+fn gen_proof(u: &mut Unstructured<'_>) -> arbitrary::Result<Proof> {
+    let n_targets = u8::arbitrary(u)? as usize % (MAX_TARGETS + 1);
+    let mut targets = Vec::with_capacity(n_targets);
+    for _ in 0..n_targets {
+        targets.push(u64::arbitrary(u)?);
+    }
+
+    let n_hashes = u8::arbitrary(u)? as usize % (MAX_HASHES + 1);
+    let mut hashes = Vec::with_capacity(n_hashes);
+    for _ in 0..n_hashes {
+        let bytes: [u8; 32] = Arbitrary::arbitrary(u)?;
+        hashes.push(BitcoinNodeHash::Some(bytes));
+    }
+
+    Ok(Proof { targets, hashes })
+}
+
+fn gen_hashes_proven(u: &mut Unstructured<'_>) -> arbitrary::Result<Vec<BitcoinNodeHash>> {
+    let n = u8::arbitrary(u)? as usize % (MAX_HASHES + 1);
+    let mut v = Vec::with_capacity(n);
+    for _ in 0..n {
+        let bytes: [u8; 32] = Arbitrary::arbitrary(u)?;
+        v.push(BitcoinNodeHash::Some(bytes));
+    }
+    Ok(v)
+}
+
+#[derive(Arbitrary)]
+struct Inputs {
+    #[arbitrary(with = gen_blockhash)]
+    proved_at_hash: BlockHash,
+    #[arbitrary(with = gen_proof)]
+    proof: Proof,
+    #[arbitrary(with = gen_hashes_proven)]
+    hashes_proven: Vec<BitcoinNodeHash>,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(inp) = Inputs::arbitrary(&mut Unstructured::new(data)) {
+        let tip_proof = TipProof {
+            proved_at_hash: inp.proved_at_hash,
+            proof: inp.proof,
+            hashes_proven: inp.hashes_proven,
+        };
+
+        // Encode
+        let mut buf = Vec::new();
+        let written = tip_proof.consensus_encode(&mut buf).expect("encode failed");
+        assert_eq!(written, buf.len(), "encode returned wrong length");
+
+        // Decode and compare
+        let decoded = TipProof::consensus_decode(&mut Cursor::new(&buf)).expect("decode failed");
+        assert_eq!(decoded, tip_proof, "roundtrip mismatch");
+    }
+});

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def florestad_bitcoind_utreexod_with_chain(
             florestad_node.rpc.load_descriptor(descriptor)
 
         if addr_coinbase:
-            bitcoind_node.rpc.generatetoaddress(blocks, addr_coinbase)
+            bitcoind_node.rpc.generate_block_to_address(blocks, addr_coinbase)
         else:
             utreexod_node.rpc.generate(blocks)
 

--- a/tests/floresta-cli/verifyutxochaintipinclusionproof.py
+++ b/tests/floresta-cli/verifyutxochaintipinclusionproof.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+verifyutxochaintipinclusionproof.py
+
+Functional tests for the `verifyutxochaintipinclusionproof` RPC command,
+exercising every code branch:
+  - valid proof with both verbosity levels (0 and 1)
+  - multiple coinbase UTXOs proved in a single proof
+  - invalid verbosity level
+  - proof verified against an explicit blockhash (UTXO unspent → stays valid)
+  - spent UTXO invalidates proof (returns false at new tip, true at original blockhash)
+  - unknown blockhash (BlockNotFound error)
+  - invalid hex input
+  - invalid proof structure
+"""
+
+import time
+from typing import Any
+
+import pytest
+from test_framework.constants import (
+    GENESIS_BLOCK_HASH,
+    JSONRPC_ERRCODE_BLOCK_NOT_FOUND,
+    JSONRPC_ERRCODE_INVALID_PARAMS,
+    WALLET_ADDRESS_PKH,
+    WALLET_DESCRIPTOR_EXTERNAL_PKH,
+    WALLET_DESCRIPTOR_PRIV_EXTERNAL_PKH,
+)
+from test_framework.node import NodeType
+
+NUM_BLOCKS = 10
+
+
+def get_coinbase_txid(utreexod, height):
+    """Get the coinbase txid at a given block height from utreexod."""
+    block_hash = utreexod.rpc.get_blockhash(height)
+    block = utreexod.rpc.perform_request("getblock", [block_hash, 1])
+    return block["tx"][0]
+
+
+def check_verbose_0(florestad, proof_hex, expected, blockhash=None):
+    """Verify a proof with verbosity=0 and assert the boolean result."""
+    params = [proof_hex, 0]
+    if blockhash is not None:
+        params.append(blockhash)
+    result = florestad.rpc.perform_request("verifyutxochaintipinclusionproof", params)
+    assert result is expected, f"Expected {expected}, got {result}"
+    return result
+
+
+def check_verbose_1_fields(florestad, proof_hex, utreexod_proof, blockhash=None):
+    """Verify a proof with verbosity=1, validate field types, and cross-check
+    against the proof data returned by utreexod's proveutxochaintipinclusion.
+
+    Returns the verbose result dict.
+    """
+    params = [proof_hex, 1]
+    if blockhash is not None:
+        params.append(blockhash)
+    result = florestad.rpc.perform_request("verifyutxochaintipinclusionproof", params)
+
+    # Must be a dict with the expected keys (field names match utreexod)
+    assert isinstance(result, dict), f"Expected dict, got {type(result)}"
+    for key in ("valid", "provedathash", "prooftargets", "proofhashes", "hashesproven"):
+        assert key in result, f"Missing key {key!r} in verbose response"
+
+    assert result["valid"] is True
+
+    # proofhashes: non-empty list of 64-char hex strings
+    assert len(result["proofhashes"]) > 0
+    for h in result["proofhashes"]:
+        assert isinstance(h, str) and len(h) == 64, f"bad proof hash: {h}"
+        int(h, 16)  # raises ValueError if not valid hex
+
+    # hashesproven: each must be a 64-char hex string
+    for h in result["hashesproven"]:
+        assert isinstance(h, str) and len(h) == 64, f"bad proven hash: {h}"
+        int(h, 16)
+
+    # Cross-check against utreexod's proof data: the targets, proof hashes,
+    # and proven hashes from florestad's verbose response must match what
+    # utreexod originally generated.
+    assert result["prooftargets"] == utreexod_proof["prooftargets"], (
+        f"prooftargets mismatch: florestad={result['prooftargets']}, "
+        f"utreexod={utreexod_proof['prooftargets']}"
+    )
+    assert result["proofhashes"] == utreexod_proof["proofhashes"], (
+        f"proofhashes mismatch: florestad={result['proofhashes']}, "
+        f"utreexod={utreexod_proof['proofhashes']}"
+    )
+    assert result["hashesproven"] == utreexod_proof["hashesproven"], (
+        f"hashesproven mismatch: florestad={result['hashesproven']}, "
+        f"utreexod={utreexod_proof['hashesproven']}"
+    )
+
+    return result
+
+
+@pytest.mark.rpc
+class TestVerifyProofOnSharedChain:
+    """Read-only tests that share a single synced chain at NUM_BLOCKS."""
+
+    log: Any = None
+    node_manager: Any = None
+    florestad: Any = None
+    utreexod: Any = None
+
+    @pytest.fixture(autouse=True)
+    def setup_chain(
+        self, setup_logging, florestad_bitcoind_utreexod_with_chain, node_manager
+    ):
+        """Initialize a synced three-node network for read-only proof tests."""
+        self.log = setup_logging
+        self.node_manager = node_manager
+        self.florestad, _, self.utreexod = florestad_bitcoind_utreexod_with_chain(
+            NUM_BLOCKS
+        )
+        self.node_manager.wait_for_sync_nodes()
+
+    def test_valid(self):
+        """Valid proof returns True for verbosity=0 and a detailed object for verbosity=1."""
+        txid = get_coinbase_txid(self.utreexod, 1)
+        self.log.info(f"Generating proof for coinbase tx {txid} at vout 0")
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion([txid], [0])
+        proof_hex = proof_response["hex"]
+
+        self.log.info("Verifying proof with verbosity=0")
+        check_verbose_0(self.florestad, proof_hex, expected=True)
+
+        self.log.info("Verifying proof with verbosity=1")
+        result_v1 = check_verbose_1_fields(self.florestad, proof_hex, proof_response)
+
+        best_hash = self.florestad.rpc.get_bestblockhash()
+        assert result_v1["provedathash"] == best_hash
+
+        # Single UTXO proved → exactly 1 target and 1 proven hash
+        assert len(result_v1["prooftargets"]) == 1
+        assert len(result_v1["hashesproven"]) == 1
+
+    def test_multiple_coinbase_utxos(self):
+        """Prove inclusion of multiple coinbase UTXOs from different blocks."""
+        txid_1 = get_coinbase_txid(self.utreexod, 1)
+        txid_2 = get_coinbase_txid(self.utreexod, 2)
+        self.log.info(f"Proving coinbase UTXOs: {txid_1}:0 and {txid_2}:0")
+
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion(
+            [txid_1, txid_2], [0, 0]
+        )
+        proof_hex = proof_response["hex"]
+        self.log.info(f"Got proof hex ({len(proof_hex)} chars)")
+
+        check_verbose_0(self.florestad, proof_hex, expected=True)
+
+        result_v1 = check_verbose_1_fields(self.florestad, proof_hex, proof_response)
+        assert (
+            len(result_v1["prooftargets"]) == 2
+        ), f"Expected 2 targets for 2 UTXOs, got {len(result_v1['prooftargets'])}"
+        assert (
+            len(result_v1["hashesproven"]) == 2
+        ), f"Expected 2 proven hashes, got {len(result_v1['hashesproven'])}"
+
+    def test_invalid_verbosity(self):
+        """Valid proof with verbosity=2 should fail."""
+        txid = get_coinbase_txid(self.utreexod, 1)
+        self.log.info(f"Generating proof for coinbase tx {txid}")
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion([txid], [0])
+        proof_hex = proof_response["hex"]
+
+        self.log.info("Verifying proof with invalid verbosity=2")
+        self.florestad.rpc.ensure_rpc_call_error(
+            "verifyutxochaintipinclusionproof",
+            [proof_hex, 2],
+            expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
+        )
+
+    def test_with_explicit_blockhash(self):
+        """Proof can be verified against an explicit blockhash."""
+        tip_hash = self.florestad.rpc.get_bestblockhash()
+        txid = get_coinbase_txid(self.utreexod, 1)
+        self.log.info(f"Generating proof for coinbase tx {txid}")
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion([txid], [0])
+        proof_hex = proof_response["hex"]
+
+        self.log.info(f"Verifying proof against explicit blockhash {tip_hash}")
+        check_verbose_0(self.florestad, proof_hex, expected=True, blockhash=tip_hash)
+
+    def test_unknown_blockhash(self):
+        """Passing a blockhash that the node doesn't know about returns an error."""
+        txid = get_coinbase_txid(self.utreexod, 1)
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion([txid], [0])
+        proof_hex = proof_response["hex"]
+
+        # Use a plausible but non-existent blockhash (genesis hash with last
+        # char flipped). This must parse as a valid BlockHash yet not match any
+        # block the node knows about.
+        fake_hash = GENESIS_BLOCK_HASH[:-1] + (
+            "1" if GENESIS_BLOCK_HASH[-1] != "1" else "2"
+        )
+        self.log.info(f"Verifying proof against unknown blockhash {fake_hash}")
+        self.florestad.rpc.ensure_rpc_call_error(
+            "verifyutxochaintipinclusionproof",
+            [proof_hex, 0, fake_hash],
+            expected_rpcerror_code=JSONRPC_ERRCODE_BLOCK_NOT_FOUND,
+        )
+
+
+@pytest.mark.rpc
+class TestVerifyProofInvalidInput:
+    """Tests that only need a bare florestad node (no chain/utreexod)."""
+
+    log: Any = None
+    florestad: Any = None
+
+    @pytest.fixture(autouse=True)
+    def setup_node(self, setup_logging, florestad_node):
+        """Initialize a bare florestad node for invalid-input tests."""
+        self.log = setup_logging
+        self.florestad = florestad_node
+
+    def test_invalid_proof(self):
+        """Well-formed hex that doesn't decode to a valid proof should fail."""
+        garbage_proof = "aa" * 32
+        self.florestad.rpc.ensure_rpc_call_error(
+            "verifyutxochaintipinclusionproof",
+            [garbage_proof],
+            expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
+        )
+
+    def test_invalid_hex(self):
+        """Non-hex input should fail."""
+        self.florestad.rpc.ensure_rpc_call_error(
+            "verifyutxochaintipinclusionproof",
+            ["not_valid_hex!!"],
+            expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
+        )
+
+
+@pytest.mark.rpc
+class TestVerifyProofBlockhashSemantics:
+    """Tests that mine extra blocks to exercise blockhash-specific verification."""
+
+    log: Any = None
+    node_manager: Any = None
+    florestad: Any = None
+    bitcoind: Any = None
+    utreexod: Any = None
+
+    @pytest.fixture(autouse=True)
+    def setup_chain(
+        self, setup_logging, florestad_bitcoind_utreexod_with_chain, node_manager
+    ):
+        """Initialize a synced three-node network for blockhash semantics tests."""
+        self.log = setup_logging
+        self.node_manager = node_manager
+        self.florestad, self.bitcoind, self.utreexod = (
+            florestad_bitcoind_utreexod_with_chain(NUM_BLOCKS)
+        )
+        self.node_manager.wait_for_sync_nodes()
+
+    def test_proof_stays_valid_after_mining(self):
+        """Proof stays valid at the original blockhash after more blocks are mined."""
+        tip_hash = self.florestad.rpc.get_bestblockhash()
+        txid = get_coinbase_txid(self.utreexod, 1)
+        self.log.info(f"Generating proof for coinbase tx {txid}")
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion([txid], [0])
+        proof_hex = proof_response["hex"]
+
+        # Mine more blocks — the UTXO is NOT spent, so the proof stays valid
+        self.log.info("Mining more blocks (UTXO remains unspent)...")
+        self.utreexod.rpc.generate(5)
+        self.node_manager.wait_for_sync_nodes()
+
+        # Proof still valid with original blockhash (leaf was never deleted)
+        self.log.info(f"Verifying proof still valid with original blockhash {tip_hash}")
+        check_verbose_0(self.florestad, proof_hex, expected=True, blockhash=tip_hash)
+
+
+@pytest.mark.rpc
+class TestVerifyProofSpentUtxo:
+    """Test that spending a UTXO invalidates its proof at the new chain tip.
+
+    Uses a legacy P2PKH mining address so that coinbases can be spent without
+    segwit activation (utreexod activates segwit via BIP9 on regtest, which
+    requires ~432 blocks). 110 blocks is enough: 100 for coinbase maturity
+    plus a small buffer.
+    """
+
+    MATURE_CHAIN_HEIGHT = 110
+
+    log: Any = None
+    node_manager: Any = None
+    florestad: Any = None
+    bitcoind: Any = None
+    utreexod: Any = None
+
+    @pytest.fixture(autouse=True)
+    def setup_chain(self, setup_logging, node_manager):
+        """Initialize a three-node network with legacy PKH mining for spend tests."""
+        self.log = setup_logging
+        self.node_manager = node_manager
+
+        # Build a three-node network with utreexod mining to a legacy P2PKH
+        # address so we can spend coinbases without needing segwit.
+        self.florestad = node_manager.add_node_default_args(variant=NodeType.FLORESTAD)
+        self.bitcoind = node_manager.add_node_default_args(variant=NodeType.BITCOIND)
+        self.utreexod = node_manager.add_node_extra_args(
+            variant=NodeType.UTREEXOD,
+            extra_args=[
+                f"--miningaddr={WALLET_ADDRESS_PKH}",
+                "--utreexoproofindex",
+                "--prune=0",
+            ],
+        )
+        node_manager.run_node(self.florestad)
+        node_manager.run_node(self.bitcoind)
+        node_manager.run_node(self.utreexod)
+
+        # Load the PKH descriptor into florestad so it tracks our coinbases.
+        self.florestad.rpc.load_descriptor(WALLET_DESCRIPTOR_EXTERNAL_PKH)
+
+        # Mine blocks before connecting nodes (fast IBD sync).
+        self.utreexod.rpc.generate(self.MATURE_CHAIN_HEIGHT)
+
+        # Establish mesh connectivity.
+        node_manager.connect_nodes(self.florestad, self.utreexod)
+        time.sleep(3)
+        node_manager.connect_nodes(self.bitcoind, self.utreexod)
+        time.sleep(1)
+        node_manager.connect_nodes(self.florestad, self.bitcoind)
+
+        self.node_manager.wait_for_sync_nodes()
+
+        # Create a wallet on bitcoind and import the PKH private descriptor
+        # so bitcoind can sign spends of utreexod's coinbases.
+        self.bitcoind.rpc.perform_request("createwallet", ["test_wallet"])
+        self.bitcoind.rpc.perform_request(
+            "importdescriptors",
+            [[{"desc": WALLET_DESCRIPTOR_PRIV_EXTERNAL_PKH, "timestamp": "now"}]],
+        )
+
+    def test_spent_utxo_invalidates_proof(self):
+        """
+        A proof becomes invalid only when the proven UTXO is spent (leaf deleted
+        from the accumulator). Mining new blocks alone does NOT invalidate a proof
+        as long as the leaf still exists.
+        """
+        # Block 1's coinbase has >100 confirmations at height 110, so it's
+        # spendable.
+        txid = get_coinbase_txid(self.utreexod, 1)
+        self.log.info(f"Generating proof for coinbase tx {txid}:0")
+        proof_response = self.utreexod.rpc.proveutxochaintipinclusion([txid], [0])
+        proof_hex = proof_response["hex"]
+        original_tip = self.florestad.rpc.get_bestblockhash()
+
+        # Proof is valid at the current tip
+        self.log.info("Verifying proof is valid before spending...")
+        result = self.florestad.rpc.perform_request(
+            "verifyutxochaintipinclusionproof", [proof_hex, 0, original_tip]
+        )
+        assert result is True
+
+        # Spend the exact proved UTXO via a raw transaction signed by bitcoind
+        # (which has the private key) and broadcast to utreexod (which mines).
+        dest_addr = self.bitcoind.rpc.perform_request("getnewaddress", [])
+        raw_tx = self.bitcoind.rpc.perform_request(
+            "createrawtransaction",
+            [[{"txid": txid, "vout": 0}], {dest_addr: 49.99}],
+        )
+        signed = self.bitcoind.rpc.perform_request(
+            "signrawtransactionwithwallet", [raw_tx]
+        )
+        self.log.info(f"Spending proved UTXO {txid}:0 to {dest_addr}")
+        # Submit to utreexod so the tx is in its mempool for the next mined block
+        spend_txid = self.utreexod.rpc.perform_request(
+            "sendrawtransaction", [signed["hex"]]
+        )
+        self.log.info(f"Spend txid: {spend_txid}")
+
+        # Mine a block to confirm the spend
+        self.utreexod.rpc.generate(1)
+        self.node_manager.wait_for_sync_nodes()
+
+        # Proof at the original blockhash is still valid (the accumulator at that
+        # point in time still had the leaf)
+        self.log.info(
+            "Verifying proof still valid at original blockhash (pre-spend)..."
+        )
+        result = self.florestad.rpc.perform_request(
+            "verifyutxochaintipinclusionproof", [proof_hex, 0, original_tip]
+        )
+        assert result is True
+
+        # Proof at the NEW tip should return false — the leaf has been deleted
+        # from the accumulator, so stump.verify() returns Ok(false)
+        new_tip = self.florestad.rpc.get_bestblockhash()
+        self.log.info(
+            f"Verifying proof returns false at new tip {new_tip} (post-spend)..."
+        )
+        result = self.florestad.rpc.perform_request(
+            "verifyutxochaintipinclusionproof", [proof_hex, 0, new_tip]
+        )
+        assert result is False, f"Expected False after spend, got {result}"

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -380,15 +380,23 @@ class FlorestaTestFramework:
         for node in self._nodes:
             block_count = node.rpc.get_block_count()
 
-            if (
-                node.variant == NodeType.FLORESTAD
-                and is_finished_ibd
-                and node.rpc.get_blockchain_info()["initialblockdownload"]
-            ):
-                self.log.debug(
-                    f"Node '{node.variant}' has not finished IBD. Block count: {block_count}"
-                )
-                return False
+            if node.variant == NodeType.FLORESTAD and is_finished_ibd:
+                info = node.rpc.get_blockchain_info()
+                if info["initialblockdownload"]:
+                    self.log.debug(
+                        f"Node '{node.variant}' has not finished IBD. "
+                        f"Block count: {block_count}"
+                    )
+                    return False
+                # Ensure validation has caught up to the header tip.
+                # headers = best-known header height, blocks = last validated height.
+                # They diverge while blocks are still being validated.
+                if info["blocks"] < info["headers"]:
+                    self.log.debug(
+                        f"Node '{node.variant}' validation behind: "
+                        f"blocks={info['blocks']}, headers={info['headers']}"
+                    )
+                    return False
 
             if block_count != expected_block:
                 self.log.debug(

--- a/tests/test_framework/constants.py
+++ b/tests/test_framework/constants.py
@@ -29,12 +29,21 @@ WALLET_DESCRIPTOR_EXTERNAL = f"wpkh({WALLET_XPUB}/0/*)#7h6kdtnk"
 WALLET_XPUB_BIP_84 = "vpub5ZrpbMUWLCJ6MbpU1RzocWBddAQnk2XYry9JSXrtzxSqoicei28CzqUhiN2HJ8z2VjY6rsUNf4qxjym43ydhAFQJ7BDDcC2bK6et6x9hc4D"
 WALLET_ADDRESS = "bcrt1q427ze5mrzqupzyfmqsx9gxh7xav538yk2j4cft"
 
+# Legacy (P2PKH) descriptors derived from the same xpriv/xpub above.
+# Used in tests that need to spend coinbases without segwit activation.
+WALLET_DESCRIPTOR_PRIV_EXTERNAL_PKH = f"pkh({WALLET_XPRIV}/0/*)#e7wql9sy"
+WALLET_DESCRIPTOR_EXTERNAL_PKH = f"pkh({WALLET_XPUB}/0/*)#kdd2p3pr"
+WALLET_ADDRESS_PKH = "mw5ibJNmFmX9bEjZwr8Lo3YZT15XY16vpB"
+
 # JSON-RPC spec error code constants
 JSONRPC_ERRCODE_PARSE = -32700
 JSONRPC_ERRCODE_INVALID_REQUEST = -32600
 JSONRPC_ERRCODE_METHOD_NOT_FOUND = -32601
 JSONRPC_ERRCODE_INVALID_PARAMS = -32602
 JSONRPC_ERRCODE_INTERNAL = -32603
+
+# Floresta-specific server error codes (-32099..=-32000)
+JSONRPC_ERRCODE_BLOCK_NOT_FOUND = -32098
 
 # JSON-RPC error message constants
 JSONRPC_ERRMSG_MISSING_PARAMS = "Missing parameter"

--- a/tests/test_framework/rpc/floresta.py
+++ b/tests/test_framework/rpc/floresta.py
@@ -40,3 +40,16 @@ class FlorestaRPC(BaseRPC):
         Load a script descriptor into the wallet.
         """
         return self.perform_request("loaddescriptor", params=[descriptor])
+
+    def verifyutxochaintipinclusionproof(
+        self, proof: str, verbosity: int = None, blockhash: str = None
+    ) -> bool:
+        """
+        Verify Utreexo accumulator proof.
+        """
+        params = [proof]
+        if verbosity is not None or blockhash is not None:
+            params.append(verbosity)
+        if blockhash is not None:
+            params.append(blockhash)
+        return self.perform_request("verifyutxochaintipinclusionproof", params)

--- a/tests/test_framework/rpc/utreexo.py
+++ b/tests/test_framework/rpc/utreexo.py
@@ -64,3 +64,9 @@ class UtreexoRPC(BaseRPC):
             return self.perform_request("addnode", params=[node, command, v2transport])
 
         return self.perform_request("addnode", params=[node, command])
+
+    def proveutxochaintipinclusion(self, txids: list, vouts: list) -> dict:
+        """
+        Generate a Utreexo proof for UTXOs at the current chain tip.
+        """
+        return self.perform_request("proveutxochaintipinclusion", [txids, vouts])


### PR DESCRIPTION
### Description and Notes

Superseeds #819.

Implement Utreexod's `verifyutxochaintipinclusionproof`

To implement the feature of specifying a blockhash to control the block which we should verify the proof against i had to make some changes on our blockchain backend only to expose the option. 

We had three main external call points to fetch the acc from the blockchain, always the tip, BlockchainInterface::acc(), ChainState::acc() and UpdatableChainstate::get_acc(), now they are centralized into BlockChainInterface::get_acc().

This PR also includes extensive tests, unit tests for the new request structure parsing and integration tests for the rpc itself.