### PR TITLE
[Enhancement] Private Broadcast over Tor

### DIFF
--- a/bin/florestad/src/cli.rs
+++ b/bin/florestad/src/cli.rs
@@ -57,6 +57,10 @@ pub struct Cli {
     /// The url of a proxy we should open p2p connections through (e.g. 127.0.0.1:9050)
     pub proxy: Option<String>,
 
+    #[arg(long, default_value_t = false)]
+    /// Broadcast submitted transactions via Tor private connections only (requires `--proxy`).
+    pub private_broadcast: bool,
+
     #[arg(long, value_name = "XPUB")]
     /// Add an xpub to our wallet
     ///

--- a/bin/florestad/src/main.rs
+++ b/bin/florestad/src/main.rs
@@ -94,6 +94,7 @@ fn main() {
         tls_key_path: params.tls_key_path,
         allow_v1_fallback: params.allow_v1_fallback,
         backfill: !params.no_backfill,
+        private_broadcast: params.private_broadcast,
     };
 
     #[cfg(unix)]

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -76,6 +76,9 @@ pub enum MempoolError {
     /// The [`Mempool`] is full and cannot accept more [`Transaction`]s.
     FullMempool,
 
+    /// Private broadcast was requested but Tor/proxy is not configured.
+    PrivateBroadcastUnavailable,
+
     /// The [`Transaction`] conflicts with another [`Transaction`] in the [`Mempool`].
     ConflictingTransaction,
 
@@ -95,6 +98,12 @@ impl Display for MempoolError {
                 write!(
                     f,
                     "The mempool is full and cannot accept any more transactions"
+                )
+            }
+            Self::PrivateBroadcastUnavailable => {
+                write!(
+                    f,
+                    "Private broadcast was requested but no Tor/proxy is configured"
                 )
             }
             Self::ConflictingTransaction => {

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -293,11 +293,11 @@ impl Mempool {
         Ok(())
     }
 
-    /// Accepts a transaction to mempool
+    /// Validates a transaction without adding it to the mempool
     ///
     /// This method will perform some context-less validations on a transaction,
-    /// and then accept to our mempool. It assumes that we have validated this transaction's
-    /// proof.
+    /// and check that it won't conflict with other mempool transactions. It does not
+    /// add the transaction to our mempool.
     ///
     /// # Errors
     ///  - If we don't have space left in our mempool
@@ -307,6 +307,32 @@ impl Mempool {
     ///    the theoretical maximum amount of Bitcoins
     ///  - If either vIn or vOut are empty
     ///  - If any script is larger than the maximum allowed size
+    pub fn validate_transaction(&mut self, transaction: &Transaction) -> Result<(), MempoolError> {
+        // Make sure our mempool has space
+        let tx_size = transaction.total_size();
+        if self.mempool_size + tx_size > self.max_mempool_size {
+            return Err(MempoolError::FullMempool);
+        }
+
+        // Perform context-free consensus checks
+        Consensus::check_transaction_context_free(transaction)
+            .map_err(MempoolError::ConsensusValidation)?;
+
+        // Make sure transaction won't conflict with other mempool transaction
+        self.check_for_conflicts(transaction)?;
+
+        Ok(())
+    }
+
+    /// Accepts a transaction to mempool
+    ///
+    /// Calls [`validate_transaction`](Self::validate_transaction) and, if we don't already have
+    /// this transaction, adds it to our mempool. It assumes that we have validated this
+    /// transaction's proof.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`validate_transaction`](Self::validate_transaction).
     pub fn accept_to_mempool(&mut self, transaction: Transaction) -> Result<(), MempoolError> {
         debug!(
             "Accepting {} to mempool {:?}",
@@ -314,25 +340,15 @@ impl Mempool {
             self.transactions
         );
 
-        // Make sure our mempool has space
-        let tx_size = transaction.total_size();
-        if self.mempool_size + tx_size > self.max_mempool_size {
-            return Err(MempoolError::FullMempool);
-        }
+        self.validate_transaction(&transaction)?;
 
+        let tx_size = transaction.total_size();
         let short_txid = self.hasher.hash_one(transaction.compute_txid());
 
         // Checks if we don't have this tx already
         if self.transactions.contains_key(&short_txid) {
             return Ok(());
         }
-
-        // Perform context-free consensus checks
-        Consensus::check_transaction_context_free(&transaction)
-            .map_err(MempoolError::ConsensusValidation)?;
-
-        // Make sure transaction won't conflict with other mempool transaction
-        self.check_for_conflicts(&transaction)?;
 
         // List dependants for this transaction
         let depends = self.find_mempool_depends(&transaction);

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -95,6 +95,9 @@ pub enum FlorestadError {
     /// Failed to create a chain provider.
     CouldNotCreateChainProvider(String),
 
+    /// `--private-broadcast` is inconsistent with other startup options.
+    InvalidPrivateBroadcastConfig(String),
+
     /// Failed to create an Electrum server.
     CouldNotCreateElectrumServer(Box<dyn error::Error>),
 
@@ -193,6 +196,9 @@ impl Display for FlorestadError {
 
             FlorestadError::CouldNotCreateChainProvider(err) => {
                 write!(f, "Could not create chain provider: {err}")
+            }
+            FlorestadError::InvalidPrivateBroadcastConfig(err) => {
+                write!(f, "Invalid private-broadcast configuration: {err}")
             }
             FlorestadError::CouldNotCreateElectrumServer(err) => {
                 write!(f, "Could not create Electrum server: {err}")

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -214,6 +214,17 @@ pub struct Config {
 
     /// Whether to allow fallback to v1 transport if v2 connection fails.
     pub allow_v1_fallback: bool,
+
+    /// Whether to broadcast locally submitted transactions only over Tor private
+    /// connections.
+    ///
+    /// When enabled, transactions you submit through the node are queued for the
+    /// private-broadcast path instead of being relayed on the public P2P mempool. The
+    /// node opens a limited number of outbound Tor connections to tx-recipient peers from
+    /// the address manager, completes a minimal decoy-version handshake, and announces
+    /// each transaction with the usual inv/getdata/tx flow. Requires `proxy` to be set
+    /// so those connections can reach onion services.
+    pub private_broadcast: bool,
     /// Whether we should backfill
     ///
     /// If we assumeutreexo or use pow fraud proofs, you have the option to download and validate
@@ -255,6 +266,7 @@ impl Config {
             tls_cert_path: None,
             allow_v1_fallback: false,
             backfill: false,
+            private_broadcast: false,
         }
     }
 }
@@ -406,6 +418,24 @@ impl Florestad {
             .map(|addr| Self::resolve_hostname(addr, 9050))
             .transpose()?;
 
+        if self.config.private_broadcast {
+            if proxy.is_none() {
+                return Err(FlorestadError::InvalidPrivateBroadcastConfig(
+                    "Private broadcast of own transactions requested (--private-broadcast), \
+                     but no Tor proxy is configured (--proxy)"
+                        .into(),
+                ));
+            }
+            if !self.config.connect.is_empty() {
+                return Err(FlorestadError::InvalidPrivateBroadcastConfig(
+                    "Private broadcast of own transactions requested (--private-broadcast), \
+                     but --connect is also configured. Private broadcast needs to open new \
+                     connections to randomly chosen Tor peers."
+                        .into(),
+                ));
+            }
+        }
+
         let config = UtreexoNodeConfig {
             disable_dns_seeds: self.config.disable_dns_seeds,
             network: self.config.network,
@@ -419,10 +449,17 @@ impl Florestad {
             filter_start_height: self.config.filters_start_height,
             user_agent: self.config.user_agent.clone(),
             allow_v1_fallback: self.config.allow_v1_fallback,
+            private_broadcast: self.config.private_broadcast,
             ..Default::default()
         };
 
         let kill_signal = self.stop_signal.clone();
+
+        let reachable_networks = if proxy.is_some() {
+            ReachableNetworks::with_proxy()
+        } else {
+            ReachableNetworks::SUPPORTED.to_vec()
+        };
 
         // Chain Provider (p2p)
         let chain_provider = UtreexoNode::<_, RunningNode>::new(
@@ -433,7 +470,7 @@ impl Florestad {
             ))),
             cfilters.clone(),
             kill_signal.clone(),
-            AddressMan::new(None, &ReachableNetworks::SUPPORTED),
+            AddressMan::new(None, &reachable_networks),
         )
         .map_err(|e| FlorestadError::CouldNotCreateChainProvider(format!("{e}")))?;
 

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -4,6 +4,8 @@
 
 use std::collections::BTreeMap;
 
+use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::hashes::Hash;
 use corepc_types::v26::AddrManInfoNetwork;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetNetworkInfo;
@@ -17,6 +19,7 @@ use floresta_wire::bitcoin_socket_addr::BitcoinSocketAddr;
 use floresta_wire::bitcoin_socket_addr::SystemResolver;
 use floresta_wire::node_interface::NetworkMethods;
 use floresta_wire::node_interface::PeerInfo;
+use floresta_wire::node_interface::PrivateBroadcastMethods;
 use serde_json::Value;
 use serde_json::json;
 
@@ -219,6 +222,80 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             local_addresses: Vec::new(), // Floresta doesn't track local addresses since it does not accept inbound connections
             warnings: Vec::new(),
         })
+    }
+
+    /// Returns a snapshot of transactions in the private-broadcast queue.
+    ///
+    /// Each [`floresta_wire::private_broadcast::TxBroadcastInfo`] includes the transaction body,
+    /// txid, wtxid, time added, and per-peer send and acknowledgment timestamps.
+    pub(crate) async fn get_private_broadcast_info(&self) -> Result<Value> {
+        let infos = self
+            .node
+            .get_private_broadcast_info()
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        let transactions: Vec<Value> = infos
+            .into_iter()
+            .map(|info| {
+                json!({
+                    "txid": info.txid.to_string(),
+                    "wtxid": info.wtxid.to_string(),
+                    "hex": serialize_hex(&info.tx),
+                    "time_added": info.time_added,
+                    "peers": info.peers.iter().map(|p| {
+                        let mut peer = json!({
+                            "address": p.address,
+                            "sent": p.sent,
+                        });
+                        if let Some(received) = p.received {
+                            peer["received"] = json!(received);
+                        }
+                        peer
+                    }).collect::<Vec<_>>(),
+                })
+            })
+            .collect();
+
+        Ok(json!({ "transactions": transactions }))
+    }
+
+    /// Aborts private broadcast for a transaction identified by txid or wtxid.
+    ///
+    /// `id_hex` is parsed as either a [`bitcoin::Txid`] or [`bitcoin::Wtxid`], matched against
+    /// queued [`floresta_wire::private_broadcast::TxBroadcastInfo`] entries, and removed from
+    /// the queue. Returns a JSON object with `removed_transactions` (txid, wtxid, hex per entry).
+    pub(crate) async fn abort_private_broadcast(&self, id_hex: &str) -> Result<Value> {
+        let id: [u8; 32] = if let Ok(txid) = id_hex.parse::<bitcoin::Txid>() {
+            *txid.as_byte_array()
+        } else if let Ok(wtxid) = id_hex.parse::<bitcoin::Wtxid>() {
+            *wtxid.as_byte_array()
+        } else {
+            return Err(JsonRpcError::InvalidHex);
+        };
+
+        let removed = self
+            .node
+            .abort_private_broadcast(id)
+            .await
+            .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        if removed.is_empty() {
+            return Err(JsonRpcError::TxNotFound);
+        }
+
+        let transactions: Vec<Value> = removed
+            .into_iter()
+            .map(|tx| {
+                json!({
+                    "txid": tx.compute_txid().to_string(),
+                    "wtxid": tx.compute_wtxid().to_string(),
+                    "hex": serialize_hex(&tx),
+                })
+            })
+            .collect();
+
+        Ok(json!({ "removed_transactions": transactions }))
     }
 }
 

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -436,11 +436,23 @@ pub mod jsonrpc_interface {
                     message: "Wallet error".into(),
                     data: Some(Value::String(msg.clone())),
                 },
-                JsonRpcError::MempoolAccept(msg) => RpcError {
-                    code: MEMPOOL_ERROR,
-                    message: "Mempool error".into(),
-                    data: Some(Value::String(format!("{msg}"))),
-                },
+                JsonRpcError::MempoolAccept(e) => {
+                    let detail = match e {
+                        MempoolError::PrivateBroadcastUnavailable => {
+                            format!("Could not broadcast transaction: {e}")
+                        }
+                        _ => format!("Could not send transaction to mempool due to {e}"),
+                    };
+                    RpcError {
+                        code: MEMPOOL_ERROR,
+                        message: if matches!(e, MempoolError::PrivateBroadcastUnavailable) {
+                            "Could not broadcast transaction".into()
+                        } else {
+                            "Mempool error".into()
+                        },
+                        data: Some(Value::String(detail)),
+                    }
+                }
                 JsonRpcError::InInitialBlockDownload => RpcError {
                     code: IN_INITIAL_BLOCK_DOWNLOAD,
                     message: "Node is in initial block download".into(),

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -449,6 +449,13 @@ async fn handle_json_rpc_request(
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }
 
+        "getprivatebroadcastinfo" => state.get_private_broadcast_info().await,
+
+        "abortprivatebroadcast" => {
+            let id: String = get_at(&params, 0, "id")?;
+            state.abort_private_broadcast(&id).await
+        }
+
         _ => Err(JsonRpcError::MethodNotFound),
     }
 }

--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -23,6 +23,8 @@ use bitcoin::block::Header as BlockHeader;
 pub use rustreexo;
 #[cfg(not(target_arch = "wasm32"))]
 mod p2p_wire;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod private_broadcast;
 pub use p2p_wire::UtreexoNodeConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::address_man;

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -94,8 +94,13 @@ impl ReachableNetworks {
     /// All networks Floresta is aware of.
     pub const ALL: [Self; 5] = [Self::IPv4, Self::IPv6, Self::TorV3, Self::I2P, Self::Cjdns];
 
-    /// Networks this implementation currently supports.
+    /// Networks this implementation currently supports for general outbound peers.
     pub const SUPPORTED: [Self; 2] = [Self::IPv4, Self::IPv6];
+
+    /// Reachable networks when a SOCKS5 proxy is configured (includes Tor v3 for private broadcast).
+    pub fn with_proxy() -> Vec<Self> {
+        vec![Self::IPv4, Self::IPv6, Self::TorV3]
+    }
 }
 
 impl Display for ReachableNetworks {
@@ -234,6 +239,11 @@ impl LocalAddress {
             services,
             id,
         }
+    }
+
+    /// Whether this address is a Tor v3 onion service.
+    pub fn is_tor_v3(&self) -> bool {
+        matches!(self.as_addrv2(), AddrV2::TorV3(_))
     }
 
     /// Get the [`SocketAddr`] for this [`LocalAddress`].
@@ -803,6 +813,54 @@ impl AddressMan {
             }
         }
 
+        None
+    }
+
+    /// Select a random Tor v3 peer for a private-broadcast outbound connection.
+    ///
+    /// Private broadcast dials random onion tx-recipients over SOCKS5. Only good,
+    /// reachable Tor v3 addresses are considered; banned and already-connected peers
+    /// are excluded. Peers we failed to reach recently stay excluded until the
+    /// 10-minute retry window elapses, then they may be chosen again.
+    ///
+    /// Picks randomly from the eligible set, retrying up to ten times (for example when
+    /// the draw hits a peer still in the failed-retry window). Returns [`None`] when no
+    /// suitable onion peer is known.
+    pub fn select_for_private_broadcast(&mut self) -> Option<(usize, LocalAddress)> {
+        let onion_ids: Vec<usize> = self
+            .good_addresses
+            .iter()
+            .filter_map(|id| self.addresses.get(id))
+            .filter(|addr| addr.is_tor_v3() && self.is_net_reachable(addr))
+            .filter(|addr| {
+                !matches!(
+                    addr.state,
+                    AddressState::Banned(_) | AddressState::Connected
+                )
+            })
+            .map(|addr| addr.id)
+            .collect();
+
+        if onion_ids.is_empty() {
+            return None;
+        }
+
+        for _ in 0..10 {
+            let idx = rand::rng().random_range(0..onion_ids.len());
+            let id = onion_ids[idx];
+            let Some(peer) = self.addresses.get(&id).cloned() else {
+                continue;
+            };
+            match peer.state {
+                AddressState::NeverTried | AddressState::Tried(_) => return Some((id, peer)),
+                AddressState::Failed(when) => {
+                    if when + RETRY_TIME < Self::time_since_unix() {
+                        return Some((id, peer));
+                    }
+                }
+                AddressState::Connected | AddressState::Banned(_) => {}
+            }
+        }
         None
     }
 

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -66,6 +66,16 @@ pub struct UtreexoNodeConfig {
     pub allow_v1_fallback: bool,
     /// Whether to disable DNS seeds. Defaults to false.
     pub disable_dns_seeds: bool,
+    /// Whether to broadcast locally submitted transactions only over Tor private
+    /// connections. Defaults to false.
+    ///
+    /// When enabled, transactions you submit through the node are queued for the
+    /// private-broadcast path instead of being relayed on the public P2P mempool. The
+    /// node opens a limited number of outbound Tor connections to tx-recipient peers from
+    /// the address manager, completes a minimal decoy-version handshake, and announces
+    /// each transaction with the usual inv/getdata/tx flow. Configure a SOCKS5 proxy so
+    /// those connections can reach onion services.
+    pub private_broadcast: bool,
 }
 
 impl Default for UtreexoNodeConfig {
@@ -84,6 +94,7 @@ impl Default for UtreexoNodeConfig {
             filter_start_height: None,
             user_agent: format!("floresta:{}", env!("CARGO_PKG_VERSION")),
             allow_v1_fallback: true,
+            private_broadcast: false,
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -226,6 +226,7 @@ where
             (peer_count, Instant::now()),
         );
 
+        let is_outbound_tor_v3 = self.socks5.is_some() && peer_address.is_tor_v3();
         self.peers.insert(
             peer_count,
             LocalPeerView {
@@ -242,7 +243,7 @@ where
                 // Will be downgraded to V1 if the V2 handshake fails, and we allow fallback
                 transport_protocol: TransportProtocol::V2,
                 ready_since: None,
-                is_outbound_tor_v3: false,
+                is_outbound_tor_v3,
             },
         );
 

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -80,9 +80,10 @@ where
         // Get the peer's `ServiceFlags`.
         let required_services = match conn_kind {
             ConnectionKind::Regular(services) => services,
-            ConnectionKind::Feeler | ConnectionKind::Extra | ConnectionKind::Manual => {
-                ServiceFlags::NONE
-            }
+            ConnectionKind::Feeler
+            | ConnectionKind::Extra
+            | ConnectionKind::Manual
+            | ConnectionKind::PrivateBroadcast => ServiceFlags::NONE,
         };
 
         // Pick the first fixed peer that we are not already connected to, or
@@ -240,6 +241,8 @@ where
                 banscore: 0,
                 // Will be downgraded to V1 if the V2 handshake fails, and we allow fallback
                 transport_protocol: TransportProtocol::V2,
+                ready_since: None,
+                is_outbound_tor_v3: false,
             },
         );
 

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -8,6 +8,7 @@ mod blocks;
 pub mod chain_selector_ctx;
 mod conn;
 mod peer_man;
+mod private_broadcast_man;
 pub mod running_ctx;
 pub mod sync_ctx;
 mod user_req;

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -23,6 +23,7 @@ use std::time::Instant;
 
 use bitcoin::BlockHash;
 use bitcoin::Network;
+use bitcoin::Transaction;
 use bitcoin::Txid;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::p2p::address::AddrV2Message;
@@ -59,6 +60,8 @@ use super::transport::TransportProtocol;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::bitcoin_socket_addr::SystemResolver;
 use crate::node_context::PeerId;
+use crate::private_broadcast::PrivateBroadcast;
+use crate::private_broadcast::PrivateBroadcastConnector;
 
 /// As per BIP 155, limit the number of addresses to 1,000
 pub const MAX_ADDRV2_ADDRESSES: usize = 1_000;
@@ -87,6 +90,27 @@ pub enum NodeRequest {
 
     /// Sends a transaction to peers
     BroadcastTransaction(Txid),
+
+    /// Announce a queued transaction on a Tor private-broadcast outbound.
+    ///
+    /// Sent to a [`ConnectionKind::PrivateBroadcast`] peer after verack, when the node
+    /// has assigned a transaction from [`PrivateBroadcast`] to that connection. The peer
+    /// task keeps the full [`Transaction`] so it can answer the recipient's `getdata` without
+    /// relying on the mempool, and writes a normal Bitcoin `inv` with the txid (same wire
+    /// shape as [`NodeRequest::BroadcastTransaction`], but on a short-lived anonymous handshake).
+    /// See [`crate::private_broadcast`] for the full inv → getdata → tx → ping flow.
+    PrivateBroadcastInv(Transaction),
+
+    /// Deliver the full transaction and probe for receipt on a private-broadcast peer.
+    ///
+    /// On the wire this is `tx` followed by `ping`; the recipient's `pong` is treated
+    /// as confirmation that the transaction was received, after which the node shuts
+    /// the connection down. Only used on [`ConnectionKind::PrivateBroadcast`] peers.
+    /// The [`Transaction`] must match the txid previously announced with
+    /// [`NodeRequest::PrivateBroadcastInv`]. In practice the peer task usually performs this step
+    /// when it handles an incoming `getdata` for that txid rather than receiving this
+    /// request from the node.
+    PrivateBroadcastSendTx(Transaction),
 
     /// Ask for an unconfirmed transaction
     MempoolTransaction(Txid),
@@ -163,6 +187,15 @@ pub enum ConnectionKind {
     /// misbehaving, and won't respect the [`ServiceFlags`] requirements when creating a
     /// connection.
     Manual,
+
+    /// A short-lived outbound Tor peer used to announce one locally submitted transaction.
+    ///
+    /// Opened when [`UtreexoNodeConfig::private_broadcast`] is enabled and a SOCKS5 proxy is
+    /// configured. The node picks tx-recipient onion addresses from the address manager,
+    /// completes a minimal handshake, relays the transaction with the usual inv/getdata/tx
+    /// flow, and disconnects once the peer acknowledges receipt or the connection ages out.
+    /// These peers do not participate in block sync or the public mempool relay path.
+    PrivateBroadcast,
 }
 
 impl Serialize for ConnectionKind {
@@ -175,6 +208,7 @@ impl Serialize for ConnectionKind {
             ConnectionKind::Regular(_) => serializer.serialize_str("regular"),
             ConnectionKind::Extra => serializer.serialize_str("extra"),
             ConnectionKind::Manual => serializer.serialize_str("manual"),
+            ConnectionKind::PrivateBroadcast => serializer.serialize_str("private_broadcast"),
         }
     }
 }
