### PR TITLE
feat: add getaddednodeinfo rpc

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -130,6 +130,9 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
         }
         Methods::GetAddrManInfo => serde_json::to_string_pretty(&client.get_addrman_info()?)?,
+        Methods::GetAddedNodeInfo { node } => {
+            serde_json::to_string_pretty(&client.get_added_node_info(node)?)?
+        }
     })
 }
 
@@ -464,4 +467,16 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetAddrManInfo,
+
+    #[doc = include_str!("../../../doc/rpc/getaddednodeinfo.md")]
+    #[command(
+        name = "getaddednodeinfo",
+        about = "Returns information about manually added nodes",
+        long_about = Some(include_str!("../../../doc/rpc/getaddednodeinfo.md")),
+        disable_help_subcommand = true
+    )]
+    GetAddedNodeInfo {
+        /// Filter results to a specific added node (ip or ip:port)
+        node: Option<String>,
+    },
 }

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -5,6 +5,9 @@
 use std::collections::BTreeMap;
 
 use corepc_types::v26::AddrManInfoNetwork;
+use corepc_types::v30::AddedNode;
+use corepc_types::v30::AddedNodeAddress;
+use corepc_types::v30::GetAddedNodeInfo;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
 use corepc_types::v30::GetNetworkInfoNetwork;
@@ -15,6 +18,7 @@ use floresta_wire::address_man::NetworkStats;
 use floresta_wire::address_man::ReachableNetworks;
 use floresta_wire::bitcoin_socket_addr::BitcoinSocketAddr;
 use floresta_wire::bitcoin_socket_addr::SystemResolver;
+use floresta_wire::node_interface::AddedNodeInfo;
 use floresta_wire::node_interface::NetworkMethods;
 use floresta_wire::node_interface::PeerInfo;
 use serde_json::Value;
@@ -165,6 +169,49 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         );
 
         Ok(GetAddrManInfo(map))
+    }
+
+    pub(crate) async fn get_added_node_info(
+        &self,
+        node: Option<String>,
+    ) -> Result<GetAddedNodeInfo> {
+        let node = node
+            .map(|str| BitcoinSocketAddr::parse_address(&str, Some(self.network), SystemResolver))
+            .transpose()?;
+
+        let node_request = self
+            .node
+            .get_added_node_info(node)
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        Ok(GetAddedNodeInfo(
+            node_request
+                .into_iter()
+                .map(
+                    |AddedNodeInfo {
+                         addednode,
+                         connected,
+                         addresses,
+                     }| AddedNode {
+                        added_node: addednode.to_string(),
+                        connected,
+                        addresses: addresses
+                            .into_iter()
+                            .map(
+                                |floresta_wire::node_interface::AddedNodeAddress {
+                                     address,
+                                     connected,
+                                 }| AddedNodeAddress {
+                                    address: address.to_string(),
+                                    connected,
+                                },
+                            )
+                            .collect(),
+                    },
+                )
+                .collect(),
+        ))
     }
 
     pub(crate) async fn get_network_info(&self) -> Result<GetNetworkInfo> {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -336,6 +336,15 @@ async fn handle_json_rpc_request(
             state.clone().find_tx_out(txid, vout, script, height).await
         }
 
+        "getaddednodeinfo" => {
+            let node = try_into_optional(get_at(&params, 0, "node"))?;
+
+            state
+                .get_added_node_info(node)
+                .await
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
+        }
+
         "getblock" => {
             let hash = get_at(&params, 0, "block_hash")?;
             let verbosity = get_with_default(&params, 1, "verbosity", 1)?;

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use std::vec;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::GetAddedNodeInfo;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
@@ -154,6 +155,9 @@ pub trait FlorestaRPC {
     fn ping(&self) -> Result<()>;
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> Result<GetAddrManInfo>;
+
+    #[doc = include_str!("../../../doc/rpc/getaddednodeinfo.md")]
+    fn get_added_node_info(&self, node: Option<String>) -> Result<GetAddedNodeInfo>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -383,5 +387,12 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+
+    fn get_added_node_info(&self, node: Option<String>) -> Result<GetAddedNodeInfo> {
+        match node {
+            Some(n) => self.call("getaddednodeinfo", &[Value::String(n)]),
+            None => self.call("getaddednodeinfo", &[]),
+        }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -36,6 +36,8 @@ use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
 use crate::node_handle::NodeResponse;
 use crate::node_handle::UserRequest;
+use crate::node_interface::AddedNodeAddress;
+use crate::node_interface::AddedNodeInfo;
 use crate::node_interface::PeerInfo;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::PeerMessages;
@@ -874,6 +876,43 @@ where
             kind: peer.kind,
             transport_protocol: peer.transport_protocol,
         })
+    }
+
+    pub(crate) fn handle_get_added_node_info(
+        &self,
+        node: Option<BitcoinSocketAddr>,
+    ) -> Vec<AddedNodeInfo> {
+        self.added_peers
+            .iter()
+            .filter_map(|added| {
+                // If a node filter is specified, skip entries that don't match
+                if let Some(filter) = &node {
+                    if added.address != *filter {
+                        return None;
+                    }
+                }
+
+                let connected = self.peers.values().any(|peer| {
+                    *peer.address.as_bitcoin_socket_addr() == added.address
+                        && peer.state == PeerStatus::Ready
+                });
+
+                let addresses = if connected {
+                    vec![AddedNodeAddress {
+                        address: added.address.clone(),
+                        connected: "outbound".to_string(),
+                    }]
+                } else {
+                    vec![]
+                };
+
+                Some(AddedNodeInfo {
+                    addednode: added.address.clone(),
+                    connected,
+                    addresses,
+                })
+            })
+            .collect()
     }
 
     // === ADDNODE ===

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -167,6 +167,12 @@ where
                 return;
             }
 
