### PR TITLE
fix(doc): Update Homebrew install command in build-macos.md

### DIFF
--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -26,7 +26,7 @@ Note: If you run into issues while installing Homebrew or pulling packages, refe
 On the Terminal, using Homebrew, run the following:
 ```bash
 brew update
-brew install gcc pkg-config
+brew install boost cmake gcc pkgconf
 ```
 You'll need Rust and Cargo, refer to [this](https://www.rust-lang.org/) for more details. Minimum support version is rustc 1.74 and newer.
 


### PR DESCRIPTION
### Description and Notes

Added boost installation to Homebrew command for macOS build.

Cherry-picked from #977, since the author didn't fix CI problems in over a month.