### PR TITLE
fix(electrum): detect TLS handshake on plaintext port

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -44,6 +44,7 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::trace;
+use tracing::warn;
 
 use crate::get_arg;
 use crate::json_rpc_res;
@@ -107,7 +108,15 @@ impl<S: AsyncStream> TcpActor<S> {
                             break;
                         }
                         Err(e) => {
-                            error!("Error reading from client: {e:?}");
+                            if e.kind() == std::io::ErrorKind::InvalidData {
+                                warn!(
+                                    "Error reading from client: {e:?}. Perhaps you are sending \
+                                     TLS traffic on a cleartext stream? Disable TLS in your \
+                                     wallet, or connect to the SSL Electrum port instead."
+                                );
+                            } else {
+                                warn!("Error reading from client: {e:?}");
+                            }
                             self.message_transmitter
                                 .send(Message::Disconnect(self.client_id))
                                 .expect("Main loop is broken");


### PR DESCRIPTION
This PR detects when a wallet configured for TLS connects to the plaintext Electrum port and gives the operator an actionable error instead of an opaque one. Such a wallet sends a TLS ClientHello starting with `0x16`, which the plaintext line reader currently rejects with `stream did not contain valid UTF-8`. 

The fix peeks the first byte of each new plaintext connection in `client_accept_loop`; if it is `0x16`, it logs an actionable warning and drops the connection. The peek is bounded by a 5s timeout so a silent client cannot park the accept loop. Also downgrades the non-UTF-8 read error from `error!` to `warn!`. 


Closes #1100.