+            UserRequest::GetAddedNodeInfo(node) => {
+                let info = self.handle_get_added_node_info(node);
+                try_and_log!(responder.send(NodeResponse::GetAddedNodeInfo(info)));
+                return;
+            }
+
             UserRequest::SendTransaction(transaction) => {
                 let txid = transaction.compute_txid();
                 let mut mempool = self.mempool.lock().await;

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -31,6 +31,7 @@ use super::UtreexoNodeConfig;
 use super::node::NodeNotification;
 use crate::address_man::ConnectionStats;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+use crate::node_interface::AddedNodeInfo;
 use crate::node_interface::ChainMethods;
 use crate::node_interface::MempoolMethods;
 use crate::node_interface::NetworkMethods;
@@ -106,6 +107,9 @@ pub enum UserRequest {
         /// The remote node will send min(height(stop_hash), 2_000) headers on each request.
         stop_hash: BlockHash,
     },
+
+    /// Request for data regarding added nodes possibly filter by a provided one
+    GetAddedNodeInfo(Option<BitcoinSocketAddr>),
 }
 
 #[derive(Debug)]
@@ -155,6 +159,9 @@ pub enum NodeResponse {
 
     /// Received compact block filter headers.
     CFilterHeaders(CFHeaders),
+
+    /// Request for data regarding added nodes possibly filter by a provided one
+    GetAddedNodeInfo(Vec<AddedNodeInfo>),
 }
 
 #[derive(Debug)]
