### PR TITLE
feat(rpc): getnodeaddresses

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -138,6 +138,14 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
         }
         Methods::GetAddrManInfo => serde_json::to_string_pretty(&client.get_addrman_info()?)?,
+        Methods::AddPeerAddress {
+            address,
+            port,
+            tried,
+        } => {
+            let tried = tried.unwrap_or(false);
+            serde_json::to_string_pretty(&client.add_peer_address(address, port, tried)?)?
+        }
     })
 }
 
@@ -456,4 +464,17 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetAddrManInfo,
+
+    #[doc = include_str!("../../../doc/rpc/addpeeraddress.md")]
+    #[command(
+        name = "addpeeraddress",
+        about = "Add an address to the address manager",
+        long_about = Some(include_str!("../../../doc/rpc/addpeeraddress.md")),
+        disable_help_subcommand = true
+    )]
+    AddPeerAddress {
+        address: String,
+        port: Option<u16>,
+        tried: Option<bool>,
+    },
 }

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -146,6 +146,9 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             let tried = tried.unwrap_or(false);
             serde_json::to_string_pretty(&client.add_peer_address(address, port, tried)?)?
         }
+        Methods::GetNodeAddresses { count, network } => {
+            serde_json::to_string_pretty(&client.get_node_addresses(count, network)?)?
+        }
     })
 }
 
@@ -476,5 +479,20 @@ pub enum Methods {
         address: String,
         port: Option<u16>,
         tried: Option<bool>,
+    },
+
+    #[doc = include_str!("../../../doc/rpc/getnodeaddresses.md")]
+    #[command(
+        name = "getnodeaddresses",
+        about = "Returns known peer addresses from the address manager",
+        long_about = Some(include_str!("../../../doc/rpc/getnodeaddresses.md")),
+        disable_help_subcommand = true
+    )]
+    GetNodeAddresses {
+        /// How many addresses we will return, defaults to 1.
+        count: Option<u32>,
+
+        /// Network to filter addresses
+        network: Option<String>,
     },
 }

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -9,6 +9,8 @@ use corepc_types::v30::AddPeerAddress;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
 use corepc_types::v30::GetNetworkInfoNetwork;
+use corepc_types::v30::GetNodeAddresses;
+use corepc_types::v30::NodeAddress as CorepcNodeAddress;
 use floresta_common::PROTOCOL_VERSION;
 use floresta_common::advertised_services;
 use floresta_common::service_flags_strings;
@@ -188,6 +190,31 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .map_err(|e| JsonRpcError::Node(e.to_string()))?;
 
         Ok(AddPeerAddress { success })
+    }
+
+    pub(crate) async fn get_node_addresses(
+        &self,
+        count: u32,
+        network: Option<ReachableNetworks>,
+    ) -> Result<GetNodeAddresses> {
+        let addresses = self
+            .node
+            .get_node_addresses(count, network)
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        Ok(GetNodeAddresses(
+            addresses
+                .into_iter()
+                .map(|addr| CorepcNodeAddress {
+                    time: addr.time,
+                    services: addr.services,
+                    address: addr.address,
+                    port: addr.port,
+                    network: addr.network.to_string(),
+                })
+                .collect(),
+        ))
     }
 
     pub(crate) async fn get_network_info(&self) -> Result<GetNetworkInfo> {

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeMap;
 
 use corepc_types::v26::AddrManInfoNetwork;
+use corepc_types::v30::AddPeerAddress;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
 use corepc_types::v30::GetNetworkInfoNetwork;
@@ -165,6 +166,28 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         );
 
         Ok(GetAddrManInfo(map))
+    }
+
+    pub(crate) async fn add_peer_address(
+        &self,
+        address: String,
+        port: Option<u16>,
+        tried: bool,
+    ) -> Result<AddPeerAddress> {
+        let addr = BitcoinSocketAddr::parse_address_with_port(
+            &address,
+            port,
+            Some(self.network),
+            SystemResolver,
+        )?;
+
+        let success = self
+            .node
+            .add_peer_address(addr, tried)
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        Ok(AddPeerAddress { success })
     }
 
     pub(crate) async fn get_network_info(&self) -> Result<GetNetworkInfo> {

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -35,6 +35,7 @@ use floresta_compact_filters::network_filters::NetworkFilters;
 use floresta_watch_only::AddressCache;
 use floresta_watch_only::CachedTransaction;
 use floresta_watch_only::kv_database::KvDatabase;
+use floresta_wire::address_man::ReachableNetworks;
 use floresta_wire::node_handle::NodeHandle;
 use floresta_wire::node_interface::ChainMethods;
 use floresta_wire::node_interface::MempoolMethods;
@@ -429,6 +430,30 @@ async fn handle_json_rpc_request(
 
             state
                 .get_txout_proof(&txids, block_hash)
+                .await
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
+        }
+
+        "getnodeaddresses" => {
+            let count = get_with_default(&params, 0, "count", 1)?;
+            let network_str = get_with_default(&params, 1, "network", "all")?;
+
+            let network: Option<ReachableNetworks> = match network_str {
+                "all" => None,
+                "ipv4" => Some(ReachableNetworks::IPv4),
+                "ipv6" => Some(ReachableNetworks::IPv6),
+                "onion" => Some(ReachableNetworks::TorV3),
+                "i2p" => Some(ReachableNetworks::I2P),
+                "cjdns" => Some(ReachableNetworks::Cjdns),
+                other => {
+                    return Err(JsonRpcError::InvalidParameterType(format!(
+                        "Unknown network '{other}'. Expected one of: ipv4, ipv6, onion, i2p, cjdns or all"
+                    )));
+                }
+            };
+
+            state
+                .get_node_addresses(count, network)
                 .await
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -314,6 +314,17 @@ async fn handle_json_rpc_request(
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }
 
+        "addpeeraddress" => {
+            let address = get_at(&params, 0, "address")?;
+            let port = try_into_optional(get_at(&params, 1, "port"))?;
+            let tried = get_with_default(&params, 2, "tried", false)?;
+
+            state
+                .add_peer_address(address, port, tried)
+                .await
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
+        }
+
         "disconnectnode" => {
             let node_address = get_at(&params, 0, "node_address")?;
             let node_id = try_into_optional(get_at(&params, 1, "node_id"))?;

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -165,6 +165,9 @@ pub trait FlorestaRPC {
         port: Option<u16>,
         tried: bool,
     ) -> Result<AddPeerAddress>;
+
+    #[doc = include_str!("../../../doc/rpc/getnodeaddresses.md")]
+    fn get_node_addresses(&self, count: Option<u32>, network: Option<String>) -> Result<Value>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -402,5 +405,14 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
             params.push(Value::Bool(tried));
         }
         self.call("addpeeraddress", &params)
+    }
+
+    fn get_node_addresses(&self, count: Option<u32>, network: Option<String>) -> Result<Value> {
+        let params = match (count, network) {
+            (None, _) => vec![],
+            (Some(c), None) => vec![Value::Number(Number::from(c))],
+            (Some(c), Some(n)) => vec![Value::Number(Number::from(c)), Value::String(n)],
+        };
+        self.call("getnodeaddresses", &params)
     }
 }

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use std::vec;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::AddPeerAddress;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
@@ -156,6 +157,14 @@ pub trait FlorestaRPC {
     fn ping(&self) -> Result<()>;
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> Result<GetAddrManInfo>;
+
+    #[doc = include_str!("../../../doc/rpc/addpeeraddress.md")]
+    fn add_peer_address(
+        &self,
+        address: String,
+        port: Option<u16>,
+        tried: bool,
+    ) -> Result<AddPeerAddress>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -379,5 +388,19 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+
+    fn add_peer_address(
+        &self,
+        address: String,
+        port: Option<u16>,
+        tried: bool,
+    ) -> Result<AddPeerAddress> {
+        let mut params: Vec<Value> = vec![Value::String(address)];
+        if let Some(p) = port {
+            params.push(Value::Number(Number::from(p)));
+            params.push(Value::Bool(tried));
+        }
+        self.call("addpeeraddress", &params)
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -82,7 +82,8 @@ pub enum AddressState {
 }
 
 /// All the networks we might receive addresses for
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ReachableNetworks {
     IPv4,
     IPv6,
@@ -649,6 +650,24 @@ impl AddressMan {
                     address.services,
                     address.get_port(),
                 ))
+            })
+            .collect()
+    }
+
+    /// Returns all known addresses that are not terrible, matching Bitcoin Core's
+    /// `GetAddr_()` behavior. This includes untried and recently-failed peers,
+    /// excluding only banned addresses.
+    pub fn get_all_not_terrible(&self) -> AddressToSend {
+        self.addresses
+            .values()
+            .filter(|addr| addr.is_routable() && !matches!(addr.state, AddressState::Banned(_)))
+            .map(|addr| {
+                (
+                    addr.address.as_addrv2().clone(),
+                    addr.last_connected,
+                    addr.services,
+                    addr.get_port(),
+                )
             })
             .collect()
     }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -471,6 +471,11 @@ impl AddressMan {
             .as_secs()
     }
 
+    /// Returns the total number of addresses stored in the address manager.
+    pub fn address_count(&self) -> usize {
+        self.addresses.len()
+    }
+
     /// Add a new address to our list of known address
     pub fn push_addresses(&mut self, addresses: &[LocalAddress]) {
         for address in addresses {

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -424,6 +424,43 @@ impl BitcoinSocketAddr {
         Self::parse_v4(address, network)
             .or_else(|_| Self::parse_and_resolve_dns(address, network, resolver))
     }
+
+    /// Parses an address string with an optional explicit port.
+    ///
+    /// This is a convenience wrapper around [`Self::parse_address`] for callers that receive the
+    /// address and port as separate values (e.g. from an RPC call). It handles the formatting
+    /// needed to produce a valid parseable string — in particular, wrapping IPv6 addresses in
+    /// brackets so the parser can distinguish colons in the address from the port separator.
+    ///
+    /// If `port` is [`None`], the address is parsed as-is and the port will come from the address
+    /// string itself or fall back to the network default.
+    pub fn parse_address_with_port(
+        address: &str,
+        port: Option<u16>,
+        network: Option<Network>,
+        resolver: impl DnsResolver,
+    ) -> Result<Self, InvalidAddressError> {
+        let is_ipv6 = address.parse::<Ipv6Addr>().is_ok();
+
+        match port {
+            Some(port) => {
+                let combined = if is_ipv6 {
+                    format!("[{address}]:{port}")
+                } else {
+                    format!("{address}:{port}")
+                };
+                Self::parse_address(&combined, network, resolver)
+            }
+            None => {
+                let address = if is_ipv6 {
+                    format!("[{address}]")
+                } else {
+                    address.to_string()
+                };
+                Self::parse_address(&address, network, resolver)
+            }
+        }
+    }
 }
 
 impl Display for BitcoinSocketAddr {

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -6,6 +6,7 @@ use std::time::UNIX_EPOCH;
 
 use bitcoin::Transaction;
 use bitcoin::p2p::ServiceFlags;
+use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::message_blockdata::Inventory;
 use floresta_chain::ChainBackend;
@@ -16,6 +17,7 @@ use rand::distr::weighted::WeightedIndex;
 use rand::prelude::IteratorRandom;
 use rand::random;
 use rand::seq::IndexedRandom;
+use rand::seq::SliceRandom;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -29,6 +31,7 @@ use super::PeerStatus;
 use super::UtreexoNode;
 use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
+use crate::address_man::ReachableNetworks;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::block_proof::Bitmap;
 use crate::node::running_ctx::RunningNode;
@@ -36,7 +39,9 @@ use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
 use crate::node_handle::NodeResponse;
 use crate::node_handle::UserRequest;
+use crate::node_interface::NodeAddress;
 use crate::node_interface::PeerInfo;
+use crate::onion::OnionV3Addr;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
@@ -873,6 +878,51 @@ where
             kind: peer.kind,
             transport_protocol: peer.transport_protocol,
         })
+    }
+
+    pub(crate) fn handle_get_node_addresses(
+        &self,
+        count: u32,
+        network: Option<ReachableNetworks>,
+    ) -> Vec<NodeAddress> {
+        let mut addresses = self.address_man.get_all_not_terrible();
+        // Shuffle to make it harder to fingerprint/eclipse the node, matching Bitcoin Core behavior
+        addresses.shuffle(&mut rand::rng());
+
+        // count=0 means return all known addresses, matching Bitcoin Core behavior
+        let count = if count == 0 {
+            usize::MAX
+        } else {
+            count as usize
+        };
+
+        addresses
+            .into_iter()
+            .filter_map(|(addr, time, services, port)| {
+                let (address, addr_network) = match (&addr, &network) {
+                    (AddrV2::Ipv4(ip), None | Some(ReachableNetworks::IPv4)) => {
+                        (ip.to_string(), ReachableNetworks::IPv4)
+                    }
+                    (AddrV2::Ipv6(ip), None | Some(ReachableNetworks::IPv6)) => {
+                        (ip.to_string(), ReachableNetworks::IPv6)
+                    }
+                    (AddrV2::TorV3(key), None | Some(ReachableNetworks::TorV3)) => (
+                        OnionV3Addr::from(*key).to_string(),
+                        ReachableNetworks::TorV3,
+                    ),
+                    _ => return None,
+                };
+
+                Some(NodeAddress {
+                    time,
+                    services: services.to_u64(),
+                    address,
+                    port,
+                    network: addr_network,
+                })
+            })
+            .take(count)
+            .collect()
     }
 
     /// Add a peer to the address manager returning whether it was added or not.

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -14,6 +14,7 @@ use floresta_common::try_and_log;
 use rand::distr::Distribution;
 use rand::distr::weighted::WeightedIndex;
 use rand::prelude::IteratorRandom;
+use rand::random;
 use rand::seq::IndexedRandom;
 use tracing::debug;
 use tracing::error;
@@ -872,6 +873,30 @@ where
             kind: peer.kind,
             transport_protocol: peer.transport_protocol,
         })
+    }
+
+    /// Add a peer to the address manager returning whether it was added or not.
+    pub(crate) fn handle_add_peer_address(&mut self, addr: BitcoinSocketAddr, tried: bool) -> bool {
+        let state = if tried {
+            AddressState::Tried(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            )
+        } else {
+            AddressState::NeverTried
+        };
+
+        let services = ServiceFlags::WITNESS | ServiceFlags::NETWORK_LIMITED;
+        let id = random::<u64>() as usize;
+        let local_addr = LocalAddress::new(addr, 0, state, services, id);
+
+        let count_before = self.address_man.address_count();
+        self.address_man.push_addresses(&[local_addr]);
+        let count_after = self.address_man.address_count();
+
+        count_after > count_before
     }
 
     // === ADDNODE ===

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -167,6 +167,17 @@ where
                 return;
             }
 
+            UserRequest::AddPeerAddress {
+                peer_address,
+                tried,
+            } => {
+                let success = self.handle_add_peer_address(peer_address, tried);
+
+                try_and_log!(responder.send(NodeResponse::AddPeerAddress(success)));
+
+                return;
+            }
+
             UserRequest::SendTransaction(transaction) => {
                 let txid = transaction.compute_txid();
                 let mut mempool = self.mempool.lock().await;

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -178,6 +178,12 @@ where
                 return;
             }
 
+            UserRequest::GetNodeAddresses(count, network) => {
+                let addresses = self.handle_get_node_addresses(count, network);
+                try_and_log!(responder.send(NodeResponse::GetNodeAddresses(addresses)));
+                return;
+            }
+
             UserRequest::SendTransaction(transaction) => {
                 let txid = transaction.compute_txid();
                 let mut mempool = self.mempool.lock().await;

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -106,6 +106,15 @@ pub enum UserRequest {
         /// The remote node will send min(height(stop_hash), 2_000) headers on each request.
         stop_hash: BlockHash,
     },
+
+    /// Add a peer to the address manager.
+    AddPeerAddress {
+        /// The Peers address.
+        peer_address: BitcoinSocketAddr,
+
+        /// Whether we should add this address to the tried table.
+        tried: bool,
+    },
 }
 
 #[derive(Debug)]
@@ -155,6 +164,9 @@ pub enum NodeResponse {
 
     /// Received compact block filter headers.
     CFilterHeaders(CFHeaders),
+
+    /// Whether an address was successfully added to the address manager.
+    AddPeerAddress(bool),
 }
 
 #[derive(Debug)]
@@ -261,6 +273,21 @@ impl NetworkMethods for NodeHandle {
             .await?;
 
         extract_variant!(Add, val);
+    }
+
+    async fn add_peer_address(
+        &self,
+        address: BitcoinSocketAddr,
+        tried: bool,
+    ) -> Result<bool, Self::Error> {
+        let val = self
+            .send_request(UserRequest::AddPeerAddress {
+                peer_address: address,
+                tried,
+            })
+            .await?;
+
+        extract_variant!(AddPeerAddress, val);
     }
 
     async fn remove_peer(&self, addr: BitcoinSocketAddr) -> Result<bool, Self::Error> {

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -30,10 +30,12 @@ use tokio::sync::oneshot::error::RecvError;
 use super::UtreexoNodeConfig;
 use super::node::NodeNotification;
 use crate::address_man::ConnectionStats;
+use crate::address_man::ReachableNetworks;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::node_interface::ChainMethods;
 use crate::node_interface::MempoolMethods;
 use crate::node_interface::NetworkMethods;
+use crate::node_interface::NodeAddress;
 use crate::node_interface::NodeConfigMethods;
 use crate::node_interface::PeerInfo;
 
@@ -107,6 +109,9 @@ pub enum UserRequest {
         stop_hash: BlockHash,
     },
 
+    /// Return known peer addresses from the address manager.
+    GetNodeAddresses(u32, Option<ReachableNetworks>),
+
     /// Add a peer to the address manager.
     AddPeerAddress {
         /// The Peers address.
@@ -164,6 +169,9 @@ pub enum NodeResponse {
 
     /// Received compact block filter headers.
     CFilterHeaders(CFHeaders),
+
+    /// Known peer addresses from the address manager.
+    GetNodeAddresses(Vec<NodeAddress>),
 
     /// Whether an address was successfully added to the address manager.
     AddPeerAddress(bool),
@@ -334,6 +342,18 @@ impl NetworkMethods for NodeHandle {
         let val = self.send_request(UserRequest::GetAddrManInfo).await?;
 
         extract_variant!(GetAddrManInfo, val)
+    }
+
+    async fn get_node_addresses(
+        &self,
+        count: u32,
+        network: Option<ReachableNetworks>,
+    ) -> Result<Vec<NodeAddress>, Self::Error> {
+        let val = self
+            .send_request(UserRequest::GetNodeAddresses(count, network))
+            .await?;
+
+        extract_variant!(GetNodeAddresses, val)
     }
 }
 

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -110,6 +110,15 @@ pub trait NetworkMethods {
         v2transport: bool,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
+    /// Adds a peer to the address manager, without any connection attempt.
+    ///
+    /// This function will return a boolean indicating whether the addition was successful.
+    fn add_peer_address(
+        &self,
+        address: BitcoinSocketAddr,
+        tried: bool,
+    ) -> impl Future<Output = Result<bool, Self::Error>>;
+
     /// Removes a peer from the node's peer list.
     /// This function will return a boolean indicating whether the peer was successfully removed.
     /// It may be called multiple times, and may use hostnames or IP addresses.

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -27,11 +27,31 @@ use floresta_domain::mempool::MempoolError;
 use serde::Serialize;
 
 use super::UtreexoNodeConfig;
+use super::address_man::ReachableNetworks;
 use super::node::ConnectionKind;
 use super::node::PeerStatus;
 use super::transport::TransportProtocol;
 use crate::address_man::ConnectionStats;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+
+#[derive(Debug, Clone, Serialize)]
+/// A known peer address from the address manager.
+pub struct NodeAddress {
+    /// Last time this address was seen (unix timestamp).
+    pub time: u64,
+
+    /// Services offered by this peer.
+    pub services: u64,
+
+    /// The IP address of this peer.
+    pub address: String,
+
+    /// The port of this peer.
+    pub port: u16,
+
+    /// The network the address belongs to (e.g. "ipv4", "ipv6", "onion", "i2p", "cjdns").
+    pub network: ReachableNetworks,
+}
 
 #[derive(Debug, Clone, Serialize)]
 /// A struct representing a peer connected to the node.
@@ -160,6 +180,13 @@ pub trait NetworkMethods {
 
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> impl Future<Output = Result<ConnectionStats, Self::Error>>;
+
+    /// Returns known peer addresses from the address manager.
+    fn get_node_addresses(
+        &self,
+        count: u32,
+        network: Option<ReachableNetworks>,
+    ) -> impl Future<Output = Result<Vec<NodeAddress>, Self::Error>>;
 }
 
 /// Methods used to interact with the node's configuration.

--- a/doc/rpc/addpeeraddress.md
+++ b/doc/rpc/addpeeraddress.md
@@ -1,0 +1,48 @@
+# `addpeeraddress`
+
+Add an IP address and port to the node's address manager.
+
+## Usage
+
+### Synopsis
+
+```text
+floresta-cli addpeeraddress <address> [port] [tried]
+```
+
+### Examples
+
+```bash
+floresta-cli addpeeraddress 192.168.0.1
+floresta-cli addpeeraddress 192.168.0.1 8333
+floresta-cli addpeeraddress 192.168.0.1 8333 true
+floresta-cli addpeeraddress "2001:db8::1" 8333 false
+floresta-cli addpeeraddress "example7abcdefg.onion" 8333
+```
+
+## Arguments
+
+- `address` - (string, required) The IP address or onion address of the peer. Accepts IPv4 (`192.168.0.1`), IPv6 (`2001:db8::1`), or Tor v3 onion addresses. The port may be embedded in the address string (e.g. `192.168.0.1:8333` or `[2001:db8::1]:8333`), in which case the separate `port` parameter is not needed.
+
+- `port` - (numeric, optional, default=network default port) The port number the peer listens on. Defaults to the network's P2P port (e.g. 8333 for mainnet). If a port is already embedded in the `address` string, this parameter should be omitted.
+
+- `tried` - (boolean, optional, default=false) If `true`, the address is added directly to the _tried_ table, indicating a previously successful connection.
+
+## Returns
+
+### Ok Response
+
+A JSON object with a single field:
+
+- `success` - (boolean) `true` if the address was accepted by the address manager, `false` otherwise (e.g. the address is not routable or the address manager is full).
+
+### Error Response
+
+- `Node` - Failed to communicate with the address manager
+
+## Notes
+
+- IPv4, IPv6, and Tor v3 onion addresses are accepted. I2P and CJDNS are not currently supported.
+- Adding an address here does not immediately open a connection to the peer. Use `addnode` to establish a persistent connection.
+- There are corner cases where the command runs fine but the address can be denied. Internally on the Address Manager, we insert address with an method
+  called `push_addresses`, which may deny some addresses. For further details, check the source code or the method documentation if its available.

--- a/doc/rpc/getnodeaddresses.md
+++ b/doc/rpc/getnodeaddresses.md
@@ -1,0 +1,51 @@
+# `getnodeaddresses`
+
+Return known peer addresses from the node's address manager. These can be used to find new peers in the network.
+
+## Usage
+
+### Synopsis
+
+```text
+floresta-cli getnodeaddresses [count] [network]
+```
+
+### Examples
+
+```bash
+floresta-cli getnodeaddresses
+floresta-cli getnodeaddresses 10
+floresta-cli getnodeaddresses 0
+floresta-cli getnodeaddresses 10 ipv4
+floresta-cli getnodeaddresses 0 ipv6
+floresta-cli getnodeaddresses 0 onion
+```
+
+## Arguments
+
+- `count` - (numeric, optional, default=1) The maximum number of addresses to return. Pass `0` to return all known addresses.
+
+- `network` - (string, optional, default="all" networks) Only return addresses from this network. One of: `ipv4`, `ipv6`, `onion`, `i2p`, `cjdns`.
+
+## Returns
+
+### Ok Response
+
+A JSON array of address objects:
+
+- `time` - (numeric) Unix timestamp of when this address was last seen
+- `services` - (numeric) Service flags advertised by this peer
+- `address` - (string) The address of the peer (IP address or `.onion` hostname)
+- `port` - (numeric) The port number of the peer
+- `network` - (string) The network the address belongs to (`ipv4`, `ipv6`, or `onion`)
+
+### Error Response
+
+- `InvalidParameterType` - A parameter is invalid.
+- `Node` - Failed to retrieve addresses from the address manager
+
+## Notes
+
+- Results are shuffled randomly before being returned, making it harder to fingerprint or eclipse the node.
+- Addresses are returned from the full address manager, including untried and recently-failed peers. Only banned addresses are excluded. This matches Bitcoin Core's behavior of returning all "not terrible" addresses.
+- The `onion` filter returns Tor v3 (`.onion`) addresses. The `i2p` and `cjdns` filters are accepted but currently return an empty list, since Floresta does not yet support connections over those networks.

--- a/tests/floresta-cli/addpeeraddress.py
+++ b/tests/floresta-cli/addpeeraddress.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_addpeeraddress.py
+
+This functional test verifies the `addpeeraddress` RPC method.
+"""
+
+import pytest
+
+
+@pytest.mark.rpc
+def test_add_peer_address(florestad_node):
+    """
+    Test `addpeeraddress` adds a peer address to the address manager.
+    """
+
+    addrman_tried_count_before = florestad_node.rpc.get_addrman_info()["ipv4"]["new"]
+    # Adding a new address with tried=false should succeed
+    #  and we should see a new entry for new addresses.
+    result = florestad_node.rpc.add_peer_address("8.8.4.4", 8333)
+    assert result["success"] is True
+    assert (
+        addrman_tried_count_before
+        < florestad_node.rpc.get_addrman_info()["ipv4"]["new"]
+    )
+
+    addrman_tried_count_before = florestad_node.rpc.get_addrman_info()["ipv4"]["tried"]
+
+    # Add a routable address as "tried"
+    result = florestad_node.rpc.add_peer_address("8.8.8.8", 8333, tried=True)
+    assert result is not None
+    assert result["success"] is True
+    assert (
+        addrman_tried_count_before
+        < florestad_node.rpc.get_addrman_info()["ipv4"]["tried"]
+    )
+
+    addrman_before = florestad_node.rpc.get_addrman_info()["ipv4"]["tried"]
+
+    # Adding a duplicate should return false
+    result = florestad_node.rpc.add_peer_address("8.8.8.8", 8333)
+    assert result["success"] is False
+    assert addrman_before == florestad_node.rpc.get_addrman_info()["ipv4"]["tried"]
+
+    # Adding an address without port should use the network default
+    result = florestad_node.rpc.add_peer_address("1.1.1.1")
+    assert result["success"] is True
+
+    # IPv6: adding a routable IPv6 address with a separate port should succeed.
+    addrman_ipv6_before = florestad_node.rpc.get_addrman_info()["ipv6"]["new"]
+    result = florestad_node.rpc.add_peer_address("2001:4860:4860::8888", 8333)
+    assert result["success"] is True
+    assert addrman_ipv6_before < florestad_node.rpc.get_addrman_info()["ipv6"]["new"]
+
+    # IPv6 without port: should use the network default
+    addrman_ipv6_before = florestad_node.rpc.get_addrman_info()["ipv6"]["new"]
+    result = florestad_node.rpc.add_peer_address("2001:4860:4860::8844")
+    assert result["success"] is True
+    assert addrman_ipv6_before < florestad_node.rpc.get_addrman_info()["ipv6"]["new"]
+
+    # Onion: adding a valid .onion v3 address should succeed
+    onion_addr = "ejgeimjypsfuijpxzy5xpwmmjmkr4izwze6od5pw74csjglflib6nsid.onion"
+    addrman_onion_before = florestad_node.rpc.get_addrman_info()["onion"]["new"]
+    result = florestad_node.rpc.add_peer_address(onion_addr, 8333)
+    assert result["success"] is True
+    assert addrman_onion_before < florestad_node.rpc.get_addrman_info()["onion"]["new"]

--- a/tests/floresta-cli/getnodeaddresses.py
+++ b/tests/floresta-cli/getnodeaddresses.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+tests/floresta-cli/getnodeaddresses.py
+
+This functional test verifies the `getnodeaddresses` RPC method.
+It uses `addpeeraddress` to inject routable addresses into the address
+manager and then verifies that `getnodeaddresses` returns them correctly.
+"""
+
+import pytest
+from test_framework.messages import msg_addrv2
+from test_framework.rpc.base import assert_rpc_error, make_request
+from test_framework.util import wait_until
+
+# Reusable test addresses across all tests
+IPV4_ADDR = "8.8.8.8"
+IPV4_ADDR_2 = "8.8.4.4"
+IPV4_ADDR_3 = "1.1.1.1"
+IPV6_ADDR = "2001:4860:4860::8888"
+ONION_ADDR = "ejgeimjypsfuijpxzy5xpwmmjmkr4izwze6od5pw74csjglflib6nsid.onion"
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_empty(florestad_node):
+    """
+    Test `getnodeaddresses` returns an empty list when no routable addresses
+    are known (the regtest case).
+    """
+    # count=0 means "return all" -- empty addrman yields an empty list
+    all_addresses = florestad_node.rpc.get_node_addresses(0)
+    assert all_addresses == []
+
+    # count=1 with no addresses still returns an empty list
+    one_address = florestad_node.rpc.get_node_addresses(1)
+    assert one_address == []
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_returns_injected(florestad_node):
+    """
+    Test that addresses injected via `addpeeraddress` are returned by
+    `getnodeaddresses` with correct fields across IPv4, IPv6, and onion.
+    """
+    injected_ipv4 = [IPV4_ADDR, IPV4_ADDR_2, IPV4_ADDR_3]
+    injected_ipv6 = [IPV6_ADDR]
+    injected_onion = [ONION_ADDR]
+
+    for addr in injected_ipv4 + injected_ipv6 + injected_onion:
+        result = florestad_node.rpc.add_peer_address(addr, 8333)
+        assert result["success"] is True
+
+    addresses = florestad_node.rpc.get_node_addresses(0)
+    total = len(injected_ipv4) + len(injected_ipv6) + len(injected_onion)
+    assert len(addresses) == total
+
+    returned_addrs = {a["address"] for a in addresses}
+    assert set(injected_ipv4).issubset(returned_addrs)
+    assert set(injected_ipv6).issubset(returned_addrs)
+    assert set(injected_onion).issubset(returned_addrs)
+
+    # Verify each entry has the expected fields and types
+    for entry in addresses:
+        assert isinstance(entry["time"], int)
+        assert isinstance(entry["services"], int)
+        assert isinstance(entry["address"], str)
+        assert isinstance(entry["port"], int)
+        assert entry["port"] == 8333
+        assert entry["network"] in ("ipv4", "ipv6", "onion")
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_count_limiting(florestad_node):
+    """
+    Test that the count parameter limits the number of returned addresses.
+    """
+    for addr in [IPV4_ADDR, IPV4_ADDR_2, IPV4_ADDR_3]:
+        florestad_node.rpc.add_peer_address(addr, 8333)
+
+    addresses = florestad_node.rpc.get_node_addresses(2)
+    assert len(addresses) == 2
+
+    # Default call (no count) returns 1 address
+    default = florestad_node.rpc.get_node_addresses()
+    assert len(default) == 1
+
+    # count=0 returns all
+    all_addresses = florestad_node.rpc.get_node_addresses(0)
+    assert len(all_addresses) == 3
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_network_filtering(florestad_node):
+    """
+    Test that filtering by network returns only addresses of that type.
+    """
+    # Inject one IPv4, one IPv6, and one onion
+    florestad_node.rpc.add_peer_address(IPV4_ADDR, 8333)
+    florestad_node.rpc.add_peer_address(IPV6_ADDR, 8333)
+    florestad_node.rpc.add_peer_address(ONION_ADDR, 8333)
+
+    ipv4_only = florestad_node.rpc.get_node_addresses(0, "ipv4")
+    assert len(ipv4_only) == 1
+    assert ipv4_only[0]["address"] == IPV4_ADDR
+    assert ipv4_only[0]["network"] == "ipv4"
+
+    ipv6_only = florestad_node.rpc.get_node_addresses(0, "ipv6")
+    assert len(ipv6_only) == 1
+    assert ipv6_only[0]["address"] == IPV6_ADDR
+    assert ipv6_only[0]["network"] == "ipv6"
+
+    onion_only = florestad_node.rpc.get_node_addresses(0, "onion")
+    assert len(onion_only) == 1
+    assert onion_only[0]["address"] == ONION_ADDR
+    assert onion_only[0]["network"] == "onion"
+
+    # All networks returns all three
+    all_addresses = florestad_node.rpc.get_node_addresses(0)
+    assert len(all_addresses) == 3
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_unsupported_networks(florestad_node):
+    """
+    Test `getnodeaddresses` returns an empty list for valid-but-currently-unsupported
+    network filters (i2p, cjdns), even when other addresses exist.
+    """
+    # Inject addresses from all supported networks so the addrman is not empty
+    florestad_node.rpc.add_peer_address(IPV4_ADDR, 8333)
+    florestad_node.rpc.add_peer_address(IPV6_ADDR, 8333)
+    florestad_node.rpc.add_peer_address(ONION_ADDR, 8333)
+
+    # Unsupported network filters return empty — none of the above addresses leak through
+    for network in ("i2p", "cjdns"):
+        result = florestad_node.rpc.get_node_addresses(0, network)
+        assert result == []
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_shuffled(florestad_node):
+    """
+    Test that `getnodeaddresses` shuffles results.
+
+    With 5 injected addresses, repeated calls should eventually return them
+    in a different order.  The probability that 10 consecutive calls all
+    produce the identical permutation by chance is (1/5!)^9 ≈ 10^-19.
+    """
+    addrs = [IPV4_ADDR, IPV4_ADDR_2, IPV4_ADDR_3, IPV6_ADDR, ONION_ADDR]
+    for addr in addrs:
+        florestad_node.rpc.add_peer_address(addr, 8333)
+
+    orderings = set()
+    for _ in range(10):
+        result = florestad_node.rpc.get_node_addresses(0)
+        ordering = tuple(a["address"] for a in result)
+        orderings.add(ordering)
+
+    # At least two distinct orderings should appear
+    assert (
+        len(orderings) > 1
+    ), "Expected shuffled results but all 10 calls returned the same order"
+
+
+@pytest.mark.rpc
+def test_get_node_addresses_unknown_network(florestad_node):
+    """
+    Test `getnodeaddresses` rejects an unknown network string with an error.
+    """
+    resp = make_request(florestad_node, "getnodeaddresses", params=[0, "banana"])
+    assert_rpc_error(
+        resp,
+        expected_status_code=400,
+        expected_message="Invalid parameter type",
+    )
+
+
+@pytest.mark.p2p
+def test_get_node_addresses_via_p2p(node_manager, florestad_node):
+    """
+    Test that addresses relayed over P2P via addrv2 messages are stored
+    in the address manager and returned by `getnodeaddresses`.
+
+    This exercises the P2P address relay path instead of only relying on addpeeraddress.
+    """
+    p2p_conn = node_manager.add_p2p_connection_default(
+        node=florestad_node,
+        p2p_idx=0,
+    )
+    wait_until(
+        predicate=lambda: florestad_node.rpc.get_connectioncount() == 1,
+        error_msg="Floresta node did not accept the P2P connection",
+    )
+
+    # create_node_address generates a mix: IPv4, IPv6, onion, and i2p addresses
+    addrs = node_manager.create_node_address(10)
+    msg = msg_addrv2()
+    msg.addrs = addrs
+
+    p2p_conn.send_and_ping(msg)
+
+    # The address manager accepts IPv4, IPv6, and TorV3 (SUPPORTED networks).
+    # I2P and CJDNS are rejected. From 10 addresses with the create_node_address
+    # distribution: i%5==0 → i2p (indices 0,5), i%3==0 → onion (indices 3,6,9),
+    # i%2==0 → ipv6 (indices 2,4,8), else → ipv4 (indices 1,7).
+    # That gives: 2 i2p (rejected), 3 onion, 3 ipv6, 2 ipv4 → 8 stored.
+    addresses = florestad_node.rpc.get_node_addresses(0)
+    assert len(addresses) == 8
+
+    networks = {a["network"] for a in addresses}
+    assert "ipv4" in networks
+    assert "ipv6" in networks
+    assert "onion" in networks
+
+    # Verify filtering works on P2P-relayed addresses too
+    ipv4_only = florestad_node.rpc.get_node_addresses(0, "ipv4")
+    assert len(ipv4_only) == 2
+    assert all(a["network"] == "ipv4" for a in ipv4_only)
+
+    ipv6_only = florestad_node.rpc.get_node_addresses(0, "ipv6")
+    assert len(ipv6_only) == 3
+    assert all(a["network"] == "ipv6" for a in ipv6_only)
+
+    onion_only = florestad_node.rpc.get_node_addresses(0, "onion")
+    assert len(onion_only) == 3
+    assert all(a["network"] == "onion" for a in onion_only)

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -393,6 +393,18 @@ class BaseRPC(ABC):
         """
         return self.perform_request("ping")
 
+    def add_peer_address(
+        self, address: str, port: int = None, tried: bool = False
+    ) -> dict:
+        """
+        Add a peer address to the address manager
+        """
+        params = [address]
+        if port is not None:
+            params.append(port)
+            params.append(tried)
+        return self.perform_request("addpeeraddress", params)
+
     def disconnectnode(self, node_address: str = "", node_id: Optional[int] = None):
         """
         Disconnect from a peer by `node_address` or `node_id`

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -416,6 +416,14 @@ class BaseRPC(ABC):
             )
         return self.perform_request("disconnectnode", params=[node_address])
 
+    def get_node_addresses(self, count: int = 1, network: Optional[str] = None) -> list:
+        """
+        Get known peer addresses from the address manager.
+        network: optional filter — one of 'ipv4', 'ipv6', 'onion', 'i2p', 'cjdns'
+        """
+        params = [count] if network is None else [count, network]
+        return self.perform_request("getnodeaddresses", params)
+
     def list_descriptors(self):
         """
         List all loaded descriptors


### PR DESCRIPTION
### Description and Notes

This pr implements getnodeaddresses, a rpc that filter and return addresses contained in the address manager.

Split of #916 

### How to verify the changes you have done?

Tests are really simple and dont cover all cases but in a local test on mainnet, the rpc implementation appeared to be solid.
```Bash
]
macbook ~/florestadois (rpc/getnodeaddresses) $ fcli getnodeaddresses 4 ipv6
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/floresta-cli getnodeaddresses 4 ipv6`
[
  {
    "address": "2604:a880:4:1d0::352:6000",
    "network": "ipv6",
    "port": 38333,
    "services": 3081,
    "time": 1774433664
  },
  {
    "address": "2a01:7c8:d008:e9::3",
    "network": "ipv6",
    "port": 38333,
    "services": 1033,
    "time": 1774433715
  },
  {
    "address": "2401:2500:102:3007:153:126:143:201",
    "network": "ipv6",
    "port": 38333,
    "services": 3081,
    "time": 1774433759
  },
  {
    "address": "2a01:4f9:3a:2496::2",
    "network": "ipv6",
    "port": 38333,
    "services": 1033,
    "time": 1774433758
  }
]
macbook ~/florestadois (rpc/getnodeaddresses) $ fcli getnodeaddresses 4 ipv4
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/floresta-cli getnodeaddresses 4 ipv4`
[
  {
    "address": "153.126.143.201",
    "network": "ipv4",
    "port": 38333,
    "services": 3081,
    "time": 1774433667
  },
  {
    "address": "95.217.198.121",
    "network": "ipv4",
    "port": 38333,
    "services": 1097,
    "time": 1774433685
  },
  {
    "address": "135.181.182.162",
    "network": "ipv4",
    "port": 38333,
    "services": 1033,
    "time": 1774433712
  },
  {
    "address": "141.94.143.203",
    "network": "ipv4",
    "port": 38333,
    "services": 1033,
    "time": 1774433713
  }
]
```
