### PR TITLE
chore: add my dns seed to testnet, mainnet and update the signet one

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -406,6 +406,7 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
     let x9 = ServiceFlags::NETWORK | ServiceFlags::WITNESS;
     let x49 = ServiceFlags::NETWORK | ServiceFlags::WITNESS | ServiceFlags::COMPACT_FILTERS;
     let x1009 = ServiceFlags::NETWORK | ServiceFlags::WITNESS | service_flags::UTREEXO.into();
+    let x1000 = service_flags::UTREEXO.into();
 
     #[rustfmt::skip]
     match network {
@@ -419,13 +420,15 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
             seeds.push(DnsSeed::new(Network::Bitcoin, "seed.bitcoin.sprovoost.nl", x49));
             seeds.push(DnsSeed::new(Network::Bitcoin, "dnsseed.emzy.de", x49));
             seeds.push(DnsSeed::new(Network::Bitcoin, "seed.bitcoin.wiz.biz", x49));
+            seeds.push(DnsSeed::new(Network::Bitcoin, "bitcoin.seed.dlsouza.lol", x1000));
         }
         Network::Signet => {
-            seeds.push(DnsSeed::new(Network::Signet, "seed.dlsouza.lol", x1009));
+            seeds.push(DnsSeed::new(Network::Signet, "signet.seed.dlsouza.lol", x1000));
             seeds.push(DnsSeed::new(Network::Signet, "seed.signet.bitcoin.sprovoost.nl", x49));
         }
         Network::Testnet => {
             seeds.push(DnsSeed::new(Network::Testnet, "testnet-seed.bitcoin.jonasschnelli.ch", x49));
+            seeds.push(DnsSeed::new(Network::Testnet, "testnet.seed.dlsouza.lol", x1000));
             seeds.push(DnsSeed::new(Network::Testnet, "seed.tbtc.petertodd.org", x49));
             seeds.push(DnsSeed::new(Network::Testnet, "seed.testnet.bitcoin.sprovoost.nl", x49));
             seeds.push(DnsSeed::new(Network::Testnet, "testnet-seed.bluematt.me", none));


### PR DESCRIPTION
### Description and Notes

It seems crawlers are having a hard time finding `utreexod` ndoes, so none of our DNS seeds responds to `x1000` requests. This new DNS seed will serve a fresh list of Utreexo nodes, maintained by me and updated frequently.

On my local tests with fresh starts, every time I was able to find a utreexo peer to IBD off.

### How to verify the changes you have done?

Start your node with this check and notice how it doesn't get stuck looking for utreexo peers.