@@ -301,6 +308,17 @@ impl NetworkMethods for NodeHandle {
         let val = self.send_request(UserRequest::Ping).await?;
 
         extract_variant!(Ping, val)
+    }
+
+    async fn get_added_node_info(
+        &self,
+        node: Option<BitcoinSocketAddr>,
+    ) -> Result<Vec<AddedNodeInfo>, Self::Error> {
+        let val = self
+            .send_request(UserRequest::GetAddedNodeInfo(node))
+            .await?;
+
+        extract_variant!(GetAddedNodeInfo, val)
     }
 
     async fn get_addrman_info(&self) -> Result<ConnectionStats, Self::Error> {

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -32,6 +32,29 @@ use super::transport::TransportProtocol;
 use crate::address_man::ConnectionStats;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 
+#[derive(Debug, Clone)]
+/// Information about a manually added node (via `addnode`).
+pub struct AddedNodeInfo {
+    /// The address of the added node.
+    pub addednode: BitcoinSocketAddr,
+
+    /// Whether we are currently connected to this node.
+    pub connected: bool,
+
+    /// Connection details. Only populated when `connected` is true.
+    pub addresses: Vec<AddedNodeAddress>,
+}
+
+#[derive(Debug, Clone)]
+/// Address information for a connected added node.
+pub struct AddedNodeAddress {
+    /// The peer address.
+    pub address: BitcoinSocketAddr,
+
+    /// The connection direction: "outbound" (Floresta does not accept inbound).
+    pub connected: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 /// A struct representing a peer connected to the node.
 ///
@@ -142,6 +165,12 @@ pub trait NetworkMethods {
     /// This function will return a list of `PeerInfo` structs, each of which contains information
     /// about a single peer.
     fn get_peer_info(&self) -> impl Future<Output = Result<Vec<PeerInfo>, Self::Error>>;
+
+    /// Information about all manually added nodes possibly filtering by a given one.
+    fn get_added_node_info(
+        &self,
+        node: Option<BitcoinSocketAddr>,
+    ) -> impl Future<Output = Result<Vec<AddedNodeInfo>, Self::Error>>;
 
     /// Returns the number of peers currently connected to the node
     fn get_connection_count(&self) -> impl Future<Output = Result<usize, Self::Error>>;

--- a/doc/rpc/getaddednodeinfo.md
+++ b/doc/rpc/getaddednodeinfo.md
@@ -1,0 +1,44 @@
+# `getaddednodeinfo`
+
+Return information about nodes that were manually added.
+
+## Usage
+
+### Synopsis
+
+```text
+floresta-cli getaddednodeinfo [node]
+```
+
+### Examples
+
+```bash
+floresta-cli getaddednodeinfo
+floresta-cli getaddednodeinfo 192.168.0.1:8333
+```
+
+## Arguments
+
+- `node` - (string, optional) If provided, return information only about this added node. The value should be an IP address or `ip:port`. If only an IP is given, port 8333 is assumed.
+
+## Returns
+
+### Ok Response
+
+A JSON array of objects, one per added node:
+
+- `addednode` - (string) The address of the node in `ip:port` format
+- `connected` - (boolean) Whether the node is currently connected
+- `addresses` - (array, only when connected) Connection details:
+  - `address` - (string) The peer address in `ip:port` format
+  - `connected` - (string) The connection direction (`"outbound"`)
+
+### Error Response
+
+- `Node` - Failed to retrieve added node information
+- `InvalidAddress` - The provided node address could not be parsed
+
+## Notes
+
+- Only manually nodes added will appear here; peers discovered automatically are not included.
+- Floresta does not accept inbound connections yet, so the `connected` field in the `addresses` array is always `"outbound"`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,6 +338,41 @@ def shared_utreexod_node(shared_node_manager) -> Node:
     return node
 
 
+@pytest.fixture(scope="class")
+def shared_extra_bitcoind_pair(shared_node_manager) -> tuple[Node, Node]:
+    """Two bitcoind nodes (v1 transport) shared across all methods in a test class."""
+    bitcoind_a = shared_node_manager.add_node_extra_args(
+        variant=NodeType.BITCOIND, extra_args=["-v2transport=0"]
+    )
+    shared_node_manager.run_node(bitcoind_a)
+
+    bitcoind_b = shared_node_manager.add_node_extra_args(
+        variant=NodeType.BITCOIND, extra_args=["-v2transport=0"]
+    )
+    shared_node_manager.run_node(bitcoind_b)
+
+    return bitcoind_a, bitcoind_b
+
+
+@pytest.fixture(scope="class")
+def shared_connect_flag_pair(shared_node_manager) -> tuple[Node, Node]:
+    """A dedicated florestad (with --connect) and bitcoind pair shared across a test class."""
+    bitcoind = shared_node_manager.add_node_extra_args(
+        variant=NodeType.BITCOIND, extra_args=["-v2transport=0"]
+    )
+    shared_node_manager.run_node(bitcoind)
+
+    florestad = shared_node_manager.add_node_extra_args(
+        variant=NodeType.FLORESTAD,
+        extra_args=[f"--connect={bitcoind.p2p_url}"],
+    )
+    shared_node_manager.run_node(florestad)
+
+    shared_node_manager.wait_for_peers_connections(florestad, bitcoind)
+
+    return florestad, bitcoind
+
+
 @pytest.fixture
 def add_node_with_extra_args(node_manager):
     """

--- a/tests/floresta-cli/getaddednodeinfo.py
+++ b/tests/floresta-cli/getaddednodeinfo.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getaddednodeinfo.py
+
+This functional test verifies the `getaddednodeinfo` RPC method.
+"""
+
+import pytest
+from test_framework.constants import JSONRPC_ERRCODE_INVALID_PARAMS
+
+
+@pytest.mark.rpc
+class TestGetAddedNodeInfo:
+    """Functional tests for the getaddednodeinfo RPC."""
+
+    def test_get_added_node_info_empty(self, shared_florestad_node):
+        """
+        With no manually added nodes, getaddednodeinfo returns an empty list.
+        """
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert isinstance(info, list)
+        assert len(info) == 0
+
+    def test_get_added_node_info_invalid_node_filter(self, shared_florestad_node):
+        """
+        Passing an invalid address as the node filter should return an error.
+        """
+        resp = shared_florestad_node.rpc.noraise_request(
+            "getaddednodeinfo", ["not-a-valid-address"]
+        )
+        shared_florestad_node.rpc.assert_rpc_error(
+            resp,
+            expected_status_code=400,
+            expected_rpcerror_code=JSONRPC_ERRCODE_INVALID_PARAMS,
+            expected_message="Invalid network address provided",
+        )
+
+    def test_get_added_node_info_connected(
+        self, shared_node_manager, shared_florestad_node, shared_bitcoind_node
+    ):
+        """
+        After adding a node via addnode and connecting, getaddednodeinfo should
+        report the node as connected with a populated addresses array.
+        """
+        shared_node_manager.connect_nodes(
+            shared_florestad_node, shared_bitcoind_node, v2transport=True
+        )
+
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 1
+
+        entry = info[0]
+        assert entry["addednode"] == shared_bitcoind_node.p2p_url
+        assert entry["connected"] is True
+
+        # The addresses array must be present and populated when connected
+        assert "addresses" in entry
+        assert len(entry["addresses"]) == 1
+        assert entry["addresses"][0]["address"] == shared_bitcoind_node.p2p_url
+        assert entry["addresses"][0]["connected"] == "outbound"
+
+        # Cleanup: remove the manually added node
+        shared_florestad_node.rpc.addnode(shared_bitcoind_node.p2p_url, "remove")
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 0
+
+    def test_get_added_node_info_after_remove(
+        self, shared_node_manager, shared_florestad_node, shared_bitcoind_node
+    ):
+        """
+        After removing a manually added node, it should no longer appear in
+        getaddednodeinfo.
+        """
+        shared_node_manager.connect_nodes(
+            shared_florestad_node, shared_bitcoind_node, v2transport=True
+        )
+
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 1
+
+        shared_florestad_node.rpc.addnode(shared_bitcoind_node.p2p_url, "remove")
+
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 0
+
+    def test_get_added_node_info_multiple_nodes(
+        self, shared_node_manager, shared_florestad_node, shared_extra_bitcoind_pair
+    ):
+        """
+        Adding multiple nodes via addnode should all appear in getaddednodeinfo.
+        """
+        bitcoind_a, bitcoind_b = shared_extra_bitcoind_pair
+
+        shared_node_manager.connect_nodes(shared_florestad_node, bitcoind_a)
+        shared_node_manager.connect_nodes(shared_florestad_node, bitcoind_b)
+
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 2
+
+        added_addresses = {entry["addednode"] for entry in info}
+        assert bitcoind_a.p2p_url in added_addresses
+        assert bitcoind_b.p2p_url in added_addresses
+
+        # Both should be connected with addresses populated
+        for entry in info:
+            assert entry["connected"] is True
+            assert len(entry["addresses"]) == 1
+            assert entry["addresses"][0]["connected"] == "outbound"
+
+        # Cleanup: remove both manually added nodes
+        shared_florestad_node.rpc.addnode(bitcoind_a.p2p_url, "remove")
+        shared_florestad_node.rpc.addnode(bitcoind_b.p2p_url, "remove")
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 0
+
+    def test_get_added_node_info_filter_by_node(
+        self, shared_node_manager, shared_florestad_node, shared_extra_bitcoind_pair
+    ):
+        """
+        The optional node parameter should filter results to a single entry.
+        """
+        bitcoind_a, bitcoind_b = shared_extra_bitcoind_pair
+
+        shared_node_manager.connect_nodes(shared_florestad_node, bitcoind_a)
+        shared_node_manager.connect_nodes(shared_florestad_node, bitcoind_b)
+
+        # Filter for node A only
+        filtered = shared_florestad_node.rpc.get_added_node_info(bitcoind_a.p2p_url)
+        assert len(filtered) == 1
+        assert filtered[0]["addednode"] == bitcoind_a.p2p_url
+
+        # Filter for node B only
+        filtered = shared_florestad_node.rpc.get_added_node_info(bitcoind_b.p2p_url)
+        assert len(filtered) == 1
+        assert filtered[0]["addednode"] == bitcoind_b.p2p_url
+
+        # Filter for non-existent node returns empty list
+        filtered_empty = shared_florestad_node.rpc.get_added_node_info("1.2.3.4:9999")
+        assert len(filtered_empty) == 0
+
+        # Cleanup: remove both manually added nodes
+        shared_florestad_node.rpc.addnode(bitcoind_a.p2p_url, "remove")
+        shared_florestad_node.rpc.addnode(bitcoind_b.p2p_url, "remove")
+        info = shared_florestad_node.rpc.get_added_node_info()
+        assert len(info) == 0
+
+    def test_get_added_node_info_connect_flag_not_listed(
+        self, shared_connect_flag_pair
+    ):
+        """
+        Peers added via --connect should NOT appear in getaddednodeinfo.
+        Only peers added via the addnode RPC are listed.
+        """
+        florestad, _ = shared_connect_flag_pair
+
+        # The --connect peer must NOT appear in getaddednodeinfo
+        info = florestad.rpc.get_added_node_info()
+        assert isinstance(info, list)
+        assert len(info) == 0

--- a/tests/test_framework/rpc/bitcoin.py
+++ b/tests/test_framework/rpc/bitcoin.py
@@ -6,6 +6,8 @@ tests.test_framework.rpc.bitcoin.py
 A test framework for testing JsonRPC calls to a bitocoin node.
 """
 
+from typing import Optional
+
 from test_framework.rpc.base import BaseRPC
 
 
@@ -83,3 +85,11 @@ class BitcoinRPC(BaseRPC):
         Send a specified amount to a given address.
         """
         return self.perform_request("sendtoaddress", params=[address, amount])
+
+    def get_added_node_info(self, node: Optional[str] = None) -> list:
+        """
+        Get information about manually added nodes.
+        node: optional filter — return only this added node's info
+        """
+        params = [node] if node is not None else []
+        return self.perform_request("getaddednodeinfo", params)

--- a/tests/test_framework/rpc/floresta.py
+++ b/tests/test_framework/rpc/floresta.py
@@ -6,6 +6,8 @@ floresta_rpc.py
 A test framework for testing JsonRPC calls to a floresta node.
 """
 
+from typing import Optional
+
 from test_framework.rpc.base import BaseRPC
 
 
@@ -40,3 +42,11 @@ class FlorestaRPC(BaseRPC):
         Load a script descriptor into the wallet.
         """
         return self.perform_request("loaddescriptor", params=[descriptor])
+
+    def get_added_node_info(self, node: Optional[str] = None) -> list:
+        """
+        Get information about manually added nodes.
+        node: optional filter — return only this added node's info
+        """
+        params = [node] if node is not None else []
+        return self.perform_request("getaddednodeinfo", params)


### PR DESCRIPTION
### Description and Notes

add get addednodeinfo rpc that returns info about the nodes that were manually added and their addresses and wheter theyre connected.

Split of #916 

### How to verify the changes you have done?

I tried to cover the basic cases so: 
Read & Run integration tests.
