### PR TITLE
Add Electrum coverage and generate_blocks_and_sync helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ markers = [
     "florestad: marks tests specific to the Florestad daemon",
     "rpc: marks tests focused on RPC calls",
     "p2p: marks tests related to peer-to-peer interactions",
+    "electrum: marks tests related to Electrum server interactions",
 ]
 
 minversion = "9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ markers = [
     "rpc: marks tests focused on RPC calls",
     "p2p: marks tests related to peer-to-peer interactions",
     "expensive: marks heavy-weight tests that only run when --run-expensive is passed",
+    "electrum: marks tests related to Electrum server interactions",
 ]
 
 minversion = "9.0"

--- a/tests/electrum/blockchain_block_header.py
+++ b/tests/electrum/blockchain_block_header.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+Tests for block header retrieval and validation in the Electrum server.
+
+This tests the blockchain.block.header endpoint which returns a block header
+at a given height, optionally with a merkle proof for verification.
+"""
+
+import random
+import pytest
+
+MINE_BLOCKS = 100
+
+
+class TestBlockchainBlockHeader:
+    """Test block header retrieval and validation."""
+
+    log = None
+    florestad = None
+    utreexod = None
+
+    @pytest.mark.electrum
+    def test_blockchain_block_header(
+        self, node_manager, setup_logging, florestad_utreexod
+    ):
+        """Test block header retrieval and validation."""
+        self.log = setup_logging
+        self.florestad, self.utreexod = florestad_utreexod
+
+        self.log.info(f"Mining {MINE_BLOCKS} blocks...")
+        node_manager.generate_blocks_and_sync(MINE_BLOCKS)
+
+        self.log.info("Testing block header invalid height superior to chain height...")
+        with pytest.raises(ValueError):
+            self.florestad.electrum.block_header(MINE_BLOCKS + 1)
+
+        self.log.info("Testing block header invalid height height negative...")
+        with pytest.raises(ValueError):
+            self.florestad.electrum.block_header(-1)
+
+        self.log.info("Testing genesis block header...")
+        self.compare_headers(0)
+
+        self.log.info(f"Testing block header at height {MINE_BLOCKS}...")
+        self.compare_headers(MINE_BLOCKS)
+
+        random_height = random.randint(1, MINE_BLOCKS - 1)
+        self.log.info(f"Testing block header at random height {random_height}...")
+        self.compare_headers(random_height)
+
+    def compare_headers(self, height):
+        """Helper function to compare block headers from Electrum and RPC."""
+        electrum_header = self.florestad.electrum.block_header(height)
+
+        block_hash = self.florestad.rpc.get_blockhash(height)
+        rpc_header = self.florestad.rpc.get_blockheader(block_hash, verbosity=False)
+
+        self.log.debug(
+            f"Electrum header: {electrum_header} and RPC header: {rpc_header}"
+        )
+        assert electrum_header == rpc_header

--- a/tests/electrum/blockchain_block_headers.py
+++ b/tests/electrum/blockchain_block_headers.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+Tests for block headers retrieval and validation in the Electrum server.
+
+This tests the blockchain.block.headers endpoint which returns a chunk
+of block headers from the main chain.
+"""
+
+import random
+import pytest
+
+from test_framework.bitcoin import BlockHeader
+
+MINE_BLOCKS = 4036
+MAX_HEADERS = 2016
+
+
+@pytest.mark.electrum
+def test_block_headers(setup_logging, node_manager, florestad_utreexod):
+    """Test block headers retrieval and validation."""
+    log = setup_logging
+    florestad, _ = florestad_utreexod
+
+    node_manager.generate_blocks_and_sync(MINE_BLOCKS, is_finished_ibd=False)
+
+    log.info("Testing out-of-range request...")
+    response = florestad.electrum.block_headers(MINE_BLOCKS + 2, 10)
+    assert response["count"] == 0
+    assert response["hex"] == ""
+    assert response["max"] == MAX_HEADERS
+
+    log.info("Testing invalid parameters...")
+    with pytest.raises(ValueError):
+        florestad.electrum.block_headers(-1, 10)
+    with pytest.raises(ValueError):
+        florestad.electrum.block_headers(0, -1)
+
+    log.info("Testing block headers starting at height 0...")
+    compare_headers_range(florestad, 0, 10)
+
+    log.info(f"Testing block headers starting at height {MINE_BLOCKS - 10}...")
+    compare_headers_range(florestad, MINE_BLOCKS - 10, 10)
+
+    random_start = random.randint(1, MINE_BLOCKS - 10)
+    log.info(f"Testing random range starting at height {random_start}...")
+    compare_headers_range(florestad, random_start, 10)
+
+    log.info("Testing max count limit...")
+    response = florestad.electrum.block_headers(0, MAX_HEADERS * 2)
+    assert response["count"] <= response["max"]
+    assert response["max"] == MAX_HEADERS
+    assert response["count"] <= MAX_HEADERS
+
+
+def compare_headers_range(florestad, start_height, count):
+    """Helper function to compare block headers from Electrum and RPC for a given range."""
+    response = florestad.electrum.block_headers(start_height, count)
+
+    assert "count" in response
+    assert "hex" in response
+    assert "max" in response
+    assert response["max"] == MAX_HEADERS
+
+    headers_hex = response["hex"]
+    header_size_hex = 160  # 80 bytes por header
+    assert len(headers_hex) % header_size_hex == 0
+
+    headers = []
+    for i in range(0, len(headers_hex), header_size_hex):
+        chunk = headers_hex[i : i + header_size_hex]
+        headers.append(BlockHeader.deserialize(bytes.fromhex(chunk)))
+
+    assert len(headers) == response["count"]
+
+    for i, header in enumerate(headers):
+        height = start_height + i
+        rpc_hash = florestad.rpc.get_blockhash(height)
+        rpc_header_hex = florestad.rpc.get_blockheader(rpc_hash, verbosity=False)
+
+        assert header.serialize().hex() == rpc_header_hex
+        assert header.hash() == rpc_hash

