### PR TITLE
Add ShellCheck to CI and fix audit findings

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-name: Zizmor
+name: Audit
 
 on:
     push:
@@ -12,8 +12,21 @@ on:
 permissions: {}
 
 jobs:
+    shellcheck:
+        name: ShellCheck
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run ShellCheck
+              run: find . -name '*.sh' -print -exec shellcheck {} +
+
     zizmor:
-        name: CI Action Static Analysis
+        name: Zizmor
         runs-on: ubuntu-latest
 
         steps:

--- a/contrib/dist/gen_manpages.sh
+++ b/contrib/dist/gen_manpages.sh
@@ -34,7 +34,8 @@ convert_single() {
     fi
 
     # Extract filename without extension
-    local basename=$(basename "$file" .md)
+    local basename
+    basename=$(basename "$file" .md)
 
     # Skip the template stub file
     if [[ "$basename" == "template" ]]; then

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -108,8 +108,7 @@ check_interactive_mode() {
 }
 
 # Use getopt for long options
-OPTIONS=$(getopt -o x:d:a:n:t:p:C:z:v:f:usUNh --long xpub:,desc:,address:,network:,tag:,proxy:,connect:,zmq-address:,assume-valid:,filters:,assume-utreexo,tls,uninstall,non-interactive,help -n "$0" -- "$@")
-if [ $? -ne 0 ]; then
+if ! OPTIONS=$(getopt -o x:d:a:n:t:p:C:z:v:f:usUNh --long xpub:,desc:,address:,network:,tag:,proxy:,connect:,zmq-address:,assume-valid:,filters:,assume-utreexo,tls,uninstall,non-interactive,help -n "$0" -- "$@"); then
     show_usage
     exit 1
 fi
@@ -218,11 +217,15 @@ done
 #   - testnet
 #   - regtest
 validate_network() {
-    valid_networks=("bitcoin" "signet" "testnet3" "testnet4" "regtest")
-    if [[ ! " ${valid_networks[@]} " =~ " ${network} " ]]; then
-        echo "❌ Invalid network '$network'. Valid options are: ${valid_networks[*]}"
-        exit 1
-    fi
+    local valid_networks=("bitcoin" "signet" "testnet3" "testnet4" "regtest")
+    local valid
+    for valid in "${valid_networks[@]}"; do
+        if [[ "$network" == "$valid" ]]; then
+            return 0
+        fi
+    done
+    echo "❌ Invalid network '$network'. Valid options are: ${valid_networks[*]}"
+    exit 1
 }
 
 # func: apt_install
@@ -266,19 +269,20 @@ install_rustup() {
         export PATH=/home/$me/.cargo/bin:$PATH
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --no-modify-path
 
-        chown $me:$me -R /home/$me/.cargo
+        chown "$me":"$me" -R /home/"$me"/.cargo
 
         # Load it on profile
-        echo "source /home/$me/.cargo/env" >>/home/$me/.profile
-        source /home/$me/.cargo/env
+        echo "source /home/$me/.cargo/env" >>/home/"$me"/.profile
+        # shellcheck source=/dev/null
+        source /home/"$me"/.cargo/env
     else
         echo "🦀 Rustup found in $haveRust. Skip download..."
     fi
 
-    isUpdated=$(/home/$me/.cargo/bin/rustup check | grep -B 1 "Up to date")
+    isUpdated=$(/home/"$me"/.cargo/bin/rustup check | grep -B 1 "Up to date")
     if [ -z "$isUpdated" ]; then
         echo "🦀 Updating rust..."
-        /home/$me/.cargo/bin/rustup update
+        /home/"$me"/.cargo/bin/rustup update
     else
         echo "🦀 Skip rust update..."
     fi
@@ -288,7 +292,7 @@ install_rustup() {
 #
 # Clean all downloaded or installed things
 clean_on_error() {
-    rm $1
+    rm "$1"
     rm -rf "$tarDest"
     rm -rf "$bdlDir"
     cleanup_apt gcc build-essential pkg-config libssl-dev mold
@@ -341,13 +345,14 @@ download_floresta() {
         clean_on_error "$ascDest"
     fi
 
-    cd /tmp
-    tarBaseName=$(basename "$tarDest")
-    if ! grep "$tarBaseName" "$shaDest" | sha256sum -c --status -; then
-        echo "❌ Integrity check failed for $tarDest"
-        clean_on_error "$tarDest"
-    fi
-    cd - >/dev/null
+    (
+        cd /tmp || exit 1
+        tarBaseName=$(basename "$tarDest")
+        if ! grep "$tarBaseName" "$shaDest" | sha256sum -c --status -; then
+            echo "❌ Integrity check failed for $tarDest"
+            clean_on_error "$tarDest"
+        fi
+    ) || exit 1
     echo "🌳 Integrity check passed"
 }
 
@@ -357,11 +362,11 @@ download_floresta() {
 # and floresta-cli (command line interface) into /usr/local/bin
 build_floresta() {
     echo "🌳 Extracting floresta $tarDest to /tmp..."
-    tar -xzf $tarDest -C /tmp
+    tar -xzf "$tarDest" -C /tmp
 
     echo "🦀 Building florestad and floresta-cli $defaultTag..."
-    cd $bdlDir
-    RUSTFLAGS="-C link-arg=-fuse-ld=mold -C target-cpu=native"
+    cd "$bdlDir" || exit
+    export RUSTFLAGS="-C link-arg=-fuse-ld=mold -C target-cpu=native"
     cargo build --release \
         --bin florestad \
         --bin floresta-cli \
@@ -369,8 +374,8 @@ build_floresta() {
         --locked
 
     echo "🌳 Copying binaries to /usr/local/bin (need sudo)..."
-    sudo install -m 0755 -t /usr/local/bin/ $bdlDir/target/release/florestad
-    sudo install -m 0755 -t /usr/local/bin/ $bdlDir/target/release/floresta-cli
+    sudo install -m 0755 -t /usr/local/bin/ "$bdlDir"/target/release/florestad
+    sudo install -m 0755 -t /usr/local/bin/ "$bdlDir"/target/release/floresta-cli
 }
 
 # func: setup_service
@@ -385,8 +390,7 @@ setup_service() {
     echo "🐧 Setup floresta sysusers.d..."
     echo "u florestad - - $florestaDir" | sudo tee $florestaUserPath >/dev/null
     echo "🐧 Applying $florestaUserPath (need sudo)"
-    sudo systemd-sysusers
-    if [ $? -ne 0 ]; then
+    if ! sudo systemd-sysusers; then
         echo "❌ Failed to create systemd-sysusers"
         exit 1
     fi
@@ -396,8 +400,7 @@ setup_service() {
     echo "d $florestaDir 0710 florestad florestad - -" | sudo tee $florestaTmpPath >/dev/null
     echo "d $florestaLib 0710 florestad florestad - -" | sudo tee -a $florestaTmpPath >/dev/null
     echo "🐧 Applying $florestaTmpPath (need sudo)"
-    sudo systemd-tmpfiles --create
-    if [ $? -ne 0 ]; then
+    if ! sudo systemd-tmpfiles --create; then
         echo "❌ Failed to create systemd-tmpfiles"
         exit 1
     fi
@@ -917,7 +920,7 @@ interactive_select_proxy() {
         check_dialog_escape
 
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$edited" -ne 0 ]; then
             dialog --title "Floresta" \
                 --msgbox "❌ Proxy input canceled. Returning to setup menu." 8 45
             check_dialog_escape
@@ -960,18 +963,19 @@ interactive_connect() {
             --inputbox "We'll connect ONLY to this node. It should be an ipv4 address in the format <address>[:<port>]." \
             10 60 \
             3>&1 1>&2 2>&3)
+        result=$?
         check_dialog_escape
 
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$result" -ne 0 ]; then
             dialog --title "Floresta-Installer" --msgbox "❌ Connect input canceled. Returning to setup menu." 8 45
             check_dialog_escape
             interactive_advanced_setup
             return 1
         fi
 
-        # Validate proxy format
-        if [[ "$proxy" =~ $proxy_regex ]]; then
+        # Validate connect format
+        if [[ "$connect" =~ $connect_regex ]]; then
             dialog --title "Floresta-Installer" --msgbox "✅ A node to connect to set successfully: $connect" 10 60
             check_dialog_escape
             interactive_advanced_setup
@@ -995,9 +999,10 @@ interactive_zeromq() {
             --inputbox "ZMQ is a lightweight and efficient message queue system used for Inter Process Communication. Floresta allows you to use this to get notified about new blocks. This option sets the socket that floresta will listen for ZMQ subscribers (IPv4:port or [IPv6]:port)." \
             10 60 \
             3>&1 1>&2 2>&3)
+        result=$?
 
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$result" -ne 0 ]; then
             dialog --title "Floresta-Installer (Set zeromq)" --msgbox "❌ ZeroMQ input canceled. Returning to setup menu." 8 45
             check_dialog_escape
             interactive_advanced_setup
@@ -1025,16 +1030,16 @@ interactive_filters() {
 
     while true; do
         # Prompt user for filters_start_height input
-        echo "sha256sum: $sha256res == $sha256exp"
         filters_start_height=$(dialog --title "Floresta-Installer (Set enable filters)" \
             --inputbox $'Do you want to use \'cfilters\' and \'filters-start-height\'?\n\n"cfilters" let you query for chain data after IBD, like wallet rescan, finding a utxo, finding specific tx_ids. Will cause more disk usage.\n\n"filters-start-height" download block filters starting at this height. Negative numbers are relative to the current tip. For example, if the current tip is at height 1000, and we set this value to -100, we will start downloading filters from height 900.\n' \
             20 60 \
             3>&1 1>&2 2>&3)
+        result=$?
 
         check_dialog_escape
 
         # Check if user pressed Cancel or ESC
-        if [ $? -ne 0 ]; then
+        if [ "$result" -ne 0 ]; then
             enable_cfilters=false
             dialog --title "Floresta-Installer (Set enable filters)" --msgbox "❌ Enable filters input canceled. Returning to setup menu." 8 45
             check_dialog_escape
@@ -1064,8 +1069,7 @@ interactive_ask_assume_valid() {
 
     if dialog --title "Floresta-Installer" --yesno "Do you want to use 'assume-valid'?\n\nThis option assumes that scripts before this height are valid." 15 60; then
         check_dialog_escape
-        interactive_assume_valid
-        if [ $? -ne 0 ]; then
+        if ! interactive_assume_valid; then
             assume_valid="" # Clear invalid value
             dialog --title "Floresta-Installer" --msgbox "❌ Invalid BLOCK_HEIGHT detected. Must be a numeric value." 8 45
             check_dialog_escape
@@ -1243,23 +1247,26 @@ interactive_ask_for_add_descriptors() {
 # wallet_descriptors array and show a confirmation.
 # If the user provides an invalid one, clear the list and restart the process.
 interactive_add_descriptor() {
-    local temp_file=$(mktemp)
+    local temp_file temp_out
+    temp_file=$(mktemp)
+    temp_out=$(mktemp)
     echo "" >"$temp_file"
 
     while true; do
         dialog --title "Floresta" \
-            --editbox "$temp_file" 15 80 2>"$temp_file"
+            --editbox "$temp_file" 15 80 2>"$temp_out"
 
         edited=$?
+        cp "$temp_out" "$temp_file"
         check_dialog_escape
 
         result=$?
-        if [ result -ne 0 ]; then
-            rm -f "$temp_file"
+        if [ "$result" -ne 0 ]; then
+            rm -f "$temp_file" "$temp_out"
             return 1
         fi
 
-        descriptor=$(<"$temp_file")
+        descriptor=$(<"$temp_out")
         descriptor=$(echo "$descriptor" | tr -d '[:space:]')
 
         if [[ -z "$descriptor" ]]; then
@@ -1277,7 +1284,7 @@ interactive_add_descriptor() {
         wallet_descriptors+=("$descriptor")
         dialog --title "Floresta" --msgbox "✅ Descriptor added successfully:\n\n$descriptor" 30 80
         check_dialog_escape
-        rm -f "$temp_file"
+        rm -f "$temp_file" "$temp_out"
         return 0
     done
 }
@@ -1356,7 +1363,7 @@ interactive_review() {
     review_message+="Proxy:              $([ -n "$proxy" ] && echo "$proxy" || echo "Not configured")\n"
     review_message+="ZeroMQ:             $([ -n "$zeromq" ] && echo "$zeromq" || echo "Not configured")\n"
     review_message+="Connect to:         $([ -n "$connect" ] && echo "$connect" || echo "Not configured")\n"
-    review_message+="Filters:            $([ -n "$filters_start_height" ] && echo $filters_start_height || echo "Not configured")\n"
+    review_message+="Filters:            $([ -n "$filters_start_height" ] && echo "$filters_start_height" || echo "Not configured")\n"
     review_message+="Assume valid:       $([ -n "$assume_valid" ] && echo "$assume_valid" || echo "Not configured")\n"
     review_message+="Assume utreexo:     $assume_utreexo\n"
     review_message+="Enable TLS:         $enable_tls\n"
@@ -1403,7 +1410,6 @@ main() {
         if [ "$uninstall_mode" = true ]; then
             clear
             uninstall_floresta
-            exit 0
         else
             interactive_setup
         fi


### PR DESCRIPTION
Closes #1051 

This PR introduces ShellCheck to CI and fixes its audit findings.

It also renames `zizmor.yml` to `audit.yml`; `audit.yml` will house Zizmor, ShellCheck, cargo-audit and similar.

## Changelog
```
- Rename `zizmor.yml` to `audit.yml`
- Introduce a `ShellCheck` CI job
- Fix `ShellCheck` audit findings
```