### PR TITLE
chore(nix): add direnv .envrc to auto-load the flake devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake


### PR DESCRIPTION
## What

Adds a minimal `.envrc` containing `use flake` to the repository, so that [direnv](https://direnv.net/) automatically loads the Nix devshell when you `cd` into the project.

```sh
$ cat .envrc
use flake
```

The generated `.direnv/` cache stays gitignored (as it already is) — only the tiny, declarative `.envrc` is tracked.

## Why

Floresta's development workflow already allows Nix: building and testing pull dependencies from the flake's devshell (e.g. `libbitcoinkernel-sys`). The repo ships a `flake.nix` and **already gitignores `.direnv/`**, which only makes sense if a direnv-based workflow is expected. The one file that actually wires that up  (`.envrc`) was simply never tracked.

Committing `.envrc` closes that gap.

## On the alternative (gitignoring `.envrc`)

There is a school of thought that `.envrc` is personal/local config and should be gitignored (the direnv project itself does this). That's a reasonable stance for projects where direnv is incidental. I'm okay with this approach as well if mantainers think its best