--- a/tests/example/electrum.py
+++ b/tests/example/electrum.py
@@ -25,5 +25,5 @@ def test_electrum(florestad_node):
     """
     rpc_response = florestad_node.electrum.get_version()
 
-    assert rpc_response["result"][0] == EXPECTED_VERSION[0]
-    assert rpc_response["result"][1] == EXPECTED_VERSION[1]
+    assert rpc_response[0] == EXPECTED_VERSION[0]
+    assert rpc_response[1] == EXPECTED_VERSION[1]

--- a/tests/floresta-cli/getbestblockhash.py
+++ b/tests/floresta-cli/getbestblockhash.py
@@ -23,9 +23,7 @@ def test_get_best_block_hash(node_manager, florestad_utreexod):
     utreexo_best_block = utreexod.rpc.get_blockchain_info()["bestblockhash"]
     assert floresta_best_block == utreexo_best_block
 
-    utreexod.rpc.generate(10)
-
-    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
+    node_manager.generate_blocks_and_sync(10, is_finished_ibd=False)
 
     utreexo_chain = utreexod.rpc.get_blockchain_info()
     floresta_best_block = florestad.rpc.get_bestblockhash()

--- a/tests/floresta-cli/getblock.py
+++ b/tests/floresta-cli/getblock.py
@@ -35,9 +35,9 @@ class TestGetBlock:
         self.log = setup_logging
         self.node_manager = node_manager
 
-        self.bitcoind.rpc.generate_block(2017)
+        self.bitcoind.rpc.generate(2017)
         time.sleep(1)
-        self.bitcoind.rpc.generate_block(6)
+        self.bitcoind.rpc.generate(6)
 
         self.node_manager.connect_nodes(self.florestad, self.bitcoind)
 

--- a/tests/floresta-cli/getblockcount.py
+++ b/tests/floresta-cli/getblockcount.py
@@ -25,9 +25,7 @@ def test_get_block_count(florestad_utreexod, node_manager):
     assert initial_florestad_count == initial_utreexod_count == 0
 
     # Mine blocks with utreexod
-    utreexod.rpc.generate(MINE_BLOCKS)
-
-    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
+    node_manager.generate_blocks_and_sync(MINE_BLOCKS, is_finished_ibd=False)
 
     # Get final block counts
     final_florestad_count = florestad.rpc.get_block_count()

--- a/tests/floresta-cli/getblockhash.py
+++ b/tests/floresta-cli/getblockhash.py
@@ -27,8 +27,7 @@ def test_get_block_hash(florestad_utreexod, node_manager):
     assert initial_florestad_hash == initial_utreexod_hash == GENESIS_BLOCK_HASH
 
     # Mine blocks with utreexod
-    utreexod.rpc.generate(MINED_BLOCKS)
-    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
+    node_manager.generate_blocks_and_sync(MINED_BLOCKS, is_finished_ibd=False)
 
     # Get final block hashes
     final_florestad_hash = florestad.rpc.get_blockhash(MINED_BLOCKS)

--- a/tests/floresta-cli/getblockheader.py
+++ b/tests/floresta-cli/getblockheader.py
@@ -52,13 +52,13 @@ class TestGetBlockheader:
         with pytest.raises(HTTPError):
             self.florestad.rpc.get_blockheader(invalid_hash, True)
 
-        self.bitcoind.rpc.generate_block(2017)
+        self.bitcoind.rpc.generate(2017)
         # Sleep is required to ensure blocks have different timestamps. In regtest, blocks are mined
         # almost instantaneously, so without this sleep, block timestamps would be nearly identical.
         # We need different timestamps to cause the median time of recent blocks to be different
         # from earlier blocks, which is necessary for proper testing.
         time.sleep(1)
-        self.bitcoind.rpc.generate_block(5)
+        self.bitcoind.rpc.generate(5)
 
         self.node_manager.connect_nodes(self.florestad, self.bitcoind)
 

--- a/tests/florestad/reorg_chain.py
+++ b/tests/florestad/reorg_chain.py
@@ -11,6 +11,9 @@ accumulator to make sure they are the same.
 
 import pytest
 
+MINE_BLOCKS = 10
+EXTRA_BLOCKS = 5
+
 
 @pytest.mark.florestad
 def test_reorg_chain(setup_logging, florestad_utreexod, node_manager):
@@ -18,60 +21,30 @@ def test_reorg_chain(setup_logging, florestad_utreexod, node_manager):
     log = setup_logging
     florestad, utreexod = florestad_utreexod
 
-    ChainReorgTest(log, florestad, utreexod, node_manager).run()
+    node_manager.generate_blocks_and_sync(MINE_BLOCKS, is_finished_ibd=False)
 
+    old_best_block_hash = florestad.rpc.get_bestblockhash()
 
-class ChainReorgTest:
-    """Tests that Florestad follows Utreexod during a chain reorganization."""
+    utreexo_block = utreexod.rpc.get_block_count()
+    count_invalid_block = 5
+    height_invalid = utreexo_block - count_invalid_block
+    hash_invalid = utreexod.rpc.get_blockhash(height_invalid)
+    utreexod.rpc.invalidate_block(hash_invalid)
 
-    def __init__(self, log, florestad, utreexod, node_manager):
-        """
-        Attributes initialized to satisfy static analysis; real values are
-        provided by pytest fixtures.
-        """
-        self.log = log
-        self.florestad = florestad
-        self.utreexod = utreexod
-        self.node_manager = node_manager
+    assert utreexod.rpc.get_block_count() < height_invalid
+    log.info(f"Utreexod node has {utreexod.rpc.get_block_count()} blocks")
+    log.info(f"Florestad node has {florestad.rpc.get_block_count()} blocks")
 
-    def run(self):
-        """Mine blocks, trigger a reorg and assert both nodes end up on the same chain."""
+    log.info(f"Mining {count_invalid_block + EXTRA_BLOCKS} blocks to trigger reorg")
+    node_manager.generate_blocks_and_sync(
+        count_invalid_block + EXTRA_BLOCKS, is_finished_ibd=False
+    )
 
-        blocks = 10
-        self.mine_blocks(blocks)
+    assert old_best_block_hash != florestad.rpc.get_bestblockhash()
+    split_block_hash = florestad.rpc.get_blockhash(height_invalid)
+    assert split_block_hash != hash_invalid
 
-        old_best_block_hash = self.florestad.rpc.get_bestblockhash()
-
-        utreexo_block = self.utreexod.rpc.get_block_count()
-        count_invalid_block = 5
-        height_invalid = utreexo_block - count_invalid_block
-        hash_invalid = self.utreexod.rpc.get_blockhash(height_invalid)
-        self.utreexod.rpc.invalidate_block(hash_invalid)
-
-        assert self.utreexod.rpc.get_block_count() < height_invalid
-        self.log.info(f"Utreexod node has {self.utreexod.rpc.get_block_count()} blocks")
-        self.log.info(
-            f"Florestad node has {self.florestad.rpc.get_block_count()} blocks"
-        )
-
-        extra_blocks = 5
-        self.log.info(
-            f"Mining {count_invalid_block + extra_blocks} blocks to trigger reorg"
-        )
-        self.mine_blocks(count_invalid_block + extra_blocks)
-
-        assert old_best_block_hash != self.florestad.rpc.get_bestblockhash()
-        split_block_hash = self.florestad.rpc.get_blockhash(height_invalid)
-        assert split_block_hash != hash_invalid
-
-        florestad_info = self.florestad.rpc.get_blockchain_info()
-        utreexod_info = self.utreexod.rpc.get_blockchain_info()
-        assert florestad_info["bestblockhash"] == utreexod_info["bestblockhash"]
-        assert florestad_info["headers"] == utreexod_info["blocks"]
-
-    def mine_blocks(self, blocks):
-        """Request Utreexod to generate blocks and wait for Florestad to sync."""
-        self.log.info(f"Utreexod node mine {blocks} blocks")
-        self.utreexod.rpc.generate(blocks)
-
-        self.node_manager.wait_for_sync_nodes(is_finished_ibd=False)
+    florestad_info = florestad.rpc.get_blockchain_info()
+    utreexod_info = utreexod.rpc.get_blockchain_info()
+    assert florestad_info["bestblockhash"] == utreexod_info["bestblockhash"]
+    assert florestad_info["headers"] == utreexod_info["blocks"]

--- a/tests/florestad/tls.py
+++ b/tests/florestad/tls.py
@@ -21,6 +21,4 @@ def test_tls(add_node_with_tls):
     assert florestad.electrum.tls
 
     response = florestad.electrum.ping()
-    assert response["result"] is None
-    assert response["id"] == 0
-    assert response["jsonrpc"] == "2.0"
+    assert response is None

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -411,6 +411,34 @@ class FlorestaTestFramework:
 
         self.log.debug("All nodes are synced")
 
+    def generate_blocks_and_sync(
+        self, blocks: int, is_finished_ibd: bool = True, address: None | str = None
+    ):
+        """Generate blocks and wait for all nodes to sync."""
+        mine_node = None
+        for node in self._nodes:
+            if address is not None and node.variant == NodeType.BITCOIND:
+                mine_node = node
+                break
+
+            if address is None and node.variant in (
+                NodeType.UTREEXOD,
+                NodeType.BITCOIND,
+            ):
+                mine_node = node
+                break
+
+        if mine_node is None:
+            raise AssertionError("No suitable node found for mining blocks")
+
+        self.log.info(f"Generating {blocks} blocks with node '{mine_node.variant}'")
+        if address is not None:
+            mine_node.rpc.generate_block_to_address(blocks, address)
+        else:
+            mine_node.rpc.generate(blocks)
+
+        self.wait_for_sync_nodes(is_finished_ibd=is_finished_ibd)
+
     def add_p2p_connection(
         self,
         node: Node,

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -425,6 +425,34 @@ class FlorestaTestFramework:
 
         self.log.debug("All nodes are synced")
 
+    def generate_blocks_and_sync(
+        self, blocks: int, is_finished_ibd: bool = True, address: None | str = None
+    ):
+        """Generate blocks and wait for all nodes to sync."""
+        mine_node = None
+        for node in self._nodes:
+            if address is not None and node.variant == NodeType.BITCOIND:
+                mine_node = node
+                break
+
+            if address is None and node.variant in (
+                NodeType.UTREEXOD,
+                NodeType.BITCOIND,
+            ):
+                mine_node = node
+                break
+
+        if mine_node is None:
+            raise AssertionError("No suitable node found for mining blocks")
+
+        self.log.info(f"Generating {blocks} blocks with node '{mine_node.variant}'")
+        if address is not None:
+            mine_node.rpc.generate_block_to_address(blocks, address)
+        else:
+            mine_node.rpc.generate(blocks)
+
+        self.wait_for_sync_nodes(is_finished_ibd=is_finished_ibd)
+
     def add_p2p_connection(
         self,
         node: Node,

--- a/tests/test_framework/electrum/base.py
+++ b/tests/test_framework/electrum/base.py
@@ -8,10 +8,17 @@ Base client to connect to Floresta's Electrum server.
 
 import json
 import socket
-from typing import Any, List, Tuple
 from OpenSSL import SSL
 
 from test_framework.electrum import ConfigElectrum
+from test_framework.util import wait_until
+
+# Read one byte at a time so the first ``\n`` terminates the message.
+# Any data that arrives after it stays in the kernel socket buffer and
+# will be returned by the next call.  This prevents coalesced messages
+# (e.g. a notification + response in one TCP segment) from being
+# concatenated into an invalid JSON payload.
+BUFFER_SIZE = 1
 
 
 # pylint: disable=too-few-public-methods
@@ -24,6 +31,8 @@ class BaseClient:
         self._conn = None
         self._config = config
         self._log = log
+        self._request_id = 0
+        self.result = None
 
     @property
     def log(self):
@@ -89,6 +98,51 @@ class BaseClient:
         else:
             self._conn = s
 
+    def receive_response(self) -> bool:
+        """
+        Receive a response from the Electrum server.
+
+        Returns True if a valid response is received, False otherwise.
+        """
+        response = self.read_response()
+        self.log.debug(f"Response: {response}")
+        result = json.loads(response)
+
+        # Notifications do not have an `id`. They can arrive before the
+        # response we are waiting for, so keep reading until the matching
+        # response shows up.
+        if result.get("id") != self._request_id:
+            if "method" in result and "id" not in result:
+                self.log.debug(f"Ignoring notification: {result}")
+                return False
+
+            self.log.debug(
+                f"Ignoring unmatched message with id {result.get('id')}: {result}"
+            )
+            return False
+
+        self.result = result
+        return True
+
+    def read_response(self) -> str:
+        """
+        Receive a single JSON-RPC message from the server (delineated by ``\\n``).
+
+        Electrum servers can send notifications asynchronously, so we may need
+        to read several messages before we get the response for the current
+        request.
+        """
+        response = b""
+        byte = self.conn.recv(BUFFER_SIZE)
+        while byte and byte != b"\n":
+            response += byte
+            byte = self.conn.recv(BUFFER_SIZE)
+        return response.decode("utf-8").strip()
+
+    def _next_request_id(self) -> int:
+        self._request_id += 1
+        return self._request_id
+
     def request(self, method, params) -> object:
         """
         Request something to Floresta server
