### PR TITLE
Pin all dependencies to the latest compatible patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,36 +43,34 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
-# Version Convention: Use major.minor only (e.g., "1.9" not "1.9.1")
-# We accept all compatible patch versions, so specifying patch level is misleading.
-# For exact versions when needed, use "=1.9.1"
 [workspace.dependencies]
-axum = { version = "0.8", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
+# All dependencies MUST be pinned precisely with `X.Y.z`
+axum = { version = "=0.8.9", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
 bitcoin = { version = "=0.32.8", default-features = false }
-clap = { version = "4.5", default-features = false, features = ["derive", "std"] }
-corepc-types = "0.11"
-console-subscriber = { version = "0.5", default-features = false }
-dns-lookup = "2.1"
-hex = "0.4"
-kv = "0.24"
-miniscript = { version = "12.3", default-features = false }
-rand = "0.9"
+clap = { version = "=4.6.1", default-features = false, features = ["derive", "std"] }
+corepc-types = "=0.11.0"
+console-subscriber = { version = "=0.5.0", default-features = false }
+dns-lookup = "=2.1.1"
+hex = "=0.4.3"
+kv = "=0.24.0"
+miniscript = { version = "=12.3.6", default-features = false }
+rand = "=0.9.4"
 rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "pem"] }
-rustreexo = "0.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sha2 = { version = "0.10", default-features = false }
-spin = { version = "0.10", default-features = false, features = ["spin_mutex", "rwlock"] }
-tempfile = "3.23"
-tokio = { version = "1.48", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
-toml = { version = "0.9", default-features = false, features = ["std", "parse", "serde"] }
-tracing = { version = "0.1", default-features = false }
-zstd = "0.13"
+rustreexo = "=0.5.0"
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.150"
+sha2 = { version = "=0.10.9", default-features = false }
+spin = { version = "=0.10.0", default-features = false, features = ["spin_mutex", "rwlock"] }
+tempfile = "=3.27.0"
+tokio = { version = "=1.52.3", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
+tokio-rustls = { version = "=0.26.4", default-features = false, features = ["ring", "tls12"] }
+toml = { version = "=0.9.12", default-features = false, features = ["std", "parse", "serde"] }
+tracing = { version = "=0.1.44", default-features = false }
+zstd = "=0.13.3"
 # Pins for MSRV compatibility:
-time = { version = "=0.3.45" }
-tonic = { version = "=0.14.5" }
-tonic-prost = { version = "=0.14.5" }
+time = { version = "=0.3.45" } # note: >0.3.45 requires Rust 1.88.0
+tonic = { version = "=0.14.5" } # note: >0.14.5 requires Rust 1.88.0
+tonic-prost = { version = "=0.14.5" } # note: >0.14.5 requires Rust 1.88.0
 
 # Local dependencies
 floresta-chain = { path = "crates/floresta-chain" }

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -17,7 +17,8 @@ keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
-anyhow = "1.0"
+# All dependencies MUST be pinned precisely with `X.Y.z`
+anyhow = "=1.0.102"
 bitcoin = { workspace = true }
 clap = { workspace = true, features = ["help"] }
 serde_json = { workspace = true }

--- a/bin/florestad/Cargo.toml
+++ b/bin/florestad/Cargo.toml
@@ -20,20 +20,21 @@ keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 clap = { workspace = true, features = ["help"] }
 console-subscriber = { workspace = true, optional = true }
-dirs = { version = "4.0", default-features = false }
+dirs = { version = "=4.0.0", default-features = false }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { version = "0.2", default-features = false }
-tracing-subscriber = { version = "0.3", features = ["chrono", "ansi", "env-filter"] }
+tracing-appender = { version = "=0.2.5", default-features = false }
+tracing-subscriber = { version = "=0.3.23", features = ["chrono", "ansi", "env-filter"] }
 
 # Local dependencies
 floresta-node = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2" }
+libc = { version = "=0.2.186" }
 
 [build-dependencies]
 toml = { workspace = true }

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -19,16 +19,17 @@ categories = ["cryptography::cryptocurrencies", "database"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
-bitcoinkernel = { version = "0.2", optional = true }
-lru = { version = "0.16", optional = true }
-memmap2 = { version = "0.9", optional = true }
+bitcoinkernel = { version = "=0.2.0", optional = true }
+lru = { version = "=0.16.4", optional = true }
+memmap2 = { version = "=0.9.10", optional = true }
 rustreexo = { workspace = true }
 serde = { workspace = true, optional = true }
 sha2 = { workspace = true, features = ["std"] }
 spin = { workspace = true }
 tracing = { workspace = true }
-twox-hash = { version = "2.1", default-features = false, features = ["xxhash3_64", "std"], optional = true }
+twox-hash = { version = "=2.1.2", default-features = false, features = ["xxhash3_64", "std"], optional = true }
 
 # Local dependencies
 floresta-common = { workspace = true, features = ["std"] }
@@ -36,7 +37,7 @@ metrics = { workspace = true,  optional = true }
 
 [dev-dependencies]
 bitcoin = { workspace = true, features = ["serde"] }
-criterion = "0.7"
+criterion = "=0.7.0"
 hex = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -10,8 +10,9 @@ repository = "https://github.com/getfloresta/Floresta"
 readme.workspace = true # Floresta/README.md
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
-hashbrown = { version = "0.16" }
+hashbrown = { version = "=0.16.1" }
 sha2 = { workspace = true }
 spin = { workspace = true }
 

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -16,11 +16,12 @@ keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 rustreexo = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-thiserror = "2.0"
+thiserror = "=2.0.18"
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }

--- a/crates/floresta-mempool/Cargo.toml
+++ b/crates/floresta-mempool/Cargo.toml
@@ -15,7 +15,8 @@ readme.workspace = true
 keywords = ["bitcoin", "mempool", "transactions"]
 
 [dependencies]
-ahash = { version = "0.8", default-features = false }
+# All dependencies MUST be pinned precisely with `X.Y.z`
+ahash = { version = "=0.8.12", default-features = false }
 bitcoin = { workspace = true }
 rand = { workspace = true }
 rustreexo = { workspace = true }

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -8,6 +8,7 @@ readme.workspace = true # Floresta/README.md
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 axum = { workspace = true, optional = true }
 bitcoin = { workspace = true }
 corepc-types = { workspace = true }
@@ -20,9 +21,9 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 toml = { workspace = true }
-tower-http = { version = "0.6", optional = true, features = ["cors"] }
+tower-http = { version = "=0.6.11", optional = true, features = ["cors"] }
 tracing = { workspace = true }
-zmq = { version = "0.10", optional = true, default-features = false }
+zmq = { version = "=0.10.0", optional = true, default-features = false }
 time = { workspace = true }
 
 # Local dependencies
@@ -36,13 +37,13 @@ floresta-wire = { workspace = true }
 metrics = { workspace = true,  optional = true }
 
 [dev-dependencies]
-pretty_assertions = "1.4"
+pretty_assertions = "=1.4.1"
 
 [target.'cfg(target_env = "gnu")'.dependencies]
-libc = "0.2"
+libc = "=0.2.186"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-libc = "0.2"
+libc = "=0.2.186"
 
 [features]
 compact-filters = ["dep:floresta-compact-filters"]

--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -16,10 +16,11 @@ keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 clap = { workspace = true, optional = true }
 corepc-types = { workspace = true }
-jsonrpc = { version = "0.19", features = ["bitreq_http"], optional = true }
+jsonrpc = { version = "=0.19.0", features = ["bitreq_http"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -16,20 +16,20 @@ keywords = ["bitcoin", "utreexo", "p2p", "networking"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 
 [dependencies]
-bip324 = { version = "0.10", features = [ "tokio" ] }
+# All dependencies MUST be pinned precisely with `X.Y.z`
+bip324 = { version = "=0.10.0", features = [ "tokio" ] }
 bitcoin = { workspace = true }
 dns-lookup = { workspace = true }
 rand = { workspace = true }
-rustls = { version = "0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { version = "=0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
 rustreexo = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
-ureq = { version = "3.1", features = ["socks-proxy", "json", "rustls-no-provider"], default-features = false }
-# These pins are needed for MSRV:
-tonic = { version = "=0.14.5" }
-tonic-prost = { version = "=0.14.5" }
+ureq = { version = "=3.3.0", features = ["socks-proxy", "json", "rustls-no-provider"], default-features = false }
+tonic = { workspace = true }
+tonic-prost = { workspace = true }
 
 # Local dependencies
 floresta-chain = { workspace = true, features = ["flat-chainstore"] }
@@ -40,7 +40,7 @@ metrics = { workspace = true,  optional = true }
 
 [dev-dependencies]
 zstd = { workspace = true }
-derive_more = { version = "2.1", features = ["constructor"] }
+derive_more = { version = "=2.1.1", features = ["constructor"] }
 
 [features]
 default = []

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,10 @@ edition.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1.4", features = ["derive"] }
+# All dependencies MUST be pinned precisely with `X.Y.z`
+arbitrary = { version = "=1.4.2", features = ["derive"] }
 bitcoin = { workspace = true }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = "=0.4.12"
 tempfile = { workspace = true }
 
 # Local dependencies

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -8,9 +8,10 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# All dependencies MUST be pinned precisely with `X.Y.z`
 axum = { workspace = true }
-prometheus-client = "0.22"
-sysinfo = { version = "0.36", default-features = false, features = ["system"] }
+prometheus-client = "=0.22.3"
+sysinfo = { version = "=0.36.1", default-features = false, features = ["system"] }
 tokio = { workspace = true }
 
 [lints]


### PR DESCRIPTION
Closes #1083 

This PR pins all dependencies in the workspace to the latest compatible patch version (a few bump to the next minor version due to RUSTSECs). From now on, every dependency bump MUST (the [RFC 2119 MUST](https://datatracker.ietf.org/doc/html/rfc2119#section-1)) be audited and manually bumped by us.

This will fix pretty much all unexpected CI breakage; before, most dependencies only had a minor version specified, and most crates don't respect [SemVer](https://semver.org) and bump MSRV on a patch release. Now, things only break when we intentionally bump something, except for GitHub-related issues.

There's also the added benefits that newly released and compromised crates don't get pulled in, the amount of duplicate package versions in the dependency tree is minimized, and helps to make deterministic builds possible.

## Changelog
```
- Workspace:
  - Pin `axum` from `0.8` to `=0.8.9`
  - Pin `bitcoin` from `=0.32.8` to `=0.32.8`
  - Pin `clap` from `4.5` to `=4.6.1`
  - Pin `console-subscriber` from `0.5` to `=0.5.0`
  - Pin `corepc-types` from `0.11` to `=0.13.0`
  - Pin `dns-lookup` from `2.1` to `=2.1.1`
  - Pin `hex` from `0.4` to `=0.4.3`
  - Pin `kv` from `0.24` to `=0.24.0`
  - Pin `miniscript` from `12.3` to `=12.3.6`
  - Pin `rand` from `0.9` to `=0.9.4`
  - Pin `rcgen` from `=0.14.7` to `=0.14.7` [>0.14.8 requires rustc 1.88]
  - Pin `rustreexo` from `0.5` to `=0.5.0`
  - Pin `serde` from `1.0` to `=1.0.228`
  - Pin `serde_json` from `1.0` to `=1.0.150`
  - Pin `sha2` from `0.10` to `=0.10.9`
  - Pin `spin` from `0.10` to `=0.10.0`
  - Pin `tempfile` from `3.23` to `=3.27.0`
  - Pin `time` from `=0.3.45` to `=0.3.45` [>0.3.45 requires rustc 1.88]
  - Pin `tokio` from `1.48` to `=1.52.3`
  - Pin `tokio-rustls` from `0.26` to `=0.26.4`
  - Pin `toml` from `0.9` to `=0.9.12`
  - Pin `tonic` from `=0.14.5` to `=0.14.5` [>0.14.5 requires rustc 1.88
  - Pin `tonic-prost` from `=0.14.5` to `=0.14.5` [>0.14.5 requires rustc 1.88]
  - Pin `tracing` from `0.1` to `=0.1.44`
  - Pin `zstd` from `0.13` to `=0.13.3`

- `crates/floresta-chain`:
  - Pin `bitcoinkernel` from `0.2` to `=0.2.0`
  - Pin `criterion` from `0.7` to `=0.7.0`
  - Pin `lru` from `0.16` to `=0.16.4`
  - Pin `memmap2` from `0.9` to `=0.9.10`
  - Pin `twox-hash` from `2.1` to `=2.1.2`

- `crates/floresta-common`:
  - Pin `hashbrown` from `0.16` to `=0.16.1`

- `crates/floresta-electrum`:
  - Pin `thiserror` from `2.0` to `=2.0.18`

- `crates/floresta-mempool`:
  - Pin `ahash` from `0.8` to `=0.8.12`

- `crates/floresta-node`:
  - Pin `libc` from `0.2` to `=0.2.186`
  - Pin `pretty_assertions` from `1.4` to `=1.4.1`
  - Pin `tower-http` from `0.6` to `=0.6.11`
  - Pin `zmq` from `0.10` to `=0.10.0`

- `crates/floresta-rpc`:
  - Pin `jsonrpc` from `0.19` to `=0.19.0`

- `crates/floresta-wire`:
  - Pin `bip324` from `0.10` to `=0.10.0`
  - Pin `derive_more` from `2.1` to `=2.1.1`
  - Pin `rustls` from `0.23.40` to `=0.23.40`
  - Pin `tonic` from `=0.14.5` to `workspace = true`
  - Pin `tonic-prost` from `=0.14.5` to `workspace = true`
  - Pin `ureq` from `3.1` to `=3.3.0`

- `bin/floresta-cli`:
  - Pin `anyhow` from `1.0` to `=1.0.102`

- `bin/florestad`:
  - Pin `dirs` from `4.0` to `=4.0.0`
  - Pin `libc` from `0.2` to `=0.2.186`
  - Pin `tracing-appender` from `0.2` to `=0.2.5`
  - Pin `tracing-subscriber` from `0.3` to `=0.3.23`

- `fuzz`:
  - Pin `arbitrary` from `1.4` to `=1.4.2`
  - Pin `libfuzzer-sys` from `0.4` to `=0.4.12`

- `metrics`:
  - Pin `prometheus-client` from `0.22` to `=0.22.3`
  - Pin `sysinfo` from `0.36` to `=0.36.1`
```
