### PR TITLE
fix(chain): reject non-final block transactions

### DIFF
--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -6,12 +6,16 @@ use std::hint::black_box;
 use std::io::Cursor;
 
 use bitcoin::Block;
+use bitcoin::BlockHash;
+use bitcoin::CompactTarget;
 use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitcoin::Transaction;
 use bitcoin::block::Header as BlockHeader;
+use bitcoin::block::Version as HeaderVersion;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::deserialize;
+use bitcoin::constants::genesis_block;
 use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::SamplingMode;
@@ -25,6 +29,9 @@ use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::pruned_utreexo::consensus::Consensus;
 use floresta_chain::pruned_utreexo::utxo_data::UtxoData;
 use rustreexo::proof::Proof;
+
+const DEFAULT_TEST_CHAINSTORE_SIZE: usize = 32_768;
+const TEST_FORK_FILE_SIZE: usize = 10_000;
 
 /// Reads the first 151 blocks (or 150 blocks on top of genesis) from `regtest_blocks.txt`
 fn read_blocks_txt() -> Vec<Block> {
@@ -65,12 +72,14 @@ fn read_mainnet_headers() -> Vec<BlockHeader> {
 fn setup_test_chain(
     network: Network,
     assume_valid_arg: AssumeValidArg,
+    header_capacity: Option<usize>,
 ) -> ChainState<FlatChainStore> {
     let test_id = rand::random::<u64>();
+    let capacity = header_capacity.unwrap_or(DEFAULT_TEST_CHAINSTORE_SIZE);
     let config = FlatChainStoreConfig {
-        block_index_size: Some(32_768),
-        headers_file_size: Some(32_768),
-        fork_file_size: Some(10_000), // Will be rounded up to 16,384
+        block_index_size: Some(capacity),
+        headers_file_size: Some(capacity),
+        fork_file_size: Some(TEST_FORK_FILE_SIZE), // Will be rounded up to 16,384
         cache_size: Some(10),
         file_permission: Some(0o660),
         path: format!("./tmp-db/{test_id}/").into(),
@@ -103,6 +112,36 @@ fn decode_block_and_inputs(
     assert!(stxos.is_empty(), "Moved all stxos to the inputs map");
 
     (block, inputs)
+}
+
+/// Stores 11 synthetic headers ending at `tip_height` for Median Time Past (MTP).
+/// Returns the most-recent synthetic block hash.
+fn store_mtp_headers(
+    chain: &ChainState<FlatChainStore>,
+    network: Network,
+    tip_height: u32,
+    time: u32,
+) -> BlockHash {
+    assert!(tip_height > 10, "Need at least 11 headers for MTP");
+    let genesis = genesis_block(network);
+    let mut prev_hash = genesis.block_hash();
+    let headers: Vec<_> = ((tip_height - 10)..=tip_height)
+        .map(|height| {
+            let header = BlockHeader {
+                version: HeaderVersion::NO_SOFT_FORK_SIGNALLING,
+                prev_blockhash: prev_hash,
+                merkle_root: genesis.header.merkle_root,
+                time,
+                bits: CompactTarget::from_consensus(0x1702_8c74),
+                nonce: height,
+            };
+            prev_hash = header.block_hash();
+            header
+        })
+        .collect();
+
+    chain.push_headers(headers, tip_height - 10).unwrap();
+    prev_hash
 }
 
 fn initialize_chainstore_benchmark(c: &mut Criterion) {
@@ -141,7 +180,7 @@ fn accept_mainnet_headers_benchmark(c: &mut Criterion) {
 
     c.bench_function("accept_10k_mainnet_headers", |b| {
         b.iter_batched(
-            || setup_test_chain(Network::Bitcoin, AssumeValidArg::Hardcoded),
+            || setup_test_chain(Network::Bitcoin, AssumeValidArg::Hardcoded, None),
             |chain| {
                 headers
                     .iter()
@@ -157,7 +196,7 @@ fn accept_headers_benchmark(c: &mut Criterion) {
 
     c.bench_function("accept_150_headers", |b| {
         b.iter_batched(
-            || setup_test_chain(Network::Regtest, AssumeValidArg::Disabled),
+            || setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None),
             |chain| {
                 blocks
                     .iter()
@@ -172,7 +211,7 @@ fn connect_blocks_benchmark(c: &mut Criterion) {
     let blocks = read_blocks_txt();
 
     let setup_chain = || {
-        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled);
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
         // We need to accept the headers before connecting blocks
         blocks
             .iter()
@@ -197,22 +236,30 @@ fn connect_blocks_benchmark(c: &mut Criterion) {
 }
 
 fn validate_full_block_benchmark(c: &mut Criterion) {
+    const HEIGHT: u32 = 866342;
+    const BLOCKS: usize = (HEIGHT + 1) as usize;
+
     let block_file = File::open("./testdata/block_866342/raw.zst").unwrap();
     let stxos_file = File::open("./testdata/block_866342/spent_utxos.zst").unwrap();
-    let (block, inputs) = decode_block_and_inputs(block_file, stxos_file);
+    let (mut block, inputs) = decode_block_and_inputs(block_file, stxos_file);
 
-    let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled);
+    let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled, Some(BLOCKS));
+    let prev_hash = store_mtp_headers(&chain, Network::Bitcoin, HEIGHT - 1, block.header.time);
+    block.header.prev_blockhash = prev_hash;
 
     c.bench_function("validate_block_866342", |b| {
         b.iter_batched(
             || inputs.clone(),
-            |inputs| chain.validate_block_no_acc(&block, 866342, inputs).unwrap(),
+            |inputs| chain.validate_block_no_acc(&block, HEIGHT, inputs).unwrap(),
             BatchSize::LargeInput,
         )
     });
 }
 
 fn validate_many_inputs_block_benchmark(c: &mut Criterion) {
+    const HEIGHT: u32 = 367891;
+    const BLOCKS: usize = (HEIGHT + 1) as usize;
+
     if std::env::var("EXPENSIVE_BENCHES").is_err() {
         println!(
             "validate_many_inputs_block_benchmark ... \x1b[33mskipped\x1b[0m\n\
@@ -226,7 +273,7 @@ fn validate_many_inputs_block_benchmark(c: &mut Criterion) {
     let stxos_file = File::open("./testdata/block_367891/spent_utxos.zst").unwrap();
     let (block, inputs) = decode_block_and_inputs(block_file, stxos_file);
 
-    let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled);
+    let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled, Some(BLOCKS));
 
     // Create a group with the lowest possible sample size, as validating this block is very slow
     let mut group = c.benchmark_group("validate_block_367891");
@@ -236,7 +283,7 @@ fn validate_many_inputs_block_benchmark(c: &mut Criterion) {
     group.bench_function("validate_block_367891", |b| {
         b.iter_batched(
             || inputs.clone(),
-            |inputs| chain.validate_block_no_acc(&block, 367891, inputs).unwrap(),
+            |inputs| chain.validate_block_no_acc(&block, HEIGHT, inputs).unwrap(),
             BatchSize::LargeInput,
         )
     });

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -10,6 +10,7 @@ use bitcoin::BlockHash;
 use bitcoin::Work;
 use bitcoin::block::Header;
 use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::hashes::Hash;
 use floresta_common::bhash;
 use floresta_common::prelude::Box;
 use floresta_common::prelude::String;
@@ -46,6 +47,14 @@ pub trait HeaderExt {
         &self,
         chain: &impl BlockchainInterface,
     ) -> Result<u32, HeaderExtError>;
+
+    /// Calculates Median Time Past using a caller-provided previous-header lookup.
+    fn median_time_past_with<E>(
+        &self,
+        previous_header: impl FnMut(&Self) -> Result<Self, E>,
+    ) -> Result<u32, E>
+    where
+        Self: Sized;
 
     /// Calculates the total accumulated chain work up to the current block.
     fn calculate_chain_work(
@@ -123,19 +132,29 @@ impl HeaderExt for Header {
         &self,
         chain: &impl BlockchainInterface,
     ) -> Result<u32, HeaderExtError> {
+        self.median_time_past_with(|current_header| current_header.get_previous_block_header(chain))
+    }
+
+    fn median_time_past_with<E>(
+        &self,
+        mut previous_header: impl FnMut(&Self) -> Result<Self, E>,
+    ) -> Result<u32, E> {
         let mut block_timestamps = Vec::with_capacity(MEDIAN_TIME_PAST_BLOCK_COUNT);
         let mut current_header = *self;
+
         for _ in 0..MEDIAN_TIME_PAST_BLOCK_COUNT {
             block_timestamps.push(current_header.time);
-            let Ok(prev_header) = current_header.get_previous_block_header(chain) else {
+            if block_timestamps.len() == MEDIAN_TIME_PAST_BLOCK_COUNT
+                || current_header.prev_blockhash == BlockHash::all_zeros()
+            {
                 break;
-            };
-            current_header = prev_header;
-        }
-        block_timestamps.sort();
-        let median_time_past = block_timestamps[block_timestamps.len() / 2];
+            }
 
-        Ok(median_time_past)
+            current_header = previous_header(&current_header)?;
+        }
+
+        block_timestamps.sort();
+        Ok(block_timestamps[block_timestamps.len() / 2])
     }
 
     fn calculate_chain_work(

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -307,6 +307,7 @@ mod tests {
     use core::fmt::Display;
     use core::fmt::Formatter;
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     use bitcoin::Block;
@@ -330,6 +331,7 @@ mod tests {
     #[derive(Debug)]
     pub enum MockBlockchainError {
         NotFound,
+        Storage,
     }
 
     impl Display for MockBlockchainError {
@@ -343,6 +345,7 @@ mod tests {
     pub struct MockBlockchainInterface {
         pub headers: HashMap<BlockHash, Header>,
         pub heights: HashMap<BlockHash, u32>,
+        pub storage_errors: HashSet<BlockHash>,
         pub chain_height: u32,
     }
 
@@ -351,6 +354,7 @@ mod tests {
             Self {
                 headers: HashMap::new(),
                 heights: HashMap::new(),
+                storage_errors: HashSet::new(),
                 chain_height: 0,
             }
         }
@@ -370,6 +374,10 @@ mod tests {
         }
 
         fn get_block_header(&self, hash: &BlockHash) -> Result<Header, Self::Error> {
+            if self.storage_errors.contains(hash) {
+                return Err(MockBlockchainError::Storage);
+            }
+
             self.headers
                 .get(hash)
                 .cloned()
@@ -563,6 +571,42 @@ mod tests {
         let expected_mtp = headers[0].time;
 
         assert_eq!(mtp, expected_mtp);
+    }
+
+    #[test]
+    fn test_calculate_median_time_past_propagates_storage_errors() {
+        let (mut mock_chain, headers) = get_chain_and_headers(12);
+        let median_header = headers[headers.len() - 1];
+        let missing_hash = headers[headers.len() - 2].block_hash();
+        mock_chain.storage_errors.insert(missing_hash);
+
+        let result = median_header.calculate_median_time_past(&mock_chain);
+
+        assert!(
+            matches!(result, Err(HeaderExtError::Chain(_))),
+            "MTP lookup failure should be propagated, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_calculate_median_time_past_does_not_fetch_past_window() {
+        let (mut mock_chain, headers) = get_chain_and_headers(12);
+        let median_header = headers[headers.len() - 1];
+        let outside_window_hash = headers[0].block_hash();
+        mock_chain.storage_errors.insert(outside_window_hash);
+
+        let mtp = median_header
+            .calculate_median_time_past(&mock_chain)
+            .expect("MTP should not fetch outside the 11-header window");
+        let mut times = headers
+            .iter()
+            .rev()
+            .take(11)
+            .map(|h| h.time)
+            .collect::<Vec<_>>();
+        times.sort();
+
+        assert_eq!(mtp, times[times.len() / 2]);
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1556,13 +1556,22 @@ mod test {
     use bitcoin::CompactTarget;
     use bitcoin::Network;
     use bitcoin::OutPoint;
+    use bitcoin::ScriptBuf;
+    use bitcoin::Sequence;
+    use bitcoin::Transaction;
+    use bitcoin::TxMerkleNode;
     use bitcoin::Work;
+    use bitcoin::absolute::LockTime;
     use bitcoin::block::Header as BlockHeader;
     use bitcoin::block::Version as HeaderVersion;
     use bitcoin::consensus::Decodable;
     use bitcoin::consensus::deserialize;
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::constants::genesis_block;
+    use bitcoin::hashes::Hash;
+    use bitcoin::opcodes::OP_TRUE;
+    use bitcoin::script::Builder;
+    use bitcoin::transaction::Version as TransactionVersion;
     use floresta_common::assert_ok;
     use floresta_common::bhash;
     use rand::RngExt;
@@ -1582,12 +1591,14 @@ mod test {
     use crate::extensions::WorkExt;
     use crate::prelude::HashMap;
     use crate::pruned_utreexo::consensus::Consensus;
+    use crate::pruned_utreexo::error::BlockValidationErrors;
     use crate::pruned_utreexo::utxo_data::UtxoData;
+    use crate::txin;
+    use crate::txout;
 
     const DEFAULT_TEST_CHAINSTORE_SIZE: usize = 32_768;
     const TEST_FORK_FILE_SIZE: usize = 10_000;
     const EASIEST_REGTEST_TARGET_BITS: u32 = 0x207f_ffff;
-
     fn setup_test_chain(
         network: Network,
         assume_valid_arg: AssumeValidArg,
@@ -1606,6 +1617,85 @@ mod test {
 
         let chainstore = FlatChainStore::new(config).unwrap();
         ChainState::open(chainstore, network, assume_valid_arg).unwrap()
+    }
+
+    fn anyone_can_spend_script() -> ScriptBuf {
+        let mut script = ScriptBuf::new();
+        script.push_opcode(OP_TRUE);
+        script
+    }
+
+    fn test_coinbase(height: u32, sequence: Sequence, lock_time: LockTime) -> Transaction {
+        let script_sig = Builder::new()
+            .push_int(i64::from(height))
+            .push_int(0)
+            .into_script();
+
+        Transaction {
+            version: TransactionVersion::TWO,
+            lock_time,
+            input: vec![txin!(OutPoint::null(), script_sig, sequence)],
+            output: vec![txout!(0, ScriptBuf::new_op_return([0x0, 0x1]))],
+        }
+    }
+
+    fn block_with_transactions(height: u32, txdata: Vec<Transaction>) -> Block {
+        let mut block = Block {
+            header: BlockHeader {
+                version: HeaderVersion::TWO,
+                prev_blockhash: genesis_block(Network::Regtest).block_hash(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 1_716_400_000 + height,
+                bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+                nonce: 0,
+            },
+            txdata,
+        };
+        block.header.merkle_root = block.compute_merkle_root().expect("block txs");
+        block
+    }
+
+    fn block_with_coinbase(height: u32, coinbase: Transaction) -> Block {
+        block_with_transactions(height, vec![coinbase])
+    }
+
+    fn test_outpoint(vout: u32) -> OutPoint {
+        OutPoint {
+            txid: genesis_block(Network::Regtest).txdata[0].compute_txid(),
+            vout,
+        }
+    }
+
+    /// Builds a two-input test transaction with the given lock time and sequences,
+    /// plus its referenced input UTXOs.
+    fn test_spend(
+        lock_time: LockTime,
+        first_sequence: Sequence,
+        second_sequence: Sequence,
+    ) -> (Transaction, HashMap<OutPoint, UtxoData>) {
+        let first_prevout = test_outpoint(0);
+        let second_prevout = test_outpoint(1);
+        let transaction = Transaction {
+            version: TransactionVersion::TWO,
+            lock_time,
+            input: vec![
+                txin!(first_prevout, ScriptBuf::new(), first_sequence),
+                txin!(second_prevout, ScriptBuf::new(), second_sequence),
+            ],
+            output: vec![txout!(1, ScriptBuf::new_op_return([0x0, 0x1]))],
+        };
+        let input_utxo = UtxoData {
+            txout: txout!(1, anyone_can_spend_script()),
+            is_coinbase: false,
+            creation_height: 0,
+            creation_time: 0,
+        };
+        let inputs = HashMap::from([
+            (first_prevout, input_utxo.clone()),
+            (second_prevout, input_utxo),
+        ]);
+
+        (transaction, inputs)
     }
 
     fn decode_block_and_inputs(
@@ -1667,6 +1757,59 @@ mod test {
         }
 
         prev_hash
+    }
+
+    #[test]
+    fn reject_non_final_block_transaction() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
+        let height = 1;
+
+        let invalid = block_with_coinbase(
+            height,
+            test_coinbase(
+                height,
+                Sequence::ENABLE_LOCKTIME_NO_RBF,
+                LockTime::from_height(height).unwrap(),
+            ),
+        );
+        let valid =
+            block_with_coinbase(height, test_coinbase(height, Sequence::MAX, LockTime::ZERO));
+
+        match chain.validate_block_no_acc(&invalid, height, HashMap::new()) {
+            Err(BlockchainError::BlockValidation(BlockValidationErrors::NonFinalTransaction)) => {}
+            other => panic!("expected NonFinalTransaction, got {other:?}"),
+        }
+
+        chain
+            .validate_block_no_acc(&valid, height, HashMap::new())
+            .expect("block transactions are valid and final");
+    }
+
+    #[test]
+    fn future_lock_time_requires_all_input_sequences_to_be_final() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
+        let height = 1;
+        let future_lock_time = LockTime::from_height(height + 1).unwrap();
+        let coinbase = || test_coinbase(height, Sequence::MAX, LockTime::ZERO);
+
+        let (transaction, inputs) = test_spend(future_lock_time, Sequence::MAX, Sequence::MAX);
+        let block = block_with_transactions(height, vec![coinbase(), transaction]);
+
+        chain
+            .validate_block_no_acc(&block, height, inputs)
+            .expect("all input sequences are final");
+
+        let (transaction, inputs) = test_spend(
+            future_lock_time,
+            Sequence::MAX,
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+        let block = block_with_transactions(height, vec![coinbase(), transaction]);
+
+        match chain.validate_block_no_acc(&block, height, inputs) {
+            Err(BlockchainError::BlockValidation(BlockValidationErrors::NonFinalTransaction)) => {}
+            other => panic!("expected NonFinalTransaction, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1533,10 +1533,12 @@ mod test {
 
     use bitcoin::Block;
     use bitcoin::BlockHash;
+    use bitcoin::CompactTarget;
     use bitcoin::Network;
     use bitcoin::OutPoint;
     use bitcoin::Work;
     use bitcoin::block::Header as BlockHeader;
+    use bitcoin::block::Version as HeaderVersion;
     use bitcoin::consensus::Decodable;
     use bitcoin::consensus::deserialize;
     use bitcoin::consensus::encode::deserialize_hex;
@@ -1562,15 +1564,20 @@ mod test {
     use crate::pruned_utreexo::consensus::Consensus;
     use crate::pruned_utreexo::utxo_data::UtxoData;
 
+    const DEFAULT_TEST_CHAINSTORE_SIZE: usize = 32_768;
+    const TEST_FORK_FILE_SIZE: usize = 10_000;
+
     fn setup_test_chain(
         network: Network,
         assume_valid_arg: AssumeValidArg,
+        header_capacity: Option<usize>,
     ) -> ChainState<FlatChainStore> {
         let test_id = rand::random::<u64>();
-        let config = crate::FlatChainStoreConfig {
-            block_index_size: Some(32_768),
-            headers_file_size: Some(32_768),
-            fork_file_size: Some(10_000), // Will be rounded up to 16,384
+        let capacity = header_capacity.unwrap_or(DEFAULT_TEST_CHAINSTORE_SIZE);
+        let config = FlatChainStoreConfig {
+            block_index_size: Some(capacity),
+            headers_file_size: Some(capacity),
+            fork_file_size: Some(TEST_FORK_FILE_SIZE), // Will be rounded up to 16,384
             cache_size: Some(10),
             file_permission: Some(0o660),
             path: format!("./tmp-db/{test_id}/").into(),
@@ -1605,9 +1612,48 @@ mod test {
         (block, inputs)
     }
 
+    /// Stores 11 synthetic headers ending at `tip_height` for Median Time Past (MTP).
+    /// Returns the most-recent synthetic block hash.
+    fn store_mtp_headers(
+        chain: &ChainState<FlatChainStore>,
+        network: Network,
+        tip_height: u32,
+        time: u32,
+    ) -> BlockHash {
+        assert!(tip_height > 10, "Need at least 11 headers for MTP");
+        let genesis = genesis_block(network);
+        let mut prev_hash = genesis.block_hash();
+
+        for height in (tip_height - 10)..=tip_height {
+            let header = BlockHeader {
+                version: HeaderVersion::NO_SOFT_FORK_SIGNALLING,
+                prev_blockhash: prev_hash,
+                merkle_root: genesis.header.merkle_root,
+                time,
+                bits: CompactTarget::from_consensus(0x1702_8c74),
+                nonce: height,
+            };
+            prev_hash = header.block_hash();
+
+            write_lock!(chain)
+                .chainstore
+                .save_header(&DiskBlockHeader::FullyValid(header, height))
+                .unwrap();
+            write_lock!(chain)
+                .chainstore
+                .update_block_index(height, prev_hash)
+                .unwrap();
+        }
+
+        prev_hash
+    }
+
     #[test]
     #[cfg_attr(debug_assertions, ignore = "this test is very slow in debug mode")]
     fn test_validate_many_inputs_block() {
+        const HEIGHT: u32 = 367891;
+        const BLOCKS: usize = (HEIGHT + 1) as usize;
+
         let block_file = File::open("./testdata/block_367891/raw.zst").unwrap();
         let stxos_file = File::open("./testdata/block_367891/spent_utxos.zst").unwrap();
         let (block, inputs) = decode_block_and_inputs(block_file, stxos_file);
@@ -1618,17 +1664,20 @@ mod test {
         );
 
         // Check whether the block validation passes or not
-        let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled);
+        let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled, Some(BLOCKS));
         chain
-            .validate_block_no_acc(&block, 367891, inputs)
+            .validate_block_no_acc(&block, HEIGHT, inputs)
             .expect("Block must be valid");
     }
 
     #[test]
     fn test_validate_full_block() {
+        const HEIGHT: u32 = 866342;
+        const BLOCKS: usize = (HEIGHT + 1) as usize;
+
         let block_file = File::open("./testdata/block_866342/raw.zst").unwrap();
         let stxos_file = File::open("./testdata/block_866342/spent_utxos.zst").unwrap();
-        let (block, inputs) = decode_block_and_inputs(block_file, stxos_file);
+        let (mut block, inputs) = decode_block_and_inputs(block_file, stxos_file);
 
         assert_eq!(
             block.block_hash(),
@@ -1636,9 +1685,11 @@ mod test {
         );
 
         // Check whether the block validation passes or not
-        let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled);
+        let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled, Some(BLOCKS));
+        let prev_hash = store_mtp_headers(&chain, Network::Bitcoin, HEIGHT - 1, block.header.time);
+        block.header.prev_blockhash = prev_hash;
         chain
-            .validate_block_no_acc(&block, 866342, inputs)
+            .validate_block_no_acc(&block, HEIGHT, inputs)
             .expect("Block must be valid");
     }
 
@@ -1650,7 +1701,7 @@ mod test {
         let mut buffer = uncompressed.as_slice();
 
         let mut headers = Vec::new();
-        let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Hardcoded);
+        let chain = setup_test_chain(Network::Bitcoin, AssumeValidArg::Hardcoded, None);
 
         while let Ok(header) = BlockHeader::consensus_decode(&mut buffer) {
             chain.accept_header(header).unwrap();
@@ -1712,7 +1763,7 @@ mod test {
         let uncompressed: Vec<u8> = zstd::decode_all(Cursor::new(file)).unwrap();
         let mut buffer = uncompressed.as_slice();
 
-        let chain = setup_test_chain(Network::Signet, AssumeValidArg::Hardcoded);
+        let chain = setup_test_chain(Network::Signet, AssumeValidArg::Hardcoded, None);
         while let Ok(header) = BlockHeader::consensus_decode(&mut buffer) {
             chain.accept_header(header).unwrap();
         }
@@ -1734,7 +1785,7 @@ mod test {
 
     #[test]
     fn test_reorg() {
-        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded, None);
         let json_blocks = include_str!("../../testdata/test_reorg.json");
         let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
         let mut fork_acc = Stump::default();
@@ -1882,7 +1933,7 @@ mod test {
 
     #[test]
     fn test_fork_tips() {
-        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded, None);
         let json_blocks = include_str!("../../testdata/test_reorg.json");
         let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
 
@@ -1929,7 +1980,7 @@ mod test {
         let uncompressed: Vec<u8> = zstd::decode_all(Cursor::new(file)).unwrap();
         let mut buffer = uncompressed.as_slice();
 
-        let chain = setup_test_chain(Network::Signet, AssumeValidArg::Hardcoded);
+        let chain = setup_test_chain(Network::Signet, AssumeValidArg::Hardcoded, None);
         let mut headers: Vec<BlockHeader> = Vec::new();
         while let Ok(header) = BlockHeader::consensus_decode(&mut buffer) {
             headers.push(header);

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -64,6 +64,7 @@ use super::partial_chain::PartialChainState;
 use super::partial_chain::PartialChainStateInner;
 use crate::BestChain;
 use crate::ChainStore;
+use crate::extensions::HeaderExt;
 use crate::extensions::WorkExt;
 use crate::prelude::*;
 use crate::pruned_utreexo::IBDState;
@@ -565,6 +566,20 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             .ok_or(BlockchainError::BlockNotPresent)
     }
 
+    /// Returns the Median Time Past (MTP) of `header`, following its `prev_blockhash` chain.
+    fn median_time_past(&self, header: BlockHeader) -> Result<u32, BlockchainError> {
+        header.median_time_past_with(|current_header| {
+            self.get_disk_block_header(&current_header.prev_blockhash)
+                .map(|header| *header)
+        })
+    }
+
+    /// Returns the Median Time Past (MTP) of `header`'s parent, resolved by `prev_blockhash`.
+    fn previous_median_time_past(&self, header: &BlockHeader) -> Result<u32, BlockchainError> {
+        let previous_header = *self.get_disk_block_header(&header.prev_blockhash)?;
+        self.median_time_past(previous_header)
+    }
+
     fn notify(&self, block: &Block, height: u32, inputs: Option<&HashMap<OutPoint, UtxoData>>) {
         let inner = self.inner.read();
         for client in &inner.subscribers {
@@ -1003,20 +1018,25 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         height: u32,
         inputs: HashMap<OutPoint, UtxoData>,
     ) -> Result<(), BlockchainError> {
-        read_lock!(self).consensus.check_block(block, height)?;
+        let consensus = read_lock!(self).consensus.clone();
+        consensus.check_block(block, height)?;
 
         // Validate block transactions
-        let subsidy = read_lock!(self).consensus.get_subsidy(height);
-        let verify_script = self.verify_script(height)?;
+        let subsidy = consensus.get_subsidy(height);
+        let lock_time_cutoff = consensus.block_lock_time_cutoff(height, &block.header, || {
+            self.previous_median_time_past(&block.header)
+        })?;
         #[cfg(feature = "bitcoinkernel")]
-        let flags = self
-            .chain_params()
+        let flags = consensus
+            .parameters
             .get_validation_flags(height, block.block_hash());
         #[cfg(not(feature = "bitcoinkernel"))]
         let flags = 0;
+        let verify_script = self.verify_script(height)?;
 
         Consensus::verify_block_transactions(
             height,
+            lock_time_cutoff,
             inputs,
             &block.txdata,
             subsidy,
@@ -1566,6 +1586,7 @@ mod test {
 
     const DEFAULT_TEST_CHAINSTORE_SIZE: usize = 32_768;
     const TEST_FORK_FILE_SIZE: usize = 10_000;
+    const EASIEST_REGTEST_TARGET_BITS: u32 = 0x207f_ffff;
 
     fn setup_test_chain(
         network: Network,
@@ -1691,6 +1712,99 @@ mod test {
         chain
             .validate_block_no_acc(&block, HEIGHT, inputs)
             .expect("Block must be valid");
+    }
+
+    fn store_linked_headers(chain: &ChainState<FlatChainStore>, times: &[u32]) -> Vec<BlockHeader> {
+        let genesis = genesis_block(Network::Regtest);
+        let mut prev_hash = genesis.block_hash();
+        let mut headers = Vec::with_capacity(times.len());
+
+        for (height, &time) in (1u32..).zip(times) {
+            let header = BlockHeader {
+                version: HeaderVersion::TWO,
+                prev_blockhash: prev_hash,
+                merkle_root: genesis.header.merkle_root,
+                time,
+                bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+                nonce: height,
+            };
+            prev_hash = header.block_hash();
+            write_lock!(chain)
+                .chainstore
+                .save_header(&DiskBlockHeader::FullyValid(header, height))
+                .unwrap();
+            write_lock!(chain)
+                .chainstore
+                .update_block_index(height, prev_hash)
+                .unwrap();
+            headers.push(header);
+        }
+
+        headers
+    }
+
+    fn median_time(mut times: Vec<u32>) -> u32 {
+        times.sort_unstable();
+        times[times.len() / 2]
+    }
+
+    #[test]
+    fn chain_state_median_time_past_sorts_recent_headers() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
+        let times = [111, 101, 109, 107, 103, 105, 110, 102, 108, 104, 106];
+        let headers = store_linked_headers(&chain, &times);
+
+        assert_eq!(
+            chain.median_time_past(headers[10]).unwrap(),
+            median_time(times.to_vec())
+        );
+    }
+
+    #[test]
+    fn chain_state_median_time_past_requires_connected_headers() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
+        let missing_prev = BlockHeader {
+            version: HeaderVersion::TWO,
+            prev_blockhash: genesis_block(Network::Regtest).block_hash(),
+            merkle_root: genesis_block(Network::Regtest).header.merkle_root,
+            time: 100,
+            bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+            nonce: 1,
+        };
+        let header = BlockHeader {
+            version: HeaderVersion::TWO,
+            prev_blockhash: missing_prev.block_hash(),
+            merkle_root: genesis_block(Network::Regtest).header.merkle_root,
+            time: 200,
+            bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+            nonce: 2,
+        };
+
+        assert!(matches!(
+            chain.median_time_past(header),
+            Err(BlockchainError::BlockNotPresent)
+        ));
+    }
+
+    #[test]
+    fn chain_state_previous_median_time_past_uses_parent_hash() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
+        let times = [211, 201, 209, 207, 203, 205, 210, 202, 208, 204, 206];
+        let headers = store_linked_headers(&chain, &times);
+
+        let candidate = BlockHeader {
+            version: HeaderVersion::TWO,
+            prev_blockhash: headers[10].block_hash(),
+            merkle_root: genesis_block(Network::Regtest).header.merkle_root,
+            time: 100,
+            bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+            nonce: 12,
+        };
+
+        assert_eq!(
+            chain.previous_median_time_past(&candidate).unwrap(),
+            median_time(times.to_vec())
+        );
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -1012,7 +1012,6 @@ mod tests {
     use bitcoin::TxIn;
     use bitcoin::TxOut;
     use bitcoin::Txid;
-    use bitcoin::Witness;
     use bitcoin::absolute::LockTime;
     use bitcoin::consensus::deserialize;
     use bitcoin::consensus::encode::deserialize_hex;
@@ -1033,41 +1032,43 @@ mod tests {
 
     use super::*;
 
+    #[macro_export]
     /// Macro for creating a TxOut
     macro_rules! txout {
         ($sats:expr, $script:expr) => {
-            TxOut {
-                value: Amount::from_sat($sats),
+            bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat($sats),
                 script_pubkey: $script,
             }
         };
     }
 
+    #[macro_export]
     /// Macro for constructing a legacy [`TxIn`] with optional scriptSig and sequence number.
     /// Needs the outpoint and, if not provided, defaults to empty scriptSig and `Sequence::MAX`.
     macro_rules! txin {
         ($outpoint:expr) => {
-            TxIn {
+            bitcoin::TxIn {
                 previous_output: $outpoint,
-                script_sig: ScriptBuf::new(),
-                sequence: Sequence::MAX,
-                witness: Witness::new(),
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
             }
         };
         ($outpoint:expr, $script:expr) => {
-            TxIn {
+            bitcoin::TxIn {
                 previous_output: $outpoint,
                 script_sig: $script,
-                sequence: Sequence::MAX,
-                witness: Witness::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
             }
         };
         ($outpoint:expr, $script:expr, $sequence:expr) => {
-            TxIn {
+            bitcoin::TxIn {
                 previous_output: $outpoint,
                 script_sig: $script,
                 sequence: $sequence,
-                witness: Witness::new(),
+                witness: bitcoin::Witness::new(),
             }
         };
     }

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -19,6 +19,7 @@ use bitcoin::Target;
 use bitcoin::Transaction;
 use bitcoin::TxIn;
 use bitcoin::Txid;
+use bitcoin::absolute;
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::blockdata::Weight;
 #[cfg(feature = "bitcoinkernel")]
@@ -101,6 +102,23 @@ impl From<Network> for Consensus {
 }
 
 impl Consensus {
+    /// Returns the block-finality lock-time cutoff for a candidate block.
+    ///
+    /// Before CSV/BIP113 activation this is the block header time. After activation
+    /// it is the previous block's Median Time Past (MTP).
+    pub(crate) fn block_lock_time_cutoff<E>(
+        &self,
+        height: u32,
+        header: &BlockHeader,
+        previous_median_time_past: impl FnOnce() -> Result<u32, E>,
+    ) -> Result<u32, E> {
+        if height >= self.parameters.csv_activation_height {
+            previous_median_time_past()
+        } else {
+            Ok(header.time)
+        }
+    }
+
     /// Returns the amount of block subsidy to be paid in a block, given its height.
     ///
     /// The Bitcoin Core source can be found [here](https://github.com/bitcoin/bitcoin/blob/2b211b41e36f914b8d0487e698b619039cc3c8e2/src/validation.cpp#L1501-L1512).
@@ -168,6 +186,7 @@ impl Consensus {
     #[allow(unused)]
     pub fn verify_block_transactions(
         height: u32,
+        lock_time_cutoff: u32,
         mut utxos: HashMap<OutPoint, UtxoData>,
         transactions: &[Transaction],
         subsidy: Amount,
@@ -183,6 +202,10 @@ impl Consensus {
         let mut fee = Amount::ZERO;
 
         for (n, transaction) in transactions.iter().enumerate() {
+            if !Self::is_final_transaction(transaction, height, lock_time_cutoff) {
+                Err(BlockValidationErrors::NonFinalTransaction)?;
+            }
+
             if n == 0 {
                 if !transaction.is_coinbase() {
                     Err(BlockValidationErrors::FirstTxIsNotCoinbase)?;
@@ -628,13 +651,34 @@ impl Consensus {
         }
     }
 
-    #[allow(unused)]
-    fn validate_locktime(
-        input: &TxIn,
-        transaction: &Transaction,
-        height: u32,
-    ) -> Result<(), BlockValidationErrors> {
-        unimplemented!("validate_locktime")
+    /// Returns whether a transaction's absolute lock time is final for a candidate block.
+    ///
+    /// Zero `nLockTime` is final. Otherwise, height and time locks must be below
+    /// `height` and `lock_time_cutoff`, respectively. `nLockTime` is disabled when
+    /// every input has a final `nSequence`.
+    ///
+    /// The cutoff is the block timestamp before BIP113 and the previous block's
+    /// Median Time Past (MTP) afterward.
+    ///
+    /// Mirrors Bitcoin Core's IsFinalTx:
+    /// <https://github.com/bitcoin/bitcoin/blob/v31.0/src/consensus/tx_verify.cpp#L17-L37>
+    fn is_final_transaction(transaction: &Transaction, height: u32, lock_time_cutoff: u32) -> bool {
+        if transaction.lock_time == absolute::LockTime::ZERO {
+            return true;
+        }
+
+        let lock_time_reached = match transaction.lock_time {
+            absolute::LockTime::Blocks(lock_height) => lock_height.to_consensus_u32() < height,
+            absolute::LockTime::Seconds(lock_time) => {
+                lock_time.to_consensus_u32() < lock_time_cutoff
+            }
+        };
+
+        lock_time_reached
+            || transaction
+                .input
+                .iter()
+                .all(|input| input.sequence.is_final())
     }
 
     /// Validates the script size and the number of sigops in a prevout scriptPubKey or scriptSig.
@@ -1045,6 +1089,104 @@ mod tests {
             txid: Txid::all_zeros(),
             vout: 0,
         }
+    }
+
+    fn tx_with_lock_time(lock_time: LockTime, sequence: Sequence) -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time,
+            input: vec![txin!(dummy_outpoint(), ScriptBuf::new(), sequence)],
+            output: vec![txout!(1, ScriptBuf::new())],
+        }
+    }
+
+    const ZERO_HEIGHT: u32 = 0;
+    const ZERO_BLOCK_TIME: u32 = 0;
+
+    #[test]
+    fn final_transaction_accepts_final_sequence() {
+        let height_locked = tx_with_lock_time(LockTime::from_height(101).unwrap(), Sequence::MAX);
+        let time_locked =
+            tx_with_lock_time(LockTime::from_time(500_000_001).unwrap(), Sequence::MAX);
+
+        assert!(Consensus::is_final_transaction(
+            &height_locked,
+            ZERO_HEIGHT,
+            ZERO_BLOCK_TIME
+        ));
+        assert!(Consensus::is_final_transaction(
+            &time_locked,
+            ZERO_HEIGHT,
+            ZERO_BLOCK_TIME
+        ));
+    }
+
+    #[test]
+    fn final_transaction_checks_height_locks_strictly() {
+        let height = 100;
+
+        let below_height = tx_with_lock_time(
+            LockTime::from_height(height - 1).unwrap(),
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+        let at_height = tx_with_lock_time(
+            LockTime::from_height(height).unwrap(),
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+        let above_height = tx_with_lock_time(
+            LockTime::from_height(height + 1).unwrap(),
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+
+        assert!(Consensus::is_final_transaction(
+            &below_height,
+            height,
+            ZERO_BLOCK_TIME
+        ));
+        assert!(!Consensus::is_final_transaction(
+            &at_height,
+            height,
+            ZERO_BLOCK_TIME
+        ));
+        assert!(!Consensus::is_final_transaction(
+            &above_height,
+            height,
+            ZERO_BLOCK_TIME
+        ));
+    }
+
+    #[test]
+    fn final_transaction_checks_time_locks_strictly() {
+        let cutoff = 500_000_100;
+
+        let below_cutoff = tx_with_lock_time(
+            LockTime::from_time(cutoff - 1).unwrap(),
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+        let at_cutoff = tx_with_lock_time(
+            LockTime::from_time(cutoff).unwrap(),
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+        let above_cutoff = tx_with_lock_time(
+            LockTime::from_time(cutoff + 1).unwrap(),
+            Sequence::ENABLE_LOCKTIME_NO_RBF,
+        );
+
+        assert!(Consensus::is_final_transaction(
+            &below_cutoff,
+            ZERO_HEIGHT,
+            cutoff
+        ));
+        assert!(!Consensus::is_final_transaction(
+            &at_cutoff,
+            ZERO_HEIGHT,
+            cutoff
+        ));
+        assert!(!Consensus::is_final_transaction(
+            &above_cutoff,
+            ZERO_HEIGHT,
+            cutoff
+        ));
     }
 
     #[cfg(feature = "bitcoinkernel")]

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -143,6 +143,7 @@ pub enum BlockValidationErrors {
     BadBip34,
     InvalidUtreexoProof,
     CoinbaseNotMatured,
+    NonFinalTransaction,
     UnspendableUTXO,
     BIP94TimeWarp,
     DuplicateInput,
@@ -229,6 +230,9 @@ impl Display for BlockValidationErrors {
             Self::InvalidUtreexoProof => write!(f, "Invalid proof"),
             Self::CoinbaseNotMatured => {
                 write!(f, "Coinbase not matured yet")
+            }
+            Self::NonFinalTransaction => {
+                write!(f, "Block contains a non-final transaction")
             }
             Self::UnspendableUTXO => {
                 write!(

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -39,6 +39,7 @@ use super::chainparams::ChainParams;
 use super::consensus::Consensus;
 use super::error::BlockValidationErrors;
 use super::error::BlockchainError;
+use crate::extensions::HeaderExt;
 use crate::pruned_utreexo::IBDState;
 use crate::pruned_utreexo::utxo_data::UtxoData;
 
@@ -129,6 +130,27 @@ impl PartialChainStateInner {
         Ok(*prev)
     }
 
+    fn median_time_past(&self, height: u32) -> Result<u32, BlockchainError> {
+        let header = self
+            .get_block(height)
+            .ok_or(BlockchainError::BlockNotPresent)?;
+        let mut current_height = height;
+
+        header.median_time_past_with(|_| {
+            current_height = current_height
+                .checked_sub(1)
+                .expect("height 0 must be genesis and short-circuit MTP computation");
+
+            self.get_block(current_height)
+                .copied()
+                .ok_or(BlockchainError::BlockNotPresent)
+        })
+    }
+
+    fn previous_median_time_past(&self, height: u32) -> Result<u32, BlockchainError> {
+        self.median_time_past(height.saturating_sub(1))
+    }
+
     /// Process a block, given the proof, inputs, and deleted hashes. If we find an error,
     /// we save it.
     pub fn process_block(
@@ -184,6 +206,11 @@ impl PartialChainStateInner {
 
         // Validate block transactions
         let subsidy = self.consensus.get_subsidy(height);
+        let lock_time_cutoff =
+            self.consensus
+                .block_lock_time_cutoff(height, &block.header, || {
+                    self.previous_median_time_past(height)
+                })?;
         let verify_script = self.assume_valid;
 
         #[cfg(feature = "bitcoinkernel")]
@@ -196,6 +223,7 @@ impl PartialChainStateInner {
 
         Consensus::verify_block_transactions(
             height,
+            lock_time_cutoff,
             inputs,
             &block.txdata,
             subsidy,
@@ -481,9 +509,12 @@ mod tests {
     use std::collections::HashMap;
 
     use bitcoin::Block;
+    use bitcoin::CompactTarget;
     use bitcoin::Network;
     use bitcoin::block::Header;
+    use bitcoin::block::Version;
     use bitcoin::consensus::encode::deserialize_hex;
+    use bitcoin::constants::genesis_block;
     use floresta_common::acchashes;
     use rustreexo::node_hash::BitcoinNodeHash;
     use rustreexo::proof::Proof;
@@ -496,6 +527,8 @@ mod tests {
     use crate::pruned_utreexo::consensus::Consensus;
     use crate::pruned_utreexo::error::BlockValidationErrors;
     use crate::pruned_utreexo::partial_chain::PartialChainStateInner;
+
+    const EASIEST_REGTEST_TARGET_BITS: u32 = 0x207f_ffff;
 
     #[test]
     fn test_with_invalid_block() {
@@ -538,6 +571,72 @@ mod tests {
             error: None,
         }
         .into()
+    }
+
+    fn test_pchain_inner_with_times(times: &[u32]) -> PartialChainStateInner {
+        let genesis = genesis_block(Network::Regtest);
+        let mut prev_hash = genesis.header.prev_blockhash;
+        let mut blocks = Vec::with_capacity(times.len());
+
+        for (height, &time) in (0u32..).zip(times) {
+            let header = Header {
+                version: Version::TWO,
+                prev_blockhash: prev_hash,
+                merkle_root: genesis.header.merkle_root,
+                time,
+                bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+                nonce: height,
+            };
+            prev_hash = header.block_hash();
+            blocks.push(header);
+        }
+
+        PartialChainStateInner {
+            assume_valid: true,
+            consensus: Consensus::from(Network::Regtest),
+            current_height: 0,
+            current_acc: Stump::default(),
+            final_height: times.len().saturating_sub(1) as u32,
+            blocks,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn partial_chain_median_time_past_uses_available_headers() {
+        let chainstate = test_pchain_inner_with_times(&[90, 120, 100, 110]);
+
+        assert_eq!(chainstate.median_time_past(3).unwrap(), 110);
+    }
+
+    #[test]
+    fn partial_chain_median_time_past_uses_last_eleven_headers() {
+        let times = [
+            300, 301, 311, 303, 309, 307, 305, 310, 302, 308, 304, 306, 312,
+        ];
+        let chainstate = test_pchain_inner_with_times(&times);
+
+        assert_eq!(chainstate.median_time_past(12).unwrap(), 307);
+    }
+
+    #[test]
+    fn partial_chain_median_time_past_requires_window_headers() {
+        let chainstate = test_pchain_inner_with_times(&[400, 401, 402]);
+
+        assert!(matches!(
+            chainstate.median_time_past(10),
+            Err(BlockchainError::BlockNotPresent)
+        ));
+    }
+
+    #[test]
+    fn partial_chain_previous_median_time_past_uses_previous_height() {
+        let times = [
+            500, 511, 501, 509, 507, 503, 505, 510, 502, 508, 504, 506, 900,
+        ];
+        let chainstate = test_pchain_inner_with_times(&times);
+
+        assert_eq!(chainstate.previous_median_time_past(12).unwrap(), 506);
     }
 
     #[test]

--- a/crates/floresta-wire/src/p2p_wire/node/blocks.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/blocks.rs
@@ -371,6 +371,7 @@ where
             | BlockValidationErrors::BadBip34
             | BlockValidationErrors::BIP94TimeWarp
             | BlockValidationErrors::UnspendableUTXO
+            | BlockValidationErrors::NonFinalTransaction
             | BlockValidationErrors::CoinbaseNotMatured => {
                 try_and_log!(self.chain.invalidate_block(hash));
 


### PR DESCRIPTION
### Description and Notes

This PR fixes a missing block-level absolute lock-time check and adds the MTP plumbing needed to apply it consistently in both full-chain and partial-chain validation.

#### Preparatory work

Median time past walked backward through previous headers, but it silently treated every previous-header lookup failure as the end of the available sample. That forgot to distinguish genesis, where the walk should stop, from a missing or failed storage lookup in a non-genesis ancestor. This PR stops only when the current header points to the all-zero previous hash and propagates other previous-header lookup failures so callers do not compute MTP from a shortened window.

It also adds a regression test for median time past calculation when the previous-header walk hits a storage error before reaching genesis. With the MTP fix reverted, the test still builds but fails because the old implementation returns `Ok(...)` instead of propagating the lookup failure.

The MTP walk is now shared through a small helper that takes a starting header plus a previous-header lookup closure. The helper uses `Ok(None)` for a genuine end of history and propagates `Err(_)` for lookup failures. `HeaderExt::calculate_median_time_past` remains a wrapper around the shared helper, and both full-chain and partial-chain validation reuse the same walk rule.

The existing high-height block validation fixtures also needed MTP context. Those fixtures previously wrote only genesis into the header store before validating real mainnet blocks, which was enough while validation ignored block-level finality. Once the forgotten finality rule is implemented, blocks mined after CSV activation need the previous median time past. The fixtures now seed the eleven synthetic headers needed to compute that MTP and size the test header store so those heights can be indexed. The fixture header-store sizes are named, and the synthetic header helper takes the network instead of relying on hardcoded Bitcoin genesis data.

#### Block transaction finality

Block validation checked transaction structure, coinbase rewards, scripts, and accumulator data, but it forgot to check whether a transaction's absolute lock time was final in the candidate block. That allowed a block to include transactions whose `nLockTime` was still in the future, for both height-based and timestamp-based absolute locks.

This PR passes the candidate block height and the contextual timestamp cutoff into block transaction validation. It rejects any non-final transaction before the coinbase fast path or normal input checks run.

When nLockTime is enabled, block validation must use strict comparisons: height locks are final only when the lock height is below the candidate block height, and time locks are final only when the lock time is below the timestamp cutoff. Equality is non-final in both cases.

Transactions whose every input has the final sequence value (`0xffffffff`) disable nLockTime entirely. They remain final regardless of the lock-time value.

The pre/post-CSV lock-time cutoff selection is centralized so both full-chain and partial-chain block validation apply the same rule: before CSV activation use the candidate block header time, and at or after CSV activation use the previous block's MTP.

No storage migration or backfill is needed.


### How to verify the changes you have done?

The regression tests `reject_non_final_block_transaction` and `reject_future_lock_time_with_one_non_final_input_sequence` pass with this branch and fail symptomatically if the fix commit is reverted: the invalid blocks are accepted.


<details>
<summary>Example regression-test failure after reverting the fix commit</summary>

```text
$ cargo test -p floresta-chain --features flat-chainstore reject_

running 2 tests
test pruned_utreexo::chain_state::test::reject_future_lock_time_with_one_non_final_input_sequence ... FAILED
test pruned_utreexo::chain_state::test::reject_non_final_block_transaction ... FAILED

failures:

---- pruned_utreexo::chain_state::test::reject_future_lock_time_with_one_non_final_input_sequence stdout ----

thread 'pruned_utreexo::chain_state::test::reject_future_lock_time_with_one_non_final_input_sequence' (1936148) panicked at crates/floresta-chain/src/pruned_utreexo/chain_state.rs:1819:9:
accepted a block containing a transaction with a future lock time and one non-final input sequence
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- pruned_utreexo::chain_state::test::reject_non_final_block_transaction stdout ----

thread 'pruned_utreexo::chain_state::test::reject_non_final_block_transaction' (1936149) panicked at crates/floresta-chain/src/pruned_utreexo/chain_state.rs:1790:9:
accepted a block containing a non-final transaction


failures:
    pruned_utreexo::chain_state::test::reject_future_lock_time_with_one_non_final_input_sequence
    pruned_utreexo::chain_state::test::reject_non_final_block_transaction

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 58 filtered out; finished in 0.11s

error: test failed, to rerun pass `-p floresta-chain --lib`
```

</details>


### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above; no issue found

🤖 Assisted-by: OpenAI GPT-5