### PR TITLE
chore: bump bitcoinkernel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,32 +86,22 @@ jobs:
           brew update
           brew install boost
 
-      - name: Install Boost (Windows)
+      - name: Install Boost library
         if: runner.os == 'Windows'
-        shell: bash
         run: |
-          triplet=x64-windows
-          vcpkgRoot="${VCPKG_INSTALLATION_ROOT:-C:/vcpkg}"
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg
+          .\bootstrap-vcpkg.bat
+          .\vcpkg install boost-multi-index:x64-windows-static boost-headers:x64-windows-static
+          echo "VCPKG_ROOT=$env:GITHUB_WORKSPACE\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "$env:GITHUB_WORKSPACE\vcpkg\installed\x64-windows-static\lib" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-          # Pin vcpkg to the baseline vendored by libbitcoinkernel-sys's Bitcoin Core subtree
-          # (2025.08.27 release; matches bitcoin/vcpkg.json in the crate's vendored source)
-          git -C "$vcpkgRoot" fetch --depth=1 origin 120deac3062162151622ca4860575a33844ba10b
-          git -C "$vcpkgRoot" checkout 120deac3062162151622ca4860575a33844ba10b
-
-          "$vcpkgRoot/bootstrap-vcpkg.bat"
-
-          "$vcpkgRoot/vcpkg.exe" install \
-          boost-system \
-          boost-filesystem \
-          boost-thread \
-          boost-multi-index \
-          --triplet "$triplet" \
-          --clean-after-build \
-          --disable-metrics
-
-          boostRoot="$vcpkgRoot/installed/$triplet"
-
-          echo "BOOST_ROOT=$boostRoot" >> "$GITHUB_ENV"
+      - name: Set environment variables for static linking
+        if: runner.os == 'windows'
+        run: |
+          echo "BOOST_ROOT=$env:GITHUB_WORKSPACE\vcpkg\installed\x64-windows-static" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "BOOST_INCLUDEDIR=$env:GITHUB_WORKSPACE\vcpkg\installed\x64-windows-static\include" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "BOOST_LIBRARYDIR=$env:GITHUB_WORKSPACE\vcpkg\installed\x64-windows-static\lib" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # Bi-weekly numbers to refresh caches every two weeks, ensuring recent project changes are cached
       - name: Set bi-weekly cache key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,26 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.1",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bip324"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoinkernel"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9c800b68ef4ad5c3bf1d668375433934b97faaa487758b7b8aadff42764c2d"
+checksum = "2af4fd16f643d5bc585073c8513a9fde0a72278a38d0957b78cfd8f2c21bbb36"
 dependencies = [
  "libbitcoinkernel-sys",
 ]
@@ -493,15 +473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-expr"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,17 +530,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1386,12 +1346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,11 +1814,10 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbitcoinkernel-sys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35576852961d85614bb5dd3f8a3283b2c4b4310d9dc306f07b4b0b6a6b039eeb"
+checksum = "2906bc31f02dff7af9611fe9129c9eae021bd359f9d8e79824026fe1aaf28ab1"
 dependencies = [
- "bindgen",
  "cc",
 ]
 
@@ -1882,16 +1835,6 @@ checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2547,12 +2490,6 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
-bitcoinkernel = { version = "=0.2.0", optional = true }
+bitcoinkernel = { version = "=0.2.1", optional = true }
 lru = { version = "=0.16.4", optional = true }
 memmap2 = { version = "=0.9.10", optional = true }
 rustreexo = { workspace = true }


### PR DESCRIPTION
### Description and Notes

Bump `rust-bitcoinkernel` to latest version.

It seems boost changed something and building is breaking for new systems. I've got this when trying to build on a fresh new Arch Linux VM. It seems the problem was already fixed upstream, and just bumping it should fix.