@@ -98,54 +152,27 @@ class BaseClient:
             if not self.is_connected:
                 raise ConnectionError("Could not connect to Electrum server")
 
+        request_id = self._next_request_id()
         request = json.dumps(
-            {"jsonrpc": "2.0", "id": 0, "method": method, "params": params}
+            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
         )
 
         mnt_point = "/".join(method.split("."))
         self.log.debug(f"GET electrum://{mnt_point}?params={params}")
         self.conn.sendall(request.encode("utf-8") + b"\n")
 
-        response = b""
-        while True:
-            chunk = self.conn.recv(1)
-            if not chunk:
-                break
-            response += chunk
-            if b"\n" in response:
-                break
-        response = response.decode("utf-8").strip()
-        self.log.debug(response)
+        # pylint: disable=unnecessary-lambda
+        # Lambda is required here because wait_until needs a callable to invoke
+        # repeatedly until it returns True. Without it, receive_response() would
+        # execute immediately and pass its result, not a function.
+        wait_until(lambda: self.receive_response(), interval=0)
 
-        return json.loads(response)
-
-    def batch_request(self, calls: List[Tuple[str, List[Any]]]) -> object:
-        """
-        Send batch JSON-RPC requests to electrum's server.
-        """
-        request_map = {
-            i: {"jsonrpc": "2.0", "id": i, "method": method, "params": params}
-            for i, (method, params) in enumerate(calls)
-        }
-
-        request_list = list(request_map.values())
-        self.log.debug(
-            "BATCH "
-            + ", ".join(
-                f"electrum://{'/'.join(m.split('.'))}?params={p}" for m, p in calls
+        # Check for JSON-RPC error response
+        error = self.result.get("error")
+        if error is not None:
+            raise ValueError(
+                f"Electrum RPC error {error.get('code')}: {error.get('message')}"
             )
-        )
-        self.conn.sendall(json.dumps(request_list).encode("utf-8") + b"\n")
 
-        response = b""
-        while True:
-            chunk = self.conn.recv(1)
-            if not chunk:
-                break
-            response += chunk
-            if b"\n" in response:
-                break
-
-        response = response.decode("utf-8").strip()
-        self.log.debug(response)
-        return response
+        # Return only the result, not the whole response
+        return self.result.get("result")

--- a/tests/test_framework/electrum/client.py
+++ b/tests/test_framework/electrum/client.py
@@ -24,11 +24,12 @@ class ElectrumClient(BaseClient):
         """
         return self.request("blockchain.block.header", [block_hash])
 
-    def get_headers(self, start_height: int, stop_height: int):
+    def block_headers(self, start_height: int, count: int):
         """
-        Returns all headers in the best known tip.
+        Return a chunk of block headers from the main chain, starting at `start_height` and
+        returning at most `count` headers.
         """
-        return self.request("blockchain.block.headers", [start_height, stop_height])
+        return self.request("blockchain.block.headers", [start_height, count])
 
     def estimate_fee(self, target: int):
         """

--- a/tests/test_framework/rpc/bitcoin.py
+++ b/tests/test_framework/rpc/bitcoin.py
@@ -45,7 +45,7 @@ class BitcoinRPC(BaseRPC):
         """
         return self.perform_request("verifytxoutproof", params=[proof])
 
-    def generate_block(self, nblocks: int) -> list:
+    def generate(self, nblocks: int) -> list:
         """
         Mine blocks immediately to a address(bcrt1q3ml87jemlfvk7lq8gfs7pthvj5678ndnxnw9ch) using
         `generate_block_to_address(nblocks, address)`


### PR DESCRIPTION
### Description and Notes

This change adds integration test coverage for Electrum-related behavior, focusing on the `blockchain.block.headers` and `blockchain.block.header` endpoints. The new tests compare Electrum headers with RPC responses to validate consistency, while also checking error handling for invalid parameters, out-of-range requests, valid ranges, and maximum count limits. They also include random height validation to improve coverage.

To simplify the integration tests, this change also introduces the generate_blocks_and_sync helper. The helper automatically selects a node capable of mining blocks (bitcoind or utreexod), generates the requested blocks, and waits until all nodes are synchronized before returning.

If a coinbase address is provided, the helper always uses bitcoind, since custom coinbase addresses are only supported there. If no suitable node is available for the requested operation, the helper returns an error.

Supporting changes were also made to improve the integration framework, including renaming `ElectrumClient.get_headers()` to `block_headers()`, changing the Electrum response key from `hex` to `headers`, and improving socket buffer reading and JSON-RPC error handling.

### How to verify the changes you have done?

- Run the integration test suite and confirm the new Electrum endpoint tests pass.
- Verify that `blockchain.block.headers` and `blockchain.block.header` return results consistent with RPC responses.
- Confirm that invalid and out-of-range requests return the expected errors.
- Verify that `generate_blocks_and_sync` correctly mines blocks using an appropriate node and waits until all nodes are synchronized before returning.