### PR TITLE
feat: addpeeraddress rpc

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -130,6 +130,14 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
         }
         Methods::GetAddrManInfo => serde_json::to_string_pretty(&client.get_addrman_info()?)?,
+        Methods::AddPeerAddress {
+            address,
+            port,
+            tried,
+        } => {
+            let tried = tried.unwrap_or(false);
+            serde_json::to_string_pretty(&client.add_peer_address(address, port, tried)?)?
+        }
     })
 }
 
@@ -464,4 +472,17 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetAddrManInfo,
+
+    #[doc = include_str!("../../../doc/rpc/addpeeraddress.md")]
+    #[command(
+        name = "addpeeraddress",
+        about = "Add an address to the address manager",
+        long_about = Some(include_str!("../../../doc/rpc/addpeeraddress.md")),
+        disable_help_subcommand = true
+    )]
+    AddPeerAddress {
+        address: String,
+        port: Option<u16>,
+        tried: Option<bool>,
+    },
 }

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeMap;
 
 use corepc_types::v26::AddrManInfoNetwork;
+use corepc_types::v30::AddPeerAddress;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
 use corepc_types::v30::GetNetworkInfoNetwork;
@@ -165,6 +166,28 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         );
 
         Ok(GetAddrManInfo(map))
+    }
+
+    pub(crate) async fn add_peer_address(
+        &self,
+        address: String,
+        port: Option<u16>,
+        tried: bool,
+    ) -> Result<AddPeerAddress> {
+        let addr = BitcoinSocketAddr::parse_address_with_port(
+            &address,
+            port,
+            Some(self.network),
+            SystemResolver,
+        )?;
+
+        let success = self
+            .node
+            .add_peer_address(addr, tried)
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        Ok(AddPeerAddress { success })
     }
 
     pub(crate) async fn get_network_info(&self) -> Result<GetNetworkInfo> {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -316,6 +316,17 @@ async fn handle_json_rpc_request(
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }
 
+        "addpeeraddress" => {
+            let address = get_at(&params, 0, "address")?;
+            let port = try_into_optional(get_at(&params, 1, "port"))?;
+            let tried = get_with_default(&params, 2, "tried", false)?;
+
+            state
+                .add_peer_address(address, port, tried)
+                .await
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
+        }
+
         "disconnectnode" => {
             let node_address = get_at(&params, 0, "node_address")?;
             let node_id = try_into_optional(get_at(&params, 1, "node_id"))?;

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -249,6 +249,72 @@ mod tests {
     }
 
     #[test]
+    fn test_add_peer_address() {
+        let (_proc, client) = start_florestad();
+
+        let addrman = |net: &str| {
+            let info = client.get_addrman_info().expect("rpc not working");
+            info.0[net].clone()
+        };
+
+        // Adding a new address with tried=false should succeed and create a "new" entry.
+        let ipv4_new_before = addrman("ipv4").new;
+        let res = client
+            .add_peer_address("8.8.4.4".into(), Some(8333), false)
+            .expect("rpc not working");
+        assert!(res.success);
+        assert!(ipv4_new_before < addrman("ipv4").new);
+
+        // Adding a routable address as "tried" should create a "tried" entry.
+        let ipv4_tried_before = addrman("ipv4").tried;
+        let res = client
+            .add_peer_address("8.8.8.8".into(), Some(8333), true)
+            .expect("rpc not working");
+        assert!(res.success);
+        assert!(ipv4_tried_before < addrman("ipv4").tried);
+
+        // Adding a duplicate should return success=false and leave counts unchanged.
+        let ipv4_tried_before = addrman("ipv4").tried;
+        let res = client
+            .add_peer_address("8.8.8.8".into(), Some(8333), false)
+            .expect("rpc not working");
+        assert!(!res.success);
+        assert_eq!(ipv4_tried_before, addrman("ipv4").tried);
+
+        // Adding an address without a port should use the network default.
+        let res = client
+            .add_peer_address("1.1.1.1".into(), None, false)
+            .expect("rpc not working");
+        assert!(res.success);
+
+        // IPv6: adding a routable IPv6 address with an explicit port should succeed. Note that
+        // IPv6 addresses must be bracketed, as everywhere else in our address-parsing API.
+        let ipv6_new_before = addrman("ipv6").new;
+        let res = client
+            .add_peer_address("[2001:4860:4860::8888]".into(), Some(8333), false)
+            .expect("rpc not working");
+        assert!(res.success);
+        assert!(ipv6_new_before < addrman("ipv6").new);
+
+        // IPv6 without a port should use the network default.
+        let ipv6_new_before = addrman("ipv6").new;
+        let res = client
+            .add_peer_address("[2001:4860:4860::8844]".into(), None, false)
+            .expect("rpc not working");
+        assert!(res.success);
+        assert!(ipv6_new_before < addrman("ipv6").new);
+
+        // Onion: adding a valid .onion v3 address should succeed.
+        let onion_addr = "ejgeimjypsfuijpxzy5xpwmmjmkr4izwze6od5pw74csjglflib6nsid.onion";
+        let onion_new_before = addrman("onion").new;
+        let res = client
+            .add_peer_address(onion_addr.into(), Some(8333), false)
+            .expect("rpc not working");
+        assert!(res.success);
+        assert!(onion_new_before < addrman("onion").new);
+    }
+
+    #[test]
     fn test_get_network_info() {
         let (_proc, client) = start_florestad();
 

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use std::vec;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::AddPeerAddress;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
@@ -154,6 +155,14 @@ pub trait FlorestaRPC {
     fn ping(&self) -> Result<()>;
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> Result<GetAddrManInfo>;
+
+    #[doc = include_str!("../../../doc/rpc/addpeeraddress.md")]
+    fn add_peer_address(
+        &self,
+        address: String,
+        port: Option<u16>,
+        tried: bool,
+    ) -> Result<AddPeerAddress>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -383,5 +392,19 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+
+    fn add_peer_address(
+        &self,
+        address: String,
+        port: Option<u16>,
+        tried: bool,
+    ) -> Result<AddPeerAddress> {
+        let mut params: Vec<Value> = vec![Value::String(address)];
+        if let Some(p) = port {
+            params.push(Value::Number(Number::from(p)));
+            params.push(Value::Bool(tried));
+        }
+        self.call("addpeeraddress", &params)
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -471,6 +471,11 @@ impl AddressMan {
             .as_secs()
     }
 
+    /// Returns the total number of addresses stored in the address manager.
+    pub fn address_count(&self) -> usize {
+        self.addresses.len()
+    }
+
     /// Add a new address to our list of known address
     pub fn push_addresses(&mut self, addresses: &[LocalAddress]) {
         for address in addresses {

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -424,6 +424,27 @@ impl BitcoinSocketAddr {
         Self::parse_v4(address, network)
             .or_else(|_| Self::parse_and_resolve_dns(address, network, resolver))
     }
+
+    /// Parses an address string with an optional explicit port.
+    ///
+    /// This is a convenience wrapper around [`Self::parse_address`] for callers that receive the
+    /// address and port as separate values (e.g. from an RPC call). The address must follow the
+    /// same format expected by [`Self::parse_address`] — in particular, IPv6 addresses must be
+    /// wrapped in brackets (e.g. `[2001:db8::1]`).
+    ///
+    /// If `port` is [`None`], the address is parsed as-is and the port will come from the address
+    /// string itself or fall back to the network default.
+    pub fn parse_address_with_port(
+        address: &str,
+        port: Option<u16>,
+        network: Option<Network>,
+        resolver: impl DnsResolver,
+    ) -> Result<Self, InvalidAddressError> {
+        match port {
+            Some(port) => Self::parse_address(&format!("{address}:{port}"), network, resolver),
+            None => Self::parse_address(address, network, resolver),
+        }
+    }
 }
 
 impl Display for BitcoinSocketAddr {

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -15,6 +15,7 @@ use floresta_common::try_and_log;
 use rand::distr::Distribution;
 use rand::distr::weighted::WeightedIndex;
 use rand::prelude::IteratorRandom;
+use rand::random;
 use rand::seq::IndexedRandom;
 use tracing::debug;
 use tracing::error;
@@ -881,6 +882,30 @@ where
             permissions: Vec::new(),
             transport_protocol: peer.transport_protocol,
         })
+    }
+
+    /// Add a peer to the address manager returning whether it was added or not.
+    pub(crate) fn handle_add_peer_address(&mut self, addr: BitcoinSocketAddr, tried: bool) -> bool {
+        let state = if tried {
+            AddressState::Tried(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            )
+        } else {
+            AddressState::NeverTried
+        };
+
+        let services = ServiceFlags::WITNESS | ServiceFlags::NETWORK_LIMITED;
+        let id = random::<u64>() as usize;
+        let local_addr = LocalAddress::new(addr, 0, state, services, id);
+
+        let count_before = self.address_man.address_count();
+        self.address_man.push_addresses(&[local_addr]);
+        let count_after = self.address_man.address_count();
+
+        count_after > count_before
     }
 
     // === ADDNODE ===

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -167,6 +167,17 @@ where
                 return;
             }
 
+            UserRequest::AddPeerAddress {
+                peer_address,
+                tried,
+            } => {
+                let success = self.handle_add_peer_address(peer_address, tried);
+
+                try_and_log!(responder.send(NodeResponse::AddPeerAddress(success)));
+
+                return;
+            }
+
             UserRequest::SendTransaction(transaction) => {
                 let txid = transaction.compute_txid();
                 let mut mempool = self.mempool.lock().await;

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -106,6 +106,15 @@ pub enum UserRequest {
         /// The remote node will send min(height(stop_hash), 2_000) headers on each request.
         stop_hash: BlockHash,
     },
+
+    /// Add a peer to the address manager.
+    AddPeerAddress {
+        /// The Peers address.
+        peer_address: BitcoinSocketAddr,
+
+        /// Whether we should add this address to the tried table.
+        tried: bool,
+    },
 }
 
 #[derive(Debug)]
@@ -155,6 +164,9 @@ pub enum NodeResponse {
 
     /// Received compact block filter headers.
     CFilterHeaders(CFHeaders),
+
+    /// Whether an address was successfully added to the address manager.
+    AddPeerAddress(bool),
 }
 
 #[derive(Debug)]
@@ -261,6 +273,21 @@ impl NetworkMethods for NodeHandle {
             .await?;
 
         extract_variant!(Add, val);
+    }
+
+    async fn add_peer_address(
+        &self,
+        address: BitcoinSocketAddr,
+        tried: bool,
+    ) -> Result<bool, Self::Error> {
+        let val = self
+            .send_request(UserRequest::AddPeerAddress {
+                peer_address: address,
+                tried,
+            })
+            .await?;
+
+        extract_variant!(AddPeerAddress, val);
     }
 
     async fn remove_peer(&self, addr: BitcoinSocketAddr) -> Result<bool, Self::Error> {

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -118,6 +118,15 @@ pub trait NetworkMethods {
         v2transport: bool,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
+    /// Adds a peer to the address manager, without any connection attempt.
+    ///
+    /// This function will return a boolean indicating whether the addition was successful.
+    fn add_peer_address(
+        &self,
+        address: BitcoinSocketAddr,
+        tried: bool,
+    ) -> impl Future<Output = Result<bool, Self::Error>>;
+
     /// Removes a peer from the node's peer list.
     /// This function will return a boolean indicating whether the peer was successfully removed.
     /// It may be called multiple times, and may use hostnames or IP addresses.

--- a/doc/rpc/addpeeraddress.md
+++ b/doc/rpc/addpeeraddress.md
@@ -1,0 +1,48 @@
+# `addpeeraddress`
+
+Add an IP address and port to the node's address manager.
+
+## Usage
+
+### Synopsis
+
+```text
+floresta-cli addpeeraddress <address> [port] [tried]
+```
+
+### Examples
+
+```bash
+floresta-cli addpeeraddress 192.168.0.1
+floresta-cli addpeeraddress 192.168.0.1 8333
+floresta-cli addpeeraddress 192.168.0.1 8333 true
+floresta-cli addpeeraddress "[2001:db8::1]" 8333 false
+floresta-cli addpeeraddress "example7abcdefg.onion" 8333
+```
+
+## Arguments
+
+- `address` - (string, required) The IP address or onion address of the peer. Accepts IPv4 (`192.168.0.1`), IPv6 (`[2001:db8::1]`, brackets required), or Tor v3 onion addresses. The port may be embedded in the address string (e.g. `192.168.0.1:8333` or `[2001:db8::1]:8333`), in which case the separate `port` parameter is not needed.
+
+- `port` - (numeric, optional, default=network default port) The port number the peer listens on. Defaults to the network's P2P port (e.g. 8333 for mainnet). If a port is already embedded in the `address` string, this parameter should be omitted.
+
+- `tried` - (boolean, optional, default=false) If `true`, the address is added directly to the _tried_ table, indicating a previously successful connection.
+
+## Returns
+
+### Ok Response
+
+A JSON object with a single field:
+
+- `success` - (boolean) `true` if the address was accepted by the address manager, `false` otherwise (e.g. the address is not routable or the address manager is full).
+
+### Error Response
+
+- `Node` - Failed to communicate with the address manager
+
+## Notes
+
+- IPv4, IPv6, and Tor v3 onion addresses are accepted. I2P and CJDNS are not currently supported.
+- Adding an address here does not immediately open a connection to the peer. Use `addnode` to establish a persistent connection.
+- There are corner cases where the command runs fine but the address can be denied. Internally on the Address Manager, we insert address with an method
+  called `push_addresses`, which may deny some addresses. For further details, check the source code or the method documentation if its available.


### PR DESCRIPTION
### Description and Notes

addpeeraddress Is a simple hidden RPC that adds an address into the Address Manager.

This PR implements the addpeeraddress rpc, with docs and integration tests.

Depends on #1116 

### How to verify the changes you have done?

The tests use the getaddrmaninfo rpc to assert the addresses are correctly handled.