### PR TITLE
fix(electrum): return output index in listunspent tx_pos

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -349,11 +349,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 for (utxo, prevout) in utxos.unwrap().into_iter() {
                     let height = self.address_cache.get_height(&prevout.txid).unwrap();
 
-                    let position = self.address_cache.get_position(&prevout.txid).unwrap();
-
                     final_utxos.push(json!({
                         "height": height,
-                        "tx_pos": position,
+                        "tx_pos": prevout.vout,
                         "tx_hash": prevout.txid,
                         "value": utxo.value
                     }));
@@ -1379,10 +1377,14 @@ mod test {
             "6bb0665122c7dcecc6e6c45b6384ee2bdce148aea097896e6f3e9e08070353ea".to_string()
         );
 
+        let unspent_response = send_request(unspent_req, port).await.unwrap();
+
         assert_eq!(
-            send_request(unspent_req, port).await.unwrap()["result"][0]["tx_hash"],
+            unspent_response["result"][0]["tx_hash"],
             "6bb0665122c7dcecc6e6c45b6384ee2bdce148aea097896e6f3e9e08070353ea".to_string()
-        )
+        );
+
+        assert_eq!(unspent_response["result"][0]["tx_pos"], 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description and Notes

Fixes the blockchain.scripthash.listunspent response to return the output index in tx_pos.

The previous implementation used the cached transaction position from get_position(&prevout.txid). Electrum clients expect tx_pos in listunspent to identify the zero-based output index within the transaction, matching the UTXO outpoint.

This caused UTXOs to be reported with the wrong outpoint when a transaction's block/cache position differed from the output index. For example, the existing fixture has a cached transaction position of 1 and an unspent output at vout = 0.

This PR uses the OutPoint returned by the watch-only cache and emits prevout.vout as tx_pos. The existing test_scripthash_txs test now asserts the expected tx_pos value.

### How to verify the changes you have done?

Ran the Electrum package tests and formatting checks:

- cargo fmt --check
- cargo test -p floresta-electrum test_scripthash_txs -- --nocapture
- cargo test -p floresta-electrum

The focused test covers the regression because the fixture caches the transaction with position 1 while the unspent output is vout = 0.