### PR TITLE
fix(rpc): check block header exists before requesting blocks.

### DIFF
--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -47,6 +47,10 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             return Ok(genesis_block(self.network));
         }
 
+        // Verify the block header is known before requesting the full block
+        // from the network, otherwise the request will hang indefinitely.
+        self.get_block_header_inner(hash)?;
+
         self.node
             .get_block(hash)
             .await


### PR DESCRIPTION
### Description and Notes

any RPC using get_block_inner would hang indefinitely when given an unknown blockhash, because it asked the network for a block that no peer has. Add a header check before the network request so unknown hashes return BlockNotFound immediately.

### How to verify the changes you have done?

Whitout the header check we exposed the case where the operator may miss some blockhash or insert any unkown blockhash, hanging forever. Now it should return 
```Bash
macbook ~/florestadois (fix/rpc/checkheaderbeforegetblock) $ fcli getblock 00000000000000000001dcbacb5f97fad4446c2007581c7f60313a7c6c516678
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/floresta-cli getblock 00000000000000000001dcbacb5f97fad4446c2007581c7f60313a7c6c516678`
Error: JsonRpc returned an error RPC error response: RpcError { code: -32600, message: "Block not found", data: None }
```