### PR TITLE
Add `cargo-audit` CI job

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0009", # blame: time@0.3.45 (unpatchable, time > v0.3.45 needs 1.88.0)
+    "RUSTSEC-2025-0057", # blame: fxhash@0.2.1 (unmaintained, pulled in by kv@0.24.0)
+    "RUSTSEC-2024-0384", # blame: instant@0.1.13 (unmaintained, pulled in by kv@0.24.0)
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,26 @@ on:
 permissions: {}
 
 jobs:
+    cargo-audit:
+        name: Cargo Audit
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Setup Build Cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+            - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
     shellcheck:
         name: ShellCheck
         runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #999 

This PR adds a `cargo-audit` job to CI and `.cargo/audit.toml`.

Three advisories are ignored:
- `RUSTSEC-2026-0009`: unfixable, since `time` >0.3.45 requires Rust 1.88.0
- `RUSTSEC-2025-0057`: unfixable, `fxhash` is unmaintained, pulled in by `kv`
- `RUSTSEC-2024-0384`: unfixable, `instant` is unmaintained, pulled in by `kv` 


## Changelog
```
- Add `cargo-audit` job to CI
- Ignore unfixable RUSTSECs
``` 