@@ -224,6 +258,17 @@ pub struct LocalPeerView {
 
     /// The transport protocol this peer is using (v1 or v2)
     pub(crate) transport_protocol: TransportProtocol,
+
+    /// When this peer entered [`PeerStatus::Ready`], if ever.
+    ///
+    /// `None` while the handshake is incomplete ([`PeerStatus::Awaiting`]). Set when verack
+    /// completes. Used with [`PeerStatus::Ready`] to disconnect stale
+    /// [`ConnectionKind::PrivateBroadcast`] peers that stay ready too long without confirming
+    /// transaction receipt.
+    pub(crate) ready_since: Option<Instant>,
+
+    /// Outbound dial targets Tor v3 via SOCKS5 (set in [`UtreexoNode::open_connection`]).
+    pub(crate) is_outbound_tor_v3: bool,
 }
 
 impl LocalPeerView {
@@ -264,6 +309,8 @@ pub struct NodeCommon<Chain: ChainBackend> {
     pub(crate) max_banscore: u32,
     pub(crate) address_man: AddressMan,
     pub(crate) added_peers: Vec<AddedPeerInfo>,
+    pub(crate) tx_for_private_broadcast: PrivateBroadcast,
+    pub(crate) private_broadcast_connector: PrivateBroadcastConnector,
 
     // 3. Internal Communication
     pub(crate) node_rx: UnboundedReceiver<NodeNotification>,
@@ -272,6 +319,8 @@ pub struct NodeCommon<Chain: ChainBackend> {
     // 4. Networking Configuration
     pub(crate) socks5: Option<Socks5StreamBuilder>,
     pub(crate) fixed_peers: Vec<LocalAddress>,
+    /// Outbound Tor v3 handshake succeeded at least once this process (via SOCKS5).
+    pub(crate) is_outbound_tor_proven: bool,
 
     // 5. Time and Event Tracking
     pub(crate) inflight: HashMap<InflightRequests, (u32, Instant)>,
@@ -288,6 +337,7 @@ pub struct NodeCommon<Chain: ChainBackend> {
     pub(crate) startup_time: Instant,
     pub(crate) last_dns_seed_call: Instant,
     pub(crate) used_fixed_addresses: bool,
+    pub(crate) last_private_broadcast_reattempt: Instant,
 
     // 6. Configuration and Metadata
     pub(crate) config: UtreexoNodeConfig,
@@ -389,13 +439,17 @@ where
                 last_get_address_request: Instant::now(),
                 last_send_addresses: Instant::now(),
                 used_fixed_addresses: false,
+                last_private_broadcast_reattempt: Instant::now(),
                 datadir: config.datadir.clone(),
                 max_banscore: config.max_banscore,
                 socks5,
                 fixed_peers,
+                is_outbound_tor_proven: false,
                 config,
                 kill_signal,
                 added_peers: Vec::new(),
+                tx_for_private_broadcast: PrivateBroadcast::default(),
+                private_broadcast_connector: PrivateBroadcastConnector::default(),
             },
             context: T::default(),
         })

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -338,6 +338,7 @@ pub struct NodeCommon<Chain: ChainBackend> {
     pub(crate) last_dns_seed_call: Instant,
     pub(crate) used_fixed_addresses: bool,
     pub(crate) last_private_broadcast_reattempt: Instant,
+    pub(crate) last_private_broadcast_unreachable_warn: Instant,
 
     // 6. Configuration and Metadata
     pub(crate) config: UtreexoNodeConfig,
@@ -440,6 +441,7 @@ where
                 last_send_addresses: Instant::now(),
                 used_fixed_addresses: false,
                 last_private_broadcast_reattempt: Instant::now(),
+                last_private_broadcast_unreachable_warn: Instant::now(),
                 datadir: config.datadir.clone(),
                 max_banscore: config.max_banscore,
                 socks5,

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -192,6 +192,9 @@ where
             if peer.state != PeerStatus::Ready {
                 continue;
             }
+            if peer.kind == ConnectionKind::PrivateBroadcast {
+                continue;
+            }
 
             if let Err(err) = peer.channel.send(request.clone()) {
                 warn!("Failed to send request to peer {}: {err}", peer.address);
@@ -221,10 +224,20 @@ where
     ) -> Result<(), WireError> {
         self.inflight.remove(&InflightRequests::Connect(peer));
 
+        if self.peers.get(&peer).is_some_and(|p| p.is_outbound_tor_v3) {
+            self.is_outbound_tor_proven = true;
+        }
+
         // Mark this peer as ready to communicate with
         self.peers.entry(peer).and_modify(|p| {
             p.state = PeerStatus::Ready;
+            p.ready_since = Some(Instant::now());
         });
+
+        // If this is a private broadcast peer, assign a queued transaction and return early
+        if version.kind == ConnectionKind::PrivateBroadcast {
+            return self.on_private_broadcast_peer_ready(peer);
+        }
 
         // Ask for new addresses to populate our address manager
         self.send_to_peer(peer, NodeRequest::GetAddresses)?;
@@ -398,10 +411,15 @@ where
         Ok(())
     }
 
-    /// Handles an incoming mempool transaction by completing any matching inflight user request.
-    pub(crate) fn handle_tx_msg(&mut self, tx: Transaction) -> Result<(), WireError> {
+    /// Handles an incoming mempool transaction.
+    ///
+    /// When private broadcast is enabled, drops a matching queued tx from the private-broadcast
+    /// queue before completing any inflight [`UserRequest::MempoolTransaction`].
+    pub(crate) fn handle_tx_msg(&mut self, peer: PeerId, tx: Transaction) -> Result<(), WireError> {
         let txid = tx.compute_txid();
         debug!("saw a mempool transaction with txid={txid}");
+
+        self.handle_private_broadcast_echo(peer, &tx);
 
         if let Some(request) = self
             .inflight_user_requests
@@ -433,7 +451,7 @@ where
                 Ok(None)
             }
             PeerMessages::Transaction(tx) => {
-                self.handle_tx_msg(tx)?;
+                self.handle_tx_msg(peer, tx)?;
                 Ok(None)
             }
             PeerMessages::UtreexoState(_) => {
@@ -445,10 +463,27 @@ where
         }
     }
 
+    /// Handles a peer disconnection.
+    ///
+    /// Removes the peer, updates addrman from its last [`PeerStatus`], clears per-service peer
+    /// lists, and redoes inflight node requests for that peer. For every
+    /// [`ConnectionKind::PrivateBroadcast`] disconnect, calls
+    /// [`UtreexoNode::on_private_broadcast_disconnect`] before dropping the channel (that helper
+    /// no-ops when receipt was already confirmed).
     pub(crate) fn handle_disconnection(&mut self, peer: u32, idx: usize) -> Result<(), WireError> {
+        let was_private = self
+            .peers
+            .get(&peer)
+            .is_some_and(|p| p.kind == ConnectionKind::PrivateBroadcast);
+
         if let Some(p) = self.peers.remove(&peer) {
             if p.is_long_lived() && p.state == PeerStatus::Ready {
                 info!("Peer disconnected: {peer}");
+            }
+
+            if was_private {
+                let peer_log = super::private_broadcast_man::peer_log(peer, &p.address.to_string());
+                self.on_private_broadcast_disconnect(peer, &peer_log);
             }
 
             std::mem::drop(p.channel);

--- a/crates/floresta-wire/src/p2p_wire/node/private_broadcast_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/private_broadcast_man.rs
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`UtreexoNode`] hooks for Tor private-broadcast outbounds.
+//!
+//! Wires the queue and connection budget in [`crate::private_broadcast`] into peer
+//! lifecycle: opening [`ConnectionKind::PrivateBroadcast`] dials, assigning transactions
+//! after verack, and tearing down peers once receipt is confirmed or the connection
+//! ages out. See [`crate::private_broadcast`] for the full protocol and constants.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use bitcoin::Transaction;
+use floresta_chain::ChainBackend;
+use tracing::debug;
+use tracing::warn;
+
+use super::ConnectionKind;
+use super::NodeRequest;
+use super::PeerStatus;
+use super::UtreexoNode;
+use crate::node_context::NodeContext;
+use crate::p2p_wire::error::WireError;
+use crate::private_broadcast::NUM_PRIVATE_BROADCAST_PER_TX;
+use crate::private_broadcast::PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME;
+
+impl<T, Chain> UtreexoNode<Chain, T>
+where
+    T: 'static + Default + NodeContext,
+    Chain: ChainBackend + 'static,
+    WireError: From<Chain::Error>,
+{
+    /// Counts live [`ConnectionKind::PrivateBroadcast`] peers.
+    ///
+    /// Includes peers still in handshake and those in [`PeerStatus::Ready`]. Used with
+    /// [`crate::private_broadcast::PrivateBroadcastConnector::can_open_more`] to enforce
+    /// [`crate::private_broadcast::MAX_PRIVATE_BROADCAST_CONNECTIONS`].
+    pub(crate) fn count_private_broadcast_peers(&self) -> usize {
+        self.peers
+            .values()
+            .filter(|p| p.kind == ConnectionKind::PrivateBroadcast)
+            .count()
+    }
+
+    /// Opens one outbound Tor private-broadcast connection.
+    ///
+    /// Picks a random onion tx-recipient via
+    /// [`crate::address_man::AddressMan::select_for_private_broadcast`] and dials it over
+    /// SOCKS5 as [`ConnectionKind::PrivateBroadcast`]. Returns
+    /// [`WireError::NoAddressesAvailable`] when the address manager has no eligible Tor v3
+    /// peers.
+    pub(crate) fn open_private_broadcast_connection(&mut self) -> Result<String, WireError> {
+        let Some((_peer_id, peer_address)) = self.address_man.select_for_private_broadcast() else {
+            return Err(WireError::NoAddressesAvailable);
+        };
+        let target = peer_address.to_string();
+        let allow_v1_fallback = self.config.allow_v1_fallback;
+        self.open_connection(
+            ConnectionKind::PrivateBroadcast,
+            peer_address,
+            allow_v1_fallback,
+        )?;
+        Ok(target)
+    }
+
+    /// Opens as many private-broadcast outbounds as the connector budget allows.
+    ///
+    /// No-op when [`crate::p2p_wire::UtreexoNodeConfig::private_broadcast`] is disabled or
+    /// no SOCKS5 proxy is configured. Otherwise drains
+    /// [`crate::private_broadcast::PrivateBroadcastConnector::num_to_open`] until the global
+    /// connection cap is reached or addrman has no onion peers left.
+    /// Other dial errors are propagated to the caller.
+    pub(crate) fn try_open_private_broadcast_connections(&mut self) -> Result<(), WireError> {
+        if !self.config.private_broadcast {
+            return Ok(());
+        }
+        if self.socks5.is_none() {
+            if self.private_broadcast_connector.num_to_open() > 0
+                && self.last_private_broadcast_unreachable_warn.elapsed() > Duration::from_secs(5)
+            {
+                warn!("Unable to open private-broadcast connections: no Tor proxy is configured");
+                self.last_private_broadcast_unreachable_warn = Instant::now();
+            }
+            return Ok(());
+        }
+
+        while self.private_broadcast_connector.num_to_open() > 0
+            && self
+                .private_broadcast_connector
+                .can_open_more(self.count_private_broadcast_peers())
+        {
+            match self.open_private_broadcast_connection() {
+                Ok(target) => {
+                    let remaining = self.private_broadcast_connector.num_to_open_sub(1);
+                    debug!(
+                        "Socket connected to {}; remaining connections to open: {remaining}",
+                        target
+                    );
+                }
+                Err(WireError::NoAddressesAvailable) => {
+                    debug!(
+                        "Connections needed for private broadcast but addrman has no eligible Tor v3 peers, will retry"
+                    );
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Enqueues a transaction for Tor private broadcast and schedules outbound dials.
+    ///
+    /// Adds `tx` to [`crate::private_broadcast::PrivateBroadcast`]. On first enqueue for
+    /// that wtxid, increments the connector budget by
+    /// [`crate::private_broadcast::NUM_PRIVATE_BROADCAST_PER_TX`]. Duplicate submissions
+    /// of the same transaction are ignored.
+    pub(crate) fn schedule_private_broadcast_for_tx(&mut self, tx: Transaction) {
+        let txid = tx.compute_txid();
+        let wtxid = tx.compute_wtxid();
+        if self.tx_for_private_broadcast.add(tx) {
+            debug!(
+                "Requesting {NUM_PRIVATE_BROADCAST_PER_TX} new connections due to txid={txid}, wtxid={wtxid}"
+            );
+            self.private_broadcast_connector
+                .num_to_open_add(NUM_PRIVATE_BROADCAST_PER_TX);
+        } else {
+            debug!(
+                "Ignoring unnecessary request to schedule an already scheduled transaction: txid={txid}, wtxid={wtxid}"
+            );
+        }
+    }
+
+    /// Assigns a queued transaction to a private-broadcast peer after verack.
+    ///
+    /// Called from [`super::peer_man`] when a [`ConnectionKind::PrivateBroadcast`] peer
+    /// enters [`PeerStatus::Ready`]. Uses
+    /// [`crate::private_broadcast::PrivateBroadcast::pick_tx_for_send`] to bind the next
+    /// in-flight transaction to this peer and sends [`NodeRequest::PrivateBroadcastInv`].
+    /// If the queue is empty, sends [`NodeRequest::Shutdown`] instead. Returns `Ok(())`
+    /// immediately when the peer id is no longer in the node's peer map.
+    pub(crate) fn on_private_broadcast_peer_ready(&mut self, peer: u32) -> Result<(), WireError> {
+        let (peer_log, address) = {
+            let Some(p) = self.peers.get(&peer) else {
+                return Ok(());
+            };
+            (
+                peer_log(peer, &p.address.to_string()),
+                p.address.to_string(),
+            )
+        };
+
+        if let Some(tx) = self
+            .tx_for_private_broadcast
+            .pick_tx_for_send(peer, address)
+        {
+            let txid = tx.compute_txid();
+            let wtxid = tx.compute_wtxid();
+            let wtxid_suffix = format!(", wtxid={wtxid}");
+            debug!(
+                "P2P handshake completed, sending INV for txid={txid}{wtxid_suffix}, {peer_log}"
+            );
+            self.send_to_peer(peer, NodeRequest::PrivateBroadcastInv(tx))?;
+        } else {
+            debug!(
+                "Disconnecting: no more transactions for private broadcast (connected in vain), {peer_log}"
+            );
+            self.send_to_peer(peer, NodeRequest::Shutdown)?;
+        }
+        Ok(())
+    }
+
+    /// Records receipt and shuts down a private-broadcast peer after `pong`.
+    ///
+    /// Invoked when the peer task reports [`crate::p2p_wire::peer::PeerMessages::PrivateBroadcastConfirmed`]
+    /// (probe `ping` answered). Marks the peer's delivery in
+    /// [`crate::private_broadcast::PrivateBroadcast::peer_confirmed_receipt`] and sends
+    /// [`NodeRequest::Shutdown`].
+    pub(crate) fn on_private_broadcast_confirmed(&mut self, peer: u32) -> Result<(), WireError> {
+        if let Some(p) = self.peers.get(&peer) {
+            let peer_log = peer_log(peer, &p.address.to_string());
+            debug!(
+                "Got a PONG (the transaction will probably reach the network), marking for disconnect, {peer_log}"
+            );
+        }
+        self.tx_for_private_broadcast.peer_confirmed_receipt(peer);
+        self.send_to_peer(peer, NodeRequest::Shutdown)?;
+        Ok(())
+    }
+
+    /// Updates private-broadcast state after a dedicated peer disconnects.
+    ///
+    /// Called from [`super::peer_man`] for every [`ConnectionKind::PrivateBroadcast`]
+    /// disconnect. Matches Bitcoin Core `FinalizeNode`: peers that already confirmed
+    /// receipt are unchanged; otherwise, if the queue still has pending work, schedules
+    /// one replacement outbound via the connector. Per-peer send history in
+    /// [`crate::private_broadcast::PrivateBroadcast`] is left intact (Core does not erase
+    /// failed picks on disconnect).
+    pub(crate) fn on_private_broadcast_disconnect(&mut self, peer: u32, peer_log: &str) {
+        if self.tx_for_private_broadcast.did_peer_confirm_receipt(peer) {
+            return;
+        }
+
+        let remaining = self.private_broadcast_connector.num_to_open();
+        if remaining == 0 {
+            debug!(
+                "Private-broadcast peer disconnected before send completed ({peer_log}); no replacement dial needed"
+            );
+        } else {
+            debug!(
+                "Private-broadcast peer disconnected before send completed ({peer_log}); will retry to another peer; remaining connections to open: {remaining}"
+            );
+        }
+
+        if self.tx_for_private_broadcast.have_pending_transactions() {
+            self.private_broadcast_connector.num_to_open_add(1);
+        }
+    }
+
+    /// Disconnects private-broadcast peers that stalled after verack.
+    ///
+    /// Targets [`ConnectionKind::PrivateBroadcast`] peers in [`PeerStatus::Ready`] that have
+    /// not confirmed receipt (see
+    /// [`crate::private_broadcast::PrivateBroadcast::did_peer_confirm_receipt`]) and have been
+    /// ready longer than [`crate::private_broadcast::PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME`].
+    /// Each match receives [`NodeRequest::Shutdown`].
+    pub(crate) fn disconnect_stale_private_broadcast_peers(&mut self) -> Result<(), WireError> {
+        let now = Instant::now();
+        let timeout_secs = PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME.as_secs();
+        let to_disconnect: Vec<(u32, String)> = self
+            .peers
+            .iter()
+            .filter_map(|(peer_id, p)| {
+                if p.kind == ConnectionKind::PrivateBroadcast
+                    && p.state == PeerStatus::Ready
+                    && !self
+                        .tx_for_private_broadcast
+                        .did_peer_confirm_receipt(*peer_id)
+                    && p.ready_since.is_some_and(|t| {
+                        now.duration_since(t) > PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME
+                    })
+                {
+                    Some((*peer_id, peer_log(*peer_id, &p.address.to_string())))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for (peer, peer_log) in to_disconnect {
+            debug!(
+                "Disconnecting: did not complete the transaction send within {timeout_secs} seconds, {peer_log}"
+            );
+            let _ = self.send_to_peer(peer, NodeRequest::Shutdown);
+        }
+        Ok(())
+    }
+
+    /// Re-schedules stale queued transactions for another round of Tor outbounds.
+    ///
+    /// No-op when private broadcast is disabled. Otherwise collects entries from
+    /// [`crate::private_broadcast::PrivateBroadcast::get_stale`] (see
+    /// [`crate::private_broadcast::INITIAL_STALE_DURATION`] and
+    /// [`crate::private_broadcast::STALE_DURATION`]). Stale transactions that still pass
+    /// local mempool validation each add one connection to the connector budget; invalid
+    /// ones are removed from the queue. Invoked periodically from [`super::running_ctx`]
+    /// on [`crate::private_broadcast::REATTEMPT_INTERVAL_BASE`].
+    pub(crate) async fn reattempt_private_broadcast(&mut self) {
+        if !self.config.private_broadcast {
+            return;
+        }
+        let stale = self.tx_for_private_broadcast.get_stale();
+        if stale.is_empty() {
+            return;
+        }
+
+        let mut num_for_rebroadcast = 0usize;
+        for tx in stale {
+            let txid = tx.compute_txid();
+            let wtxid = tx.compute_wtxid();
+            let valid = {
+                let mut guard = self.mempool.lock().await;
+                guard.validate_transaction(&tx)
+            };
+            if valid.is_ok() {
+                debug!("Reattempting broadcast of stale txid={txid} wtxid={wtxid}");
+                num_for_rebroadcast += 1;
+            } else {
+                debug!("Giving up broadcast attempts for txid={txid} wtxid={wtxid}: {valid:?}");
+                self.tx_for_private_broadcast.remove(&tx);
+            }
+        }
+        if num_for_rebroadcast > 0 {
+            self.private_broadcast_connector
+                .num_to_open_add(num_for_rebroadcast);
+        }
+    }
+
+    /// Removes a queued transaction when it appears on the public P2P network.
+    ///
+    /// Called from [`super::peer_man`] on every clearnet `tx`. No-op when private broadcast is disabled or the wtxid is not in
+    /// [`crate::private_broadcast::PrivateBroadcast`]. Otherwise drops the queue entry and
+    /// reduces the connector budget by the number of
+    /// [`crate::private_broadcast::NUM_PRIVATE_BROADCAST_PER_TX`] outbounds that were still
+    /// unacknowledged.
+    pub(crate) fn handle_private_broadcast_echo(&mut self, tx: &Transaction) {
+        if !self.config.private_broadcast {
+            return;
+        }
+        if let Some(num_confirmed) = self.tx_for_private_broadcast.remove(tx) {
+            debug!(
+                "private broadcast tx {} echoed; confirmed on {} peers",
+                tx.compute_txid(),
+                num_confirmed
+            );
+            if NUM_PRIVATE_BROADCAST_PER_TX > num_confirmed {
+                self.private_broadcast_connector
+                    .num_to_open_sub(NUM_PRIVATE_BROADCAST_PER_TX - num_confirmed);
+            }
+        }
+    }
+
+    /// Aborts private broadcast for a transaction identified by txid or wtxid.
+    ///
+    /// Removes matching entries via [`crate::private_broadcast::PrivateBroadcast::abort_by_id`]
+    /// and subtracts from the connector budget any outbound slots that were still
+    /// unacknowledged. Used by [`super::user_req`] for RPC abort.
+    pub(crate) fn abort_private_broadcast(&mut self, id: [u8; 32]) -> Vec<Transaction> {
+        let removed = self.tx_for_private_broadcast.abort_by_id(id);
+        let mut connections_cancelled = 0usize;
+        let mut txs = Vec::new();
+        for (tx, acks) in removed {
+            txs.push(tx);
+            if NUM_PRIVATE_BROADCAST_PER_TX > acks {
+                connections_cancelled += NUM_PRIVATE_BROADCAST_PER_TX - acks;
+            }
+        }
+        if connections_cancelled > 0 {
+            self.private_broadcast_connector
+                .num_to_open_sub(connections_cancelled);
+        }
+        txs
+    }
+}
+
+pub(super) fn peer_log(peer: u32, address: &str) -> String {
+    format!("peer={peer} addr={address}")
+}

--- a/crates/floresta-wire/src/p2p_wire/node/private_broadcast_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/private_broadcast_man.rs
@@ -302,15 +302,18 @@ where
     /// reduces the connector budget by the number of
     /// [`crate::private_broadcast::NUM_PRIVATE_BROADCAST_PER_TX`] outbounds that were still
     /// unacknowledged.
-    pub(crate) fn handle_private_broadcast_echo(&mut self, tx: &Transaction) {
+    pub(crate) fn handle_private_broadcast_echo(&mut self, peer: u32, tx: &Transaction) {
         if !self.config.private_broadcast {
             return;
         }
+        let txid = tx.compute_txid();
         if let Some(num_confirmed) = self.tx_for_private_broadcast.remove(tx) {
+            let peer_log = self.peers.get(&peer).map_or_else(
+                || format!("peer={peer}"),
+                |p| peer_log(peer, &p.address.to_string()),
+            );
             debug!(
-                "private broadcast tx {} echoed; confirmed on {} peers",
-                tx.compute_txid(),
-                num_confirmed
+                "Received our privately broadcast transaction (txid={txid}) from the network from {peer_log}; stopping private broadcast attempts"
             );
             if NUM_PRIVATE_BROADCAST_PER_TX > num_confirmed {
                 self.private_broadcast_connector

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -446,6 +446,17 @@ where
             no_log,
         );
 
+        if self.config.private_broadcast {
+            try_and_log!(self.try_open_private_broadcast_connections());
+            try_and_log!(self.disconnect_stale_private_broadcast_peers());
+            if self.last_private_broadcast_reattempt.elapsed()
+                > crate::private_broadcast::REATTEMPT_INTERVAL_BASE
+            {
+                self.reattempt_private_broadcast().await;
+                self.last_private_broadcast_reattempt = Instant::now();
+            }
+        }
+
         // The jobs below need a connected peer to work
         if self.peer_ids.is_empty() {
             return LoopControl::Continue;
@@ -794,6 +805,10 @@ where
                             version.kind
                         );
                         self.handle_peer_ready(peer, version)?;
+                    }
+
+                    PeerMessages::PrivateBroadcastConfirmed => {
+                        self.on_private_broadcast_confirmed(peer)?;
                     }
 
                     PeerMessages::Disconnected(idx) => {

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -6,6 +6,7 @@ use bitcoin::Block;
 use bitcoin::p2p::ServiceFlags;
 use floresta_chain::ChainBackend;
 use floresta_common::try_and_log;
+use floresta_mempool::mempool::MempoolError;
 use tokio::sync::oneshot;
 use tracing::debug;
 use tracing::info;
@@ -169,6 +170,27 @@ where
 
             UserRequest::SendTransaction(transaction) => {
                 let txid = transaction.compute_txid();
+
+                if self.config.private_broadcast {
+                    if self.socks5.is_none() {
+                        warn!("Private broadcast was requested but no Tor/proxy is configured");
+                        let _ = responder.send(NodeResponse::TransactionBroadcastResult(Err(
+                            MempoolError::PrivateBroadcastUnavailable,
+                        )));
+                        return;
+                    }
+                    let mut mempool = self.mempool.lock().await;
+                    if let Err(e) = mempool.validate_transaction(&transaction) {
+                        warn!("Could not validate transaction {txid} for private broadcast: {e}");
+                        let _ = responder.send(NodeResponse::TransactionBroadcastResult(Err(e)));
+                        return;
+                    }
+                    drop(mempool);
+                    self.schedule_private_broadcast_for_tx(transaction);
+                    let _ = responder.send(NodeResponse::TransactionBroadcastResult(Ok(txid)));
+                    return;
+                }
+
                 let mut mempool = self.mempool.lock().await;
 
                 if let Err(e) = mempool.accept_to_mempool(transaction) {
@@ -182,6 +204,18 @@ where
                 // Announce the transaction to our peers, broadcast from mempool if requested
                 self.broadcast_to_peers(NodeRequest::BroadcastTransaction(txid));
                 let _ = responder.send(NodeResponse::TransactionBroadcastResult(Ok(txid)));
+                return;
+            }
+
+            UserRequest::GetPrivateBroadcastInfo => {
+                let info = self.tx_for_private_broadcast.get_broadcast_info();
+                let _ = responder.send(NodeResponse::GetPrivateBroadcastInfo(info));
+                return;
+            }
+
+            UserRequest::AbortPrivateBroadcast(id) => {
+                let removed = self.abort_private_broadcast(id);
+                let _ = responder.send(NodeResponse::AbortPrivateBroadcast(removed));
                 return;
             }
         };

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -35,6 +35,7 @@ use crate::node_interface::MempoolMethods;
 use crate::node_interface::NetworkMethods;
 use crate::node_interface::NodeConfigMethods;
 use crate::node_interface::PeerInfo;
+use crate::private_broadcast::TxBroadcastInfo;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// A request that can be made to the node.
@@ -93,6 +94,12 @@ pub enum UserRequest {
 
     /// Return address manager statistics.
     GetAddrManInfo,
+
+    /// Return the private-broadcast queue (in-flight Tor outbounds per transaction).
+    GetPrivateBroadcastInfo,
+
+    /// Stop private broadcast for a transaction identified by txid or wtxid bytes.
+    AbortPrivateBroadcast([u8; 32]),
 }
 
 #[derive(Debug)]
@@ -139,6 +146,12 @@ pub enum NodeResponse {
 
     /// Address manager statistics.
     GetAddrManInfo(ConnectionStats),
+
+    /// Private-broadcast queue snapshot.
+    GetPrivateBroadcastInfo(Vec<TxBroadcastInfo>),
+
+    /// Transactions removed from the private-broadcast queue by abort.
+    AbortPrivateBroadcast(Vec<Transaction>),
 }
 
 #[derive(Debug)]

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -35,6 +35,7 @@ use crate::node_interface::MempoolMethods;
 use crate::node_interface::NetworkMethods;
 use crate::node_interface::NodeConfigMethods;
 use crate::node_interface::PeerInfo;
+use crate::node_interface::PrivateBroadcastMethods;
 use crate::private_broadcast::TxBroadcastInfo;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -298,6 +299,24 @@ impl NodeConfigMethods for NodeHandle {
         let val = self.send_request(UserRequest::Config).await?;
 
         extract_variant!(Config, val)
+    }
+}
+
+impl PrivateBroadcastMethods for NodeHandle {
+    type Error = RecvError;
+
+    async fn get_private_broadcast_info(&self) -> Result<Vec<TxBroadcastInfo>, Self::Error> {
+        let val = self
+            .send_request(UserRequest::GetPrivateBroadcastInfo)
+            .await?;
+        extract_variant!(GetPrivateBroadcastInfo, val)
+    }
+
+    async fn abort_private_broadcast(&self, id: [u8; 32]) -> Result<Vec<Transaction>, Self::Error> {
+        let val = self
+            .send_request(UserRequest::AbortPrivateBroadcast(id))
+            .await?;
+        extract_variant!(AbortPrivateBroadcast, val)
     }
 }
 

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -237,14 +237,48 @@ pub trait NodeConfigMethods {
     fn get_config(&self) -> impl Future<Output = Result<UtreexoNodeConfig, Self::Error>>;
 }
 
+/// Methods for the private-broadcast Tor relay queue.
+pub trait PrivateBroadcastMethods {
+    type Error: core::error::Error;
+
+    /// Returns a snapshot of transactions in the private-broadcast queue.
+    ///
+    /// Each [`crate::private_broadcast::TxBroadcastInfo`] includes the transaction body,
+    /// txid, wtxid, time added, and per-peer send and acknowledgment timestamps.
+    fn get_private_broadcast_info(
+        &self,
+    ) -> impl Future<Output = Result<Vec<crate::private_broadcast::TxBroadcastInfo>, Self::Error>>;
+
+    /// Aborts private broadcast for a transaction identified by txid or wtxid.
+    ///
+    /// `id` is matched against queued [`crate::private_broadcast::TxBroadcastInfo`]
+    /// entries. Returns the removed [`Transaction`] bodies; empty when nothing matches.
+    fn abort_private_broadcast(
+        &self,
+        id: [u8; 32],
+    ) -> impl Future<Output = Result<Vec<Transaction>, Self::Error>>;
+}
+
 /// A trait defining what methods our node can expose.
 pub trait NodeMethods:
-    ChainMethods + MempoolMethods + NetworkMethods + NodeConfigMethods + Send + 'static
+    ChainMethods
+    + MempoolMethods
+    + NetworkMethods
+    + NodeConfigMethods
+    + PrivateBroadcastMethods
+    + Send
+    + 'static
 {
 }
 
 impl<T> NodeMethods for T where
-    T: ChainMethods + MempoolMethods + NetworkMethods + NodeConfigMethods + Send + 'static
+    T: ChainMethods
+        + MempoolMethods
+        + NetworkMethods
+        + NodeConfigMethods
+        + PrivateBroadcastMethods
+        + Send
+        + 'static
 {
 }
 

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -108,6 +108,12 @@ pub enum UserRequest {
 
     /// Return address manager statistics.
     GetAddrManInfo,
+
+    /// Return the private-broadcast queue (in-flight Tor outbounds per transaction).
+    GetPrivateBroadcastInfo,
+
+    /// Stop private broadcast for a transaction identified by txid or wtxid bytes.
+    AbortPrivateBroadcast([u8; 32]),
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -395,6 +395,15 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                 self.write(NetworkMessage::Inv(vec![Inventory::Transaction(tx)]))
                     .await?;
             }
+            NodeRequest::PrivateBroadcastInv(tx) => {
+                self.write(NetworkMessage::Inv(vec![Inventory::Transaction(
+                    tx.compute_txid(),
+                )]))
+                .await?;
+            }
+            NodeRequest::PrivateBroadcastSendTx(tx) => {
+                self.write(NetworkMessage::Tx(tx)).await?;
+            }
             NodeRequest::MempoolTransaction(txid) => {
                 self.write(NetworkMessage::GetData(vec![Inventory::Transaction(txid)]))
                     .await?;

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -151,6 +151,8 @@ pub struct Peer<T: AsyncWrite + Unpin + Send + Sync> {
     // This is kept as an option to avoid the need to keep the other half around during tests.
     cancellation_sender: Option<oneshot::Sender<()>>,
     transport_protocol: TransportProtocol,
+    private_broadcast_tx: Option<Transaction>,
+    private_broadcast_awaiting_pong: bool,
 }
 
 #[derive(Debug)]
@@ -270,6 +272,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
     async fn peer_loop_inner(&mut self) -> Result<()> {
         // Send a `version` message to the peer.
         let message_version = peer_utils::build_version_message(
+            self.kind,
             self.our_user_agent.clone(),
             self.our_best_block,
             &self.address,
@@ -352,8 +355,27 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         }
     }
 
+    fn private_broadcast_peer_log(&self) -> String {
+        format!("peer={} addr={}", self.id, self.address)
+    }
+
     pub async fn handle_node_request(&mut self, request: NodeRequest) -> Result<()> {
         assert_eq!(self.state, State::Connected);
+        if self.kind == ConnectionKind::PrivateBroadcast {
+            match &request {
+                NodeRequest::PrivateBroadcastInv(_)
+                | NodeRequest::PrivateBroadcastSendTx(_)
+                | NodeRequest::Shutdown
+                | NodeRequest::Ping => {}
+                other => {
+                    debug!(
+                        "Omitting send of message '{other:?}', {}",
+                        self.private_broadcast_peer_log()
+                    );
+                    return Ok(());
+                }
+            }
+        }
         debug!("Handling node request: {request:?}");
         match request {
             NodeRequest::GetBlock(block_hashes) => {
@@ -396,13 +418,14 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                     .await?;
             }
             NodeRequest::PrivateBroadcastInv(tx) => {
+                self.private_broadcast_tx = Some(tx.clone());
                 self.write(NetworkMessage::Inv(vec![Inventory::Transaction(
                     tx.compute_txid(),
                 )]))
                 .await?;
             }
             NodeRequest::PrivateBroadcastSendTx(tx) => {
-                self.write(NetworkMessage::Tx(tx)).await?;
+                self.send_private_broadcast_tx_and_probe(tx).await?;
             }
             NodeRequest::MempoolTransaction(txid) => {
                 self.write(NetworkMessage::GetData(vec![Inventory::Transaction(txid)]))
@@ -453,6 +476,11 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         self.messages += 1;
 
         debug!("Received {} from peer {}", message.command(), self.id);
+        if self.kind == ConnectionKind::PrivateBroadcast && self.state == State::Connected {
+            return self
+                .handle_private_broadcast_connected_message(message, time)
+                .await;
+        }
         match self.state {
             State::Connected => match message {
                 NetworkMessage::Inv(inv) => {
@@ -714,6 +742,8 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             our_best_block,
             cancellation_sender: Some(cancellation_sender),
             transport_protocol,
+            private_broadcast_tx: None,
+            private_broadcast_awaiting_pong: false,
         };
 
         spawn(peer.read_loop());
@@ -724,18 +754,91 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         self.write(pong).await
     }
 
+    /// Sends `tx` then a probe `ping`. The peer's `pong` confirms receipt of the `tx`.
+    async fn send_private_broadcast_tx_and_probe(&mut self, tx: Transaction) -> Result<()> {
+        self.write(NetworkMessage::Tx(tx)).await?;
+        self.private_broadcast_awaiting_pong = true;
+        let nonce = rand::random();
+        self.last_ping = Some(Instant::now());
+        self.write(NetworkMessage::Ping(nonce)).await
+    }
+
     async fn handle_version(&mut self, version: VersionMessage) -> Result<()> {
         self.user_agent = version.user_agent;
         self.blocks_only = !version.relay;
         self.current_best_block = version.start_height;
         self.services = version.services;
+
+        if self.kind == ConnectionKind::PrivateBroadcast {
+            if !version.relay {
+                debug!(
+                    "Disconnecting: does not support transaction relay (connected in vain), {}",
+                    self.private_broadcast_peer_log()
+                );
+                return Err(PeerError::UnexpectedMessage);
+            }
+            self.state = State::SentVerack;
+            return self.write(NetworkMessage::Verack).await;
+        }
+
         if version.version >= PROTOCOL_VERSION {
             self.write(NetworkMessage::SendAddrV2).await?;
         }
         self.state = State::SentVerack;
-        let verack = NetworkMessage::Verack;
-        self.state = State::SentVerack;
-        self.write(verack).await
+        self.write(NetworkMessage::Verack).await
+    }
+
+    /// Handles post-handshake messages for [`ConnectionKind::PrivateBroadcast`] peers.
+    ///
+    /// Once `inv` has been sent, only two inbound messages matter:
+    /// - `getdata` for the queued transaction → deliver `tx` and a probe `ping` via
+    ///   [`Self::send_private_broadcast_tx_and_probe`];
+    /// - `pong` for that probe → [`PeerMessages::PrivateBroadcastConfirmed`] to the node.
+    ///
+    /// Other messages are ignored. Unexpected `getdata` returns [`PeerError::UnexpectedMessage`].
+    async fn handle_private_broadcast_connected_message(
+        &mut self,
+        message: NetworkMessage,
+        time: Instant,
+    ) -> Result<()> {
+        let peer_log = self.private_broadcast_peer_log();
+        match message {
+            NetworkMessage::GetData(inv) => {
+                let Some(ref tx) = self.private_broadcast_tx else {
+                    debug!("Disconnecting: got GETDATA without sending an INV, {peer_log}");
+                    return Err(PeerError::UnexpectedMessage);
+                };
+                if inv.len() != 1 {
+                    debug!("Disconnecting: got an unexpected GETDATA message, {peer_log}");
+                    return Err(PeerError::UnexpectedMessage);
+                }
+                match inv[0] {
+                    Inventory::Transaction(txid) | Inventory::WitnessTransaction(txid)
+                        if txid == tx.compute_txid() =>
+                    {
+                        self.send_private_broadcast_tx_and_probe(tx.clone()).await?;
+                    }
+                    _ => {
+                        debug!("Disconnecting: got an unexpected GETDATA message, {peer_log}");
+                        return Err(PeerError::UnexpectedMessage);
+                    }
+                }
+            }
+            NetworkMessage::Pong(_) => {
+                if self.private_broadcast_awaiting_pong {
+                    self.private_broadcast_awaiting_pong = false;
+                    self.last_ping = None;
+                    self.send_to_node(PeerMessages::PrivateBroadcastConfirmed, time);
+                }
+            }
+            other => {
+                debug!(
+                    "Ignoring incoming message '{}', {peer_log}",
+                    other.command()
+                );
+            }
+        }
+        Ok(())
     }
 
     fn send_to_node(&self, message: PeerMessages, time: Instant) {
@@ -752,6 +855,7 @@ pub(super) mod peer_utils {
     use std::time::UNIX_EPOCH;
 
     use bitcoin::p2p::Address;
+    use bitcoin::p2p::ServiceFlags;
     use bitcoin::p2p::message::NetworkMessage;
     use bitcoin::p2p::message_network::VersionMessage;
     use floresta_common::PROTOCOL_VERSION;
@@ -760,6 +864,8 @@ pub(super) mod peer_utils {
     use rand::rng;
 
     use crate::address_man::LocalAddress;
+    use crate::node::ConnectionKind;
+    use crate::private_broadcast::PRIVATE_BROADCAST_USER_AGENT;
 
     /// Build the [pong](NetworkMessage::Pong) message, which must be sent whenever a peer sends us a
     /// [ping](NetworkMessage::Ping). Note that the nonce received in the ping must be reused in the pong.
@@ -770,10 +876,15 @@ pub(super) mod peer_utils {
     /// Build the [version](NetworkMessage::Version) message used to perform the peer connection
     /// handshake, as described in the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Protocol_documentation#version).
     pub(crate) fn build_version_message(
+        kind: ConnectionKind,
         user_agent: String,
         best_block: u32,
         peer_address: &LocalAddress,
     ) -> NetworkMessage {
+        if kind == ConnectionKind::PrivateBroadcast {
+            return build_private_broadcast_version_message();
+        }
+
         // The set of services supported by this node.
         let services = advertised_services();
 
@@ -812,6 +923,27 @@ pub(super) mod peer_utils {
             user_agent,
             start_height,
             relay,
+        })
+    }
+
+    /// Builds a minimal version for Tor private-broadcast outbounds.
+    fn build_private_broadcast_version_message() -> NetworkMessage {
+        let services = ServiceFlags::NONE;
+        let empty_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
+        let dummy_address = Address::new(&empty_socket, ServiceFlags::NONE);
+        let mut prng = rng();
+        let nonce: u64 = prng.random();
+
+        NetworkMessage::Version(VersionMessage {
+            version: PROTOCOL_VERSION,
+            services,
+            timestamp: 0,
+            sender: dummy_address.clone(),
+            receiver: dummy_address,
+            nonce,
+            user_agent: PRIVATE_BROADCAST_USER_AGENT.into(),
+            start_height: 0,
+            relay: false,
         })
     }
 }
@@ -856,6 +988,9 @@ pub enum PeerMessages {
 
     /// Remote peer sent us a transaction
     Transaction(Transaction),
+
+    /// Private-broadcast peer acknowledged our post-TX ping with pong.
+    PrivateBroadcastConfirmed,
 
     /// Remote peer sent us a Utreexo state
     UtreexoState(Vec<u8>),
@@ -958,6 +1093,8 @@ mod tests {
             current_best_block: 0,
             transport_protocol: TransportProtocol::V1,
             cancellation_sender: Some(cancellation_sender),
+            private_broadcast_tx: None,
+            private_broadcast_awaiting_pong: false,
         };
 
         SetupData {
@@ -975,6 +1112,43 @@ mod tests {
         actor_sender
             .send(ReaderMessage::Message(network_message, Instant::now()))
             .unwrap();
+    }
+
+    #[test]
+    fn private_broadcast_version_is_anonymous() {
+        use crate::private_broadcast::PRIVATE_BROADCAST_USER_AGENT;
+
+        const NODE_USER_AGENT: &str = "/Floresta-test:0.0.0/";
+        const NODE_BEST_HEIGHT: u32 = 900_000;
+
+        let address = LocalAddress::new(
+            BitcoinSocketAddr::new(AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1)), 18444),
+            0,
+            AddressState::NeverTried,
+            ServiceFlags::NONE,
+            0,
+        );
+
+        let msg = peer_utils::build_version_message(
+            ConnectionKind::PrivateBroadcast,
+            NODE_USER_AGENT.into(),
+            NODE_BEST_HEIGHT,
+            &address,
+        );
+
+        let NetworkMessage::Version(version) = msg else {
+            panic!("expected version message");
+        };
+
+        assert_eq!(version.services, ServiceFlags::NONE);
+        assert_eq!(version.timestamp, 0);
+        assert_eq!(version.start_height, 0);
+        assert!(!version.relay);
+        assert_eq!(version.user_agent, PRIVATE_BROADCAST_USER_AGENT);
+        assert_eq!(version.sender.services, ServiceFlags::NONE);
+        assert_eq!(version.receiver.services, ServiceFlags::NONE);
+        assert_eq!(version.sender.port, 0);
+        assert_eq!(version.receiver.port, 0);
     }
 
     #[tokio::test]
@@ -1012,7 +1186,12 @@ mod tests {
 
         send_to_peer(
             &mut actor_sender,
-            peer_utils::build_version_message("/Floresta-test:0.0.0/".into(), 0, &address),
+            peer_utils::build_version_message(
+                ConnectionKind::Manual,
+                "/Floresta-test:0.0.0/".into(),
+                0,
+                &address,
+            ),
         );
 
         send_to_peer(&mut actor_sender, NetworkMessage::Verack);

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -185,6 +185,8 @@ pub fn create_peer(
         banscore: 0,
         _last_message: Instant::now(),
         transport_protocol: TransportProtocol::V2,
+        ready_since: Some(Instant::now()),
+        is_outbound_tor_v3: false,
     }
 }
 

--- a/crates/floresta-wire/src/private_broadcast/connector.rs
+++ b/crates/floresta-wire/src/private_broadcast/connector.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use super::MAX_PRIVATE_BROADCAST_CONNECTIONS;
+
+/// Tracks the pending-open budget for private-broadcast outbound connections.
+///
+/// Active peer counts are supplied by the caller when checking capacity.
+#[derive(Debug, Default)]
+pub struct PrivateBroadcastConnector {
+    num_to_open: AtomicUsize,
+}
+
+impl PrivateBroadcastConnector {
+    /// Returns the number of connections that need to be opened.
+    pub fn num_to_open(&self) -> usize {
+        self.num_to_open.load(Ordering::Acquire)
+    }
+
+    /// Adds `n` to the number of connections that need to be opened.
+    pub fn num_to_open_add(&self, n: usize) {
+        self.num_to_open.fetch_add(n, Ordering::AcqRel);
+    }
+
+    /// Subtracts up to `n`, returning the value remaining after the operation.
+    pub fn num_to_open_sub(&self, n: usize) -> usize {
+        let mut current = self.num_to_open();
+        loop {
+            let new_value = current.saturating_sub(n);
+            match self.num_to_open.compare_exchange_weak(
+                current,
+                new_value,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return new_value,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    /// Checks if more private-broadcast connections can be opened.
+    ///
+    /// `active_connections` is the caller's count of connected private-broadcast peers.
+    /// Returns true when that count is below [`MAX_PRIVATE_BROADCAST_CONNECTIONS`] and
+    /// the pending-open budget is still positive.
+    pub fn can_open_more(&self, active_connections: usize) -> bool {
+        active_connections < MAX_PRIVATE_BROADCAST_CONNECTIONS && self.num_to_open() > 0
+    }
+}

--- a/crates/floresta-wire/src/private_broadcast/mod.rs
+++ b/crates/floresta-wire/src/private_broadcast/mod.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Private transaction broadcast over Tor.
+//!
+//! Mirrors Bitcoin Core's `PrivateBroadcast`. Floresta dials random Tor v3 **tx-recipients** from
+//! the addrman over SOCKS5. With `config.private_broadcast` enabled, [`crate::node_interface::UserRequest::SendTransaction`]
+//! enqueues the tx in [`PrivateBroadcast`] instead of the public mempool relay path.
+//! Each new entry schedules [`NUM_PRIVATE_BROADCAST_PER_TX`] such outbounds, capped by
+//! [`MAX_PRIVATE_BROADCAST_CONNECTIONS`]. [`PrivateBroadcastConnector`] counts how
+//! many connections still need to open; [`crate::address_man::AddressMan::select_for_private_broadcast`]
+//! picks the next onion peer. One connection, end to end:
+//!
+//! ```text
+//! tx-sender >--- connect -------> tx-recipient
+//! tx-sender >--- VERSION -------> tx-recipient   (anonymous VERSION; see [`PRIVATE_BROADCAST_USER_AGENT`])
+//! tx-sender <--- VERSION -------< tx-recipient
+//! tx-sender <--- VERACK --------< tx-recipient
+//! tx-sender >--- VERACK --------> tx-recipient
+//! tx-sender >--- INV -----------> tx-recipient
+//! tx-sender <--- GETDATA -------< tx-recipient
+//! tx-sender >--- TX ------------> tx-recipient
+//! tx-sender >--- PING ----------> tx-recipient
+//! tx-sender <--- PONG ----------< tx-recipient
+//! tx-sender disconnects
+//! ```
+//!
+//! On Tor private-broadcast outbounds, tx-sender sends a minimal `version` message
+//! (no services, zero time/height, empty addrs, decoy user agent) so recipients cannot
+//! fingerprint this client. Regular P2P peers still get the normal version.
+//!
+//! The handshake is a trimmed P2P version exchange: optional recipient features are
+//! ignored, but the recipient must advertise `relay`. After `verack`, tx-sender
+//! announces the tx with `inv`; tx-recipient pulls it with `getdata`; tx-sender
+//! delivers `tx` and probes with `ping`. `pong` counts as receipt in
+//! [`PrivateBroadcast`], then the outbound peer is shut down. Wire handling lives in
+//! `p2p_wire`; this module holds only the queue and connection budget.
+//!
+//! A tx leaves the queue when it is echoed back on the ordinary P2P network (mempool
+//! acceptance elsewhere) or when RPC abort removes it. Entries that miss acks within
+//! [`INITIAL_STALE_DURATION`] / [`STALE_DURATION`] are reconsidered on
+//! [`REATTEMPT_INTERVAL_BASE`] if mempool validation still passes. Peers that never
+//! finish the flow are dropped after [`PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME`].
+//!
+//! ## Logging
+//!
+//! Events are emitted with [`tracing`] at `debug`/`warn`, like the rest of `floresta-wire`.
+//! Use `--debug` or `RUST_LOG` to enable them. For private-broadcast only (without full
+//! wire noise), for example:
+//!
+//! ```text
+//! RUST_LOG=floresta_wire::p2p_wire::node::private_broadcast_man=debug,floresta_wire::p2p_wire::peer=debug,info
+//! ```
+
+mod connector;
+mod queue;
+
+pub use connector::PrivateBroadcastConnector;
+pub use queue::PeerSendInfo;
+pub use queue::PrivateBroadcast;
+pub use queue::TxBroadcastInfo;
+
+/// User agent sent on private-broadcast outbounds only.
+///
+/// Bitcoin Core uses this exact string on `IsPrivateBroadcastConn()` ([discussion](https://github.com/bitcoin/bitcoin/pull/27509#discussion_r1214671917)).
+/// We reuse it so Tor recipients cannot distinguish Floresta from Core private-broadcast
+/// senders and cannot link the connection to the configured user agent on clearnet peers.
+pub const PRIVATE_BROADCAST_USER_AGENT: &str = "/pynode:0.0.1/";
+
+/// Outbound private-broadcast connections opened per submitted transaction.
+pub const NUM_PRIVATE_BROADCAST_PER_TX: usize = 3;
+
+/// Maximum simultaneous `ConnectionKind::PrivateBroadcast` peers.
+pub const MAX_PRIVATE_BROADCAST_CONNECTIONS: usize = 64;
+
+/// Disconnect private-broadcast peers that do not finish the send/ack flow in time.
+pub const PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME: std::time::Duration =
+    std::time::Duration::from_secs(3 * 60);
+
+/// Interval between stale-queue scans.
+pub const REATTEMPT_INTERVAL_BASE: std::time::Duration = std::time::Duration::from_secs(2 * 60);
+
+/// If a transaction is not sent to any peer for this duration, consider it stale.
+pub const INITIAL_STALE_DURATION: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// After the last peer ack, wait this long before considering the tx stale again.
+pub const STALE_DURATION: std::time::Duration = std::time::Duration::from_secs(60);

--- a/crates/floresta-wire/src/private_broadcast/queue.rs
+++ b/crates/floresta-wire/src/private_broadcast/queue.rs
@@ -1,0 +1,669 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use bitcoin::Transaction;
+use bitcoin::Txid;
+use bitcoin::Wtxid;
+use bitcoin::hashes::Hash;
+
+use super::INITIAL_STALE_DURATION;
+use super::STALE_DURATION;
+use crate::node_context::PeerId;
+
+/// Per-peer send/ack timestamps for one in-flight private broadcast.
+#[derive(Debug, Clone)]
+pub struct PeerSendInfo {
+    /// The address of the peer.
+    pub address: String,
+    /// The timestamp when the transaction was sent to the peer.
+    pub sent: u64,
+    /// The timestamp when the transaction was received from the peer.
+    pub received: Option<u64>,
+}
+
+/// Snapshot of one transaction moving through the private-broadcast queue.
+#[derive(Debug, Clone)]
+pub struct TxBroadcastInfo {
+    /// The transaction.
+    pub tx: Transaction,
+    /// The transaction ID.
+    pub txid: Txid,
+    /// The transaction wtxid.
+    pub wtxid: Wtxid,
+    /// The timestamp when the transaction was added to the queue.
+    pub time_added: u64,
+    /// The peers that the transaction has been sent to.
+    pub peers: Vec<PeerSendInfo>,
+}
+
+/// Per-peer delivery state for one in-flight private broadcast transaction.
+///
+/// Created each time a peer is picked to receive the transaction. Records when
+/// that peer was selected and, once known, when they acknowledged receipt (UNIX seconds).
+#[derive(Debug)]
+struct SendStatus {
+    /// The peer that the transaction was sent to.
+    peer_id: PeerId,
+    /// The address of the peer that the transaction was sent to.
+    address: String,
+    /// UNIX time (seconds) when this peer was selected to receive the tx.
+    picked_unix: u64,
+    /// UNIX time (seconds) when the peer acknowledged receipt, if known.
+    confirmed_unix: Option<u64>,
+}
+
+/// One transaction in the private-broadcast queue and all peers targeted so far.
+///
+/// Holds the transaction body, when it was enqueued, and a growing list of
+/// per-peer pick/ack timestamps as broadcast retries reach more peers.
+#[derive(Debug)]
+struct TxSendStatus {
+    /// The transaction.
+    tx: Transaction,
+    /// UNIX time (seconds) when the transaction was added to the queue.
+    time_added_unix: u64,
+    /// The send statuses of the transaction.
+    send_statuses: Vec<SendStatus>,
+}
+
+/// Priority of a transaction in the queue.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Priority {
+    /// The number of times the transaction was picked for sending.
+    num_picked: usize,
+    /// The number of peers that have confirmed receipt of the transaction.
+    num_confirmed: usize,
+    /// Most recent pick time across peers (UNIX seconds).
+    last_picked: Option<u64>,
+    /// Most recent peer ack time (UNIX seconds).
+    last_confirmed: Option<u64>,
+}
+
+/// In-memory queue of transactions awaiting or undergoing Tor private broadcast.
+#[derive(Debug, Default)]
+pub struct PrivateBroadcast {
+    /// The mutex protecting the private broadcast queue.
+    mutex: Mutex<HashMap<Wtxid, TxSendStatus>>,
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn num_confirmed(sent_to: &[SendStatus]) -> usize {
+    sent_to
+        .iter()
+        .filter(|s| s.confirmed_unix.is_some())
+        .count()
+}
+
+/// Derives [`Priority`] from a transaction's per-peer send history.
+///
+/// One transaction may be sent to many peers over time. The queue needs a
+/// single measure of broadcast progress to rank in-flight work when choosing
+/// the next outbound send and when applying stale timeouts.
+fn derive_priority(sent_to: &[SendStatus]) -> Priority {
+    let mut p = Priority {
+        num_picked: sent_to.len(),
+        last_picked: None,
+        num_confirmed: num_confirmed(sent_to),
+        last_confirmed: None,
+    };
+    for status in sent_to {
+        match p.last_picked {
+            None => p.last_picked = Some(status.picked_unix),
+            Some(t) if status.picked_unix > t => p.last_picked = Some(status.picked_unix),
+            _ => {}
+        }
+        if let Some(confirmed) = status.confirmed_unix {
+            match p.last_confirmed {
+                None => p.last_confirmed = Some(confirmed),
+                Some(t) if confirmed > t => p.last_confirmed = Some(confirmed),
+                _ => {}
+            }
+        }
+    }
+    p
+}
+
+/// Determines whether a queued transaction should be reconsidered for rebroadcast at `now_unix`.
+fn tx_is_stale(time_added_unix: u64, send_statuses: &[SendStatus], now_unix: u64) -> bool {
+    let p = derive_priority(send_statuses);
+    if p.num_confirmed == 0 {
+        time_added_unix.saturating_add(INITIAL_STALE_DURATION.as_secs()) < now_unix
+    } else {
+        p.last_confirmed
+            .expect("num_confirmed > 0 implies last_confirmed")
+            .saturating_add(STALE_DURATION.as_secs())
+            < now_unix
+    }
+}
+
+/// Compares queue entries for `pick_tx_for_send` by [`Priority`] only (Bitcoin Core `PickTxForSend`).
+fn compare_tx_for_send(
+    a: &(&Wtxid, &TxSendStatus),
+    b: &(&Wtxid, &TxSendStatus),
+) -> std::cmp::Ordering {
+    derive_priority(&a.1.send_statuses).cmp(&derive_priority(&b.1.send_statuses))
+}
+
+impl PrivateBroadcast {
+    /// Adds a transaction to the private broadcast queue.
+    ///
+    /// Returns `false` if the transaction is already in the queue.
+    pub fn add(&self, tx: Transaction) -> bool {
+        let wtxid = tx.compute_wtxid();
+        let mut guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        if guard.contains_key(&wtxid) {
+            return false;
+        }
+        guard.insert(
+            wtxid,
+            TxSendStatus {
+                tx,
+                time_added_unix: unix_now(),
+                send_statuses: Vec::new(),
+            },
+        );
+        true
+    }
+
+    /// Removes a transaction from the private broadcast queue.
+    ///
+    /// Called from `p2p_wire` on clearnet P2P echo, stale reattempt give-up, etc. Returns the
+    /// number of peers that had already confirmed receipt, if the wtxid was present.
+    pub fn remove(&self, tx: &Transaction) -> Option<usize> {
+        let wtxid = tx.compute_wtxid();
+        let mut guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        let status = guard.remove(&wtxid)?;
+        Some(num_confirmed(&status.send_statuses))
+    }
+
+    /// Aborts queued transactions matching `id` (txid or wtxid).
+    ///
+    /// Returns each removed transaction with the number of peers that had already
+    /// confirmed receipt before removal.
+    pub fn abort_by_id(&self, id: [u8; 32]) -> Vec<(Transaction, usize)> {
+        let mut guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        let keys: Vec<Wtxid> = guard
+            .iter()
+            .filter(|(_, state)| {
+                state.tx.compute_txid().as_byte_array() == &id
+                    || state.tx.compute_wtxid().as_byte_array() == &id
+            })
+            .map(|(w, _)| *w)
+            .collect();
+        keys.into_iter()
+            .filter_map(|w| {
+                guard
+                    .remove(&w)
+                    .map(|s| (s.tx, num_confirmed(&s.send_statuses)))
+            })
+            .collect()
+    }
+
+    /// Checks if a transaction is in the private broadcast queue.
+    ///
+    /// Returns `true` if the transaction is in the queue.
+    pub fn contains_tx(&self, tx: &Transaction) -> bool {
+        self.mutex
+            .lock()
+            .expect("private broadcast lock poisoned")
+            .contains_key(&tx.compute_wtxid())
+    }
+
+    /// Checks if there are any pending transactions in the private broadcast queue.
+    ///
+    /// Returns `true` if there are any pending transactions.
+    pub fn have_pending_transactions(&self) -> bool {
+        !self
+            .mutex
+            .lock()
+            .expect("private broadcast lock poisoned")
+            .is_empty()
+    }
+
+    /// Picks a transaction for sending to a peer.
+    ///
+    /// Returns the transaction if it was picked for sending.
+    pub fn pick_tx_for_send(&self, peer_id: PeerId, peer_address: String) -> Option<Transaction> {
+        let mut guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        let wtxid = *guard.iter().min_by(compare_tx_for_send)?.0;
+
+        let state = guard.get_mut(&wtxid)?;
+        state.send_statuses.push(SendStatus {
+            peer_id,
+            address: peer_address,
+            picked_unix: unix_now(),
+            confirmed_unix: None,
+        });
+        Some(state.tx.clone())
+    }
+
+    /// Gets the transaction assigned to a peer.
+    ///
+    /// Returns their transaction if it is still in the queue.
+    pub fn get_tx_for_peer(&self, peer_id: PeerId) -> Option<Transaction> {
+        let guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        for state in guard.values() {
+            if state.send_statuses.iter().any(|s| s.peer_id == peer_id) {
+                return Some(state.tx.clone());
+            }
+        }
+        None
+    }
+
+    /// Marks a peer as having confirmed receipt of their transaction.
+    ///
+    /// Updates the peer's send status to indicate they have confirmed receipt.
+    pub fn peer_confirmed_receipt(&self, peer_id: PeerId) {
+        let mut guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        for state in guard.values_mut() {
+            for status in &mut state.send_statuses {
+                if status.peer_id == peer_id {
+                    status.confirmed_unix = Some(unix_now());
+                }
+            }
+        }
+    }
+
+    /// Checks if the given peer has confirmed receipt of their transaction.
+    ///
+    /// Returns `true` if the peer has confirmed receipt of their transaction.
+    pub fn did_peer_confirm_receipt(&self, peer_id: PeerId) -> bool {
+        let guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        guard.values().any(|state| {
+            state
+                .send_statuses
+                .iter()
+                .any(|s| s.peer_id == peer_id && s.confirmed_unix.is_some())
+        })
+    }
+
+    /// Gets all transactions that are stale and should be rebroadcast.
+    ///
+    /// Returns a list of transactions that are stale and should be rebroadcast.
+    pub fn get_stale(&self) -> Vec<Transaction> {
+        let now_unix = unix_now();
+        let guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        let mut stale = Vec::new();
+        for state in guard.values() {
+            if tx_is_stale(state.time_added_unix, &state.send_statuses, now_unix) {
+                stale.push(state.tx.clone());
+            }
+        }
+        stale
+    }
+
+    /// Gets a snapshot of all transactions in the private broadcast queue.
+    ///
+    /// Returns a list of transactions in the queue, including the transaction ID,
+    /// wtxid, timestamp when added, and the peers that the transaction has been
+    /// sent to.
+    pub fn get_broadcast_info(&self) -> Vec<TxBroadcastInfo> {
+        let guard = self.mutex.lock().expect("private broadcast lock poisoned");
+        guard
+            .values()
+            .map(|state| {
+                let peers = state
+                    .send_statuses
+                    .iter()
+                    .map(|status| PeerSendInfo {
+                        address: status.address.clone(),
+                        sent: status.picked_unix,
+                        received: status.confirmed_unix,
+                    })
+                    .collect();
+                TxBroadcastInfo {
+                    txid: state.tx.compute_txid(),
+                    wtxid: state.tx.compute_wtxid(),
+                    tx: state.tx.clone(),
+                    time_added: state.time_added_unix,
+                    peers,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::Transaction;
+    use bitcoin::absolute::LockTime;
+    use bitcoin::transaction::Version;
+
+    use super::*;
+
+    /// Synthetic UNIX clock (seconds) for stale/priority unit tests.
+    const NOW: u64 = 21_000_000;
+
+    fn tx(n_sequence: u32) -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::null(),
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence(n_sequence),
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![],
+        }
+    }
+
+    fn send_status(peer_id: PeerId, picked_unix: u64, confirmed_unix: Option<u64>) -> SendStatus {
+        SendStatus {
+            peer_id,
+            address: format!("peer{peer_id}"),
+            picked_unix,
+            confirmed_unix,
+        }
+    }
+
+    fn queue_with_picked_tx(peer_id: PeerId, n_sequence: u32) -> (PrivateBroadcast, Transaction) {
+        let pb = PrivateBroadcast::default();
+        let tx = tx(n_sequence);
+        assert!(pb.add(tx.clone()));
+        assert!(
+            pb.pick_tx_for_send(peer_id, format!("peer{peer_id}:8333"))
+                .is_some()
+        );
+        (pb, tx)
+    }
+
+    #[test]
+    fn test_tx_is_stale_unacked_after_initial_timeout() {
+        let time_added = NOW - (INITIAL_STALE_DURATION.as_secs() + 1);
+        assert!(tx_is_stale(time_added, &[], NOW));
+    }
+
+    #[test]
+    fn test_tx_is_stale_unacked_before_initial_timeout() {
+        assert!(!tx_is_stale(NOW, &[], NOW));
+    }
+
+    #[test]
+    fn test_tx_is_stale_acked_after_rebroadcast_timeout() {
+        let last_confirmed = NOW - (STALE_DURATION.as_secs() + 1);
+        let statuses = vec![send_status(1, last_confirmed, Some(last_confirmed))];
+        assert!(tx_is_stale(last_confirmed, &statuses, NOW));
+    }
+
+    #[test]
+    fn test_tx_is_stale_acked_before_rebroadcast_timeout() {
+        let statuses = vec![send_status(1, NOW, Some(NOW))];
+        assert!(!tx_is_stale(NOW, &statuses, NOW));
+    }
+
+    #[test]
+    fn test_derive_priority_orders_by_picks_then_confirms() {
+        let two_picks = vec![send_status(1, NOW, None), send_status(2, NOW, None)];
+        let one_pick_one_confirm = vec![send_status(3, NOW, Some(NOW))];
+        assert!(
+            derive_priority(&two_picks) > derive_priority(&one_pick_one_confirm),
+            "more picks: one confirmation does not win"
+        );
+
+        let one_pick_unconfirmed = vec![send_status(4, NOW, None)];
+        let one_pick_confirmed = vec![send_status(5, NOW, Some(NOW))];
+        assert!(
+            derive_priority(&one_pick_confirmed) > derive_priority(&one_pick_unconfirmed),
+            "equal picks: more confirmations win"
+        );
+    }
+
+    #[test]
+    fn test_add() {
+        let pb = PrivateBroadcast::default();
+        let tx = tx(1);
+
+        let first_add = pb.add(tx.clone());
+
+        assert!(first_add);
+
+        let duplicate_add = pb.add(tx);
+
+        assert!(!duplicate_add);
+    }
+
+    #[test]
+    fn test_contains_tx() {
+        let pb = PrivateBroadcast::default();
+        let tx = tx(1);
+
+        let absent = !pb.contains_tx(&tx);
+
+        assert!(absent);
+
+        assert!(pb.add(tx.clone()));
+
+        let present = pb.contains_tx(&tx);
+
+        assert!(present);
+    }
+
+    #[test]
+    fn test_have_pending_transactions() {
+        let pb = PrivateBroadcast::default();
+
+        let empty = !pb.have_pending_transactions();
+
+        assert!(empty);
+
+        assert!(pb.add(tx(1)));
+
+        let pending = pb.have_pending_transactions();
+
+        assert!(pending);
+    }
+
+    #[test]
+    fn test_abort_by_id() {
+        let pb = PrivateBroadcast::default();
+        let wrong_id = [0u8; 32];
+
+        let empty_abort = pb.abort_by_id(wrong_id);
+
+        assert!(empty_abort.is_empty());
+
+        let tx = tx(1);
+        assert!(pb.add(tx.clone()));
+
+        let no_match_abort = pb.abort_by_id(wrong_id);
+
+        assert!(no_match_abort.is_empty());
+
+        let txid_abort = pb.abort_by_id(*tx.compute_txid().as_byte_array());
+
+        assert_eq!(txid_abort.len(), 1);
+        assert_eq!(txid_abort[0].0.compute_wtxid(), tx.compute_wtxid());
+
+        assert!(pb.add(tx.clone()));
+
+        let wtxid_abort = pb.abort_by_id(*tx.compute_wtxid().as_byte_array());
+
+        assert_eq!(wtxid_abort.len(), 1);
+        assert_eq!(wtxid_abort[0].0.compute_wtxid(), tx.compute_wtxid());
+    }
+
+    #[test]
+    fn test_pick_tx_for_send() {
+        let pb = PrivateBroadcast::default();
+
+        let empty_pick = pb.pick_tx_for_send(1, "peer1:8333".into());
+
+        assert!(empty_pick.is_none());
+
+        let tx = tx(1);
+        assert!(pb.add(tx.clone()));
+
+        let picked = pb.pick_tx_for_send(1, "peer1:8333".into());
+
+        assert_eq!(
+            picked.expect("queued tx should be picked").compute_wtxid(),
+            tx.compute_wtxid()
+        );
+    }
+
+    #[test]
+    fn test_pick_tx_for_send_prefers_least_in_flight_tx() {
+        let pb = PrivateBroadcast::default();
+        let tx_a = tx(1);
+        let tx_b = tx(2);
+        assert!(pb.add(tx_a.clone()));
+        assert!(pb.add(tx_b.clone()));
+
+        let first = pb
+            .pick_tx_for_send(1, "peer1:8333".into())
+            .expect("non-empty queue should yield a tx for peer 1");
+        let second = pb
+            .pick_tx_for_send(2, "peer2:8333".into())
+            .expect("queue should still have a tx for peer 2");
+        assert_ne!(first.compute_wtxid(), second.compute_wtxid());
+
+        pb.peer_confirmed_receipt(1);
+        let third = pb
+            .pick_tx_for_send(3, "peer3:8333".into())
+            .expect("less in-flight tx should be pickable for peer 3");
+        assert_eq!(
+            second.compute_wtxid(),
+            third.compute_wtxid(),
+            "still prefer the tx with fewer picks and confirmations"
+        );
+    }
+
+    #[test]
+    fn test_get_tx_for_peer() {
+        let pb = PrivateBroadcast::default();
+
+        let missing = pb.get_tx_for_peer(1);
+
+        assert!(missing.is_none());
+
+        let tx = tx(1);
+        assert!(pb.add(tx.clone()));
+        assert!(pb.pick_tx_for_send(1, "peer1:8333".into()).is_some());
+
+        let assigned = pb.get_tx_for_peer(1);
+
+        assert_eq!(
+            assigned
+                .expect("picked peer should have a tx")
+                .compute_wtxid(),
+            tx.compute_wtxid()
+        );
+    }
+
+    #[test]
+    fn test_did_peer_confirm_receipt() {
+        let pb = PrivateBroadcast::default();
+        let tx = tx(1);
+        assert!(pb.add(tx));
+        assert!(pb.pick_tx_for_send(1, "peer1:8333".into()).is_some());
+
+        let unconfirmed = !pb.did_peer_confirm_receipt(1);
+
+        assert!(unconfirmed);
+
+        pb.peer_confirmed_receipt(1);
+
+        let confirmed = pb.did_peer_confirm_receipt(1);
+
+        assert!(confirmed);
+    }
+
+    #[test]
+    fn test_get_broadcast_info() {
+        let pb = PrivateBroadcast::default();
+
+        let empty_info = pb.get_broadcast_info();
+
+        assert!(empty_info.is_empty());
+
+        let tx = tx(1);
+        assert!(pb.add(tx.clone()));
+        assert!(pb.pick_tx_for_send(1, "peer1:8333".into()).is_some());
+        assert!(pb.pick_tx_for_send(2, "peer2:8333".into()).is_some());
+        pb.peer_confirmed_receipt(1);
+
+        let info = pb.get_broadcast_info();
+
+        assert_eq!(
+            (
+                info.len(),
+                info[0].peers.len(),
+                info[0].peers[0].received.is_some(),
+                info[0].peers[1].received.is_none(),
+            ),
+            (1, 2, true, true)
+        );
+    }
+
+    #[test]
+    fn test_remove() {
+        let pb = PrivateBroadcast::default();
+        let tx = tx(1);
+
+        let missing = pb.remove(&tx);
+
+        assert_eq!(missing, None);
+
+        assert!(pb.add(tx.clone()));
+        assert!(pb.pick_tx_for_send(1, "peer1:8333".into()).is_some());
+
+        let removed = pb.remove(&tx);
+
+        assert_eq!(removed, Some(0));
+    }
+
+    #[test]
+    fn test_remove_confirmed_count() {
+        let (pb, picked_tx) = queue_with_picked_tx(1, 1);
+        pb.peer_confirmed_receipt(1);
+        assert!(pb.did_peer_confirm_receipt(1));
+        assert_eq!(pb.remove(&picked_tx), Some(1));
+        assert!(!pb.have_pending_transactions());
+
+        let pb = PrivateBroadcast::default();
+        let tx1 = tx(1);
+        let tx2 = tx(2);
+        assert!(pb.add(tx1.clone()));
+        assert!(pb.add(tx2.clone()));
+        let t1 = pb
+            .pick_tx_for_send(1, "peer1:8333".into())
+            .expect("peer 1 should get a tx");
+        let t2 = pb
+            .pick_tx_for_send(2, "peer2:8333".into())
+            .expect("peer 2 should get a tx");
+        assert_ne!(t1.compute_wtxid(), t2.compute_wtxid());
+        pb.peer_confirmed_receipt(1);
+        pb.peer_confirmed_receipt(2);
+        assert_eq!(pb.remove(&t1), Some(1));
+        assert_eq!(pb.remove(&t2), Some(1));
+        assert!(!pb.have_pending_transactions());
+    }
+
+    /// Bitcoin Core keeps failed private-broadcast picks in `send_statuses` on disconnect.
+    #[test]
+    fn failed_peer_pick_retained_after_disconnect_like_bitcoin_core() {
+        let pb = PrivateBroadcast::default();
+        let tx = tx(1);
+        assert!(pb.add(tx.clone()));
+        assert!(pb.pick_tx_for_send(1, "peer1:8333".into()).is_some());
+
+        assert!(pb.get_tx_for_peer(1).is_some());
+        assert!(!pb.did_peer_confirm_receipt(1));
+
+        let info = pb.get_broadcast_info();
+        assert_eq!(info.len(), 1);
+        assert_eq!(info[0].peers.len(), 1);
+        assert_eq!(info[0].peers[0].address, "peer1:8333");
+    }
+}

--- a/doc/proxy.md
+++ b/doc/proxy.md
@@ -9,3 +9,11 @@ florestad --proxy 127.0.0.1:9050
 ```
 
 This will route all your connections through the Tor network, effectively masking your IP address.
+
+With `--private-broadcast`, locally submitted transactions (for example via `sendrawtransaction`) are relayed only over short-lived Tor connections to onion peers, instead of being announced to all regular peers. Private broadcast requires a working SOCKS5 proxy (typically Tor on port 9050).
+
+Private-broadcast diagnostics use the same [`tracing`](https://docs.rs/tracing) setup as the rest of Floresta. Enable them with `--debug`, or narrow to private-broadcast modules only:
+
+```bash
+RUST_LOG=floresta_wire::p2p_wire::node::private_broadcast_man=debug,floresta_wire::p2p_wire::peer=debug,info florestad ...
+```

--- a/doc/rpc/abortprivatebroadcast.md
+++ b/doc/rpc/abortprivatebroadcast.md
@@ -1,0 +1,43 @@
+# `abortprivatebroadcast`
+
+Abort private broadcast for a transaction identified by txid or wtxid.
+
+## Usage
+
+### Synopsis
+
+```
+floresta-cli abortprivatebroadcast <txid|wtxid>
+```
+
+### Examples
+
+```bash
+floresta-cli abortprivatebroadcast 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
+## Arguments
+
+`id` - (string, required) The transaction id or witness transaction id (hex).
+
+## Returns
+
+### Ok Response
+
+A JSON object with a `removed_transactions` array. Each element is an object with:
+
+- `txid` - (string) The transaction id
+- `wtxid` - (string) The witness transaction id
+- `hex` - (string) The serialized transaction
+
+### Error Response
+
+- `InvalidHex` - The id is not valid hex or not a recognized txid/wtxid
+- `TxNotFound` - No queued transaction matches the id
+- `Node` - Failed to abort private broadcast on the node
+
+## Notes
+
+- Removes the transaction from the private-broadcast queue and cancels Tor outbound slots that have not yet confirmed receipt.
+- Does not remove a transaction from the public mempool if it was already accepted through another path.
+- For inspecting the queue, see [`getprivatebroadcastinfo`](getprivatebroadcastinfo.md).

--- a/doc/rpc/getprivatebroadcastinfo.md
+++ b/doc/rpc/getprivatebroadcastinfo.md
@@ -1,0 +1,45 @@
+# `getprivatebroadcastinfo`
+
+Return a snapshot of transactions in the private-broadcast queue.
+
+## Usage
+
+### Synopsis
+
+```
+floresta-cli getprivatebroadcastinfo
+```
+
+### Examples
+
+```bash
+floresta-cli getprivatebroadcastinfo
+```
+
+## Arguments
+
+None.
+
+## Returns
+
+### Ok Response
+
+A JSON object with a `transactions` array. Each element is an object with:
+
+- `txid` - (string) The transaction id
+- `wtxid` - (string) The witness transaction id
+- `hex` - (string) The serialized transaction
+- `time_added` - (numeric) UNIX time when the transaction was enqueued
+- `peers` - (array) Per-peer relay state. Each entry contains:
+  - `address` - (string) The onion peer address
+  - `sent` - (numeric) UNIX time when the transaction was assigned to this peer
+  - `received` - (numeric, optional) UNIX time when receipt was confirmed
+
+### Error Response
+
+- `Node` - Failed to retrieve the private-broadcast queue from the node
+
+## Notes
+
+- Only useful when the node was started with `--private-broadcast` and a SOCKS5 proxy; otherwise the queue is typically empty.
+- For cancelling a queued broadcast, see [`abortprivatebroadcast`](abortprivatebroadcast.md).


### PR DESCRIPTION

## Description and Notes

The `--proxy` flag routes P2P over Tor but `sendrawtransaction` still accepts a transaction into the local mempool and announces it to every regular peer. Bitcoin Core’s [Private Broadcast](https://github.com/bitcoin/bitcoin/pull/29415) lets a node relay its own transactions on short-lived outbound dials to random Tor v3 tx-recipients, not on the normal fanout. This PR brings that functionality into Floresta.

Requires `--private-broadcast` with `--proxy`. Incompatible with `--connect`.

With `--private-broadcast` and a SOCKS5 proxy (typically Tor on `127.0.0.1:9050`):

- Locally submitted transactions are validated and queued for private broadcast. They are not accepted into the local mempool and not announced on the public relay path. The queue clears when we see the same transaction again on ordinary P2P (echo), or when RPC `abortprivatebroadcast` removes it.
- For each new queued transaction, the wire schedules 3 short-lived Tor outbounds, capped at 64 simultaneous private-broadcast connections globally.
- Good, reachable, Tor v3 onion-address peers are chosen at random from addrman. Each dial uses `ConnectionKind::PrivateBroadcast`, which is separate from regular sync/mempool peers.
- After `VERACK`, the node runs `INV(tx) → GETDATA(tx) → tx`, then sends a `PING`. A `PONG` marks that peer as having received the transaction and the outbound connection is shut down. If the flow stalls, the peer is dropped after 3 minutes. Stale queue transactions can be retried on a timer if they still pass mempool validation.
- Private-broadcast outbounds use a minimal anonymous `version` so recipients cannot link the dial to your normal clearnet identity.

```text
tx-sender >--- connect -------> tx-recipient
tx-sender >--- VERSION -------> tx-recipient
tx-sender <--- VERSION -------< tx-recipient
tx-sender <--- VERACK --------< tx-recipient
tx-sender >--- VERACK --------> tx-recipient
tx-sender >--- INV -----------> tx-recipient
tx-sender <--- GETDATA -------< tx-recipient
tx-sender >--- TX ------------> tx-recipient
tx-sender >--- PING ----------> tx-recipient
tx-sender <--- PONG ----------< tx-recipient
tx-sender disconnects
```

### How to verify the changes you have done?

```bash
cargo test -p floresta-wire -p floresta-node --lib
```