### PR TITLE
docs(cli): document gettransaction and findtxout RPCs

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -228,8 +228,13 @@ pub enum Methods {
         blockhash: Option<BlockHash>,
     },
 
-    /// Returns the transaction, assuming it is cached by our watch only wallet
-    #[command(name = "gettransaction")]
+    #[doc = include_str!("../../../doc/rpc/gettransaction.md")]
+    #[command(
+        name = "gettransaction",
+        about = "Returns detailed information about a transaction cached in the watch-only wallet database.",
+        long_about = Some(include_str!("../../../doc/rpc/gettransaction.md")),
+        disable_help_subcommand = true
+    )]
     GetTransaction { txid: Txid, verbose: Option<bool> },
 
     #[doc = include_str!("../../../doc/rpc/rescanblockchain.md")]
@@ -389,7 +394,13 @@ pub enum Methods {
         node_id: Option<usize>,
     },
 
-    #[command(name = "findtxout")]
+    #[doc = include_str!("../../../doc/rpc/findtxout.md")]
+    #[command(
+        name = "findtxout",
+        about = "Attempts to find a transaction output (UTXO) in the blockchain using compact block filters.",
+        long_about = Some(include_str!("../../../doc/rpc/findtxout.md")),
+        disable_help_subcommand = true
+    )]
     FindTxOut {
         txid: Txid,
         vout: u32,

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -54,11 +54,7 @@ pub trait FlorestaRPC {
     #[doc = include_str!("../../../doc/rpc/getdeploymentinfo.md")]
     fn get_deployment_info(&self, blockhash: Option<BlockHash>) -> Result<GetDeploymentInfo>;
 
-    /// Gets a transaction from the blockchain
-    ///
-    /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
-    /// set to false, the transaction is returned as a hexadecimal string. If the verbosity
-    /// flag is set to true, the transaction is returned as a json object.
+    #[doc = include_str!("../../../doc/rpc/gettransaction.md")]
     fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value>;
     /// Returns the proof that one or more transactions were included in a block
     ///
@@ -129,11 +125,7 @@ pub trait FlorestaRPC {
     /// The peer can be referenced either by node_address or node_id.
     /// If referencing by node_id, an empty string must be passed as the node_address.
     fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value>;
-    /// Finds an specific utxo in the chain
-    ///
-    /// You can use this to look for a utxo. If it exists, it will return the amount and
-    /// scriptPubKey of this utxo. It returns an empty object if the utxo doesn't exist.
-    /// You must have enabled block filters by setting the `blockfilters=1` option.
+    #[doc = include_str!("../../../doc/rpc/findtxout.md")]
     fn find_tx_out(
         &self,
         tx_id: Txid,

--- a/doc/rpc/findtxout.md
+++ b/doc/rpc/findtxout.md
@@ -1,0 +1,57 @@
+# `findtxout`
+
+Attempts to find a transaction output (UTXO) in the blockchain using compact block filters, even if it is not currently tracked/cached by the wallet.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli findtxout <txid> <vout> <script> [height_hint]
+```
+
+### Examples
+
+```bash
+# Find a UTXO starting the scan from block height 800000
+floresta-cli findtxout "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b" 0 "76a91462e905b400ac30f81e85fcfcffc89f54f9b84a1488ac" 800000
+
+# Find a UTXO scanning from genesis (height_hint = 0)
+floresta-cli findtxout "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b" 0 "76a91462e905b400ac30f81e85fcfcffc89f54f9b84a1488ac"
+```
+
+## Arguments
+
+- `txid` - (string, required) The transaction ID (hex-encoded).
+- `vout` - (numeric, required) The output index (vout) to find.
+- `script` - (string, required) The hex-encoded locking script (scriptPubKey) of the output.
+- `height_hint` - (numeric, optional, default=0) The block height from which to start scanning the compact block filters. Providing a hint close to the block height where the transaction was mined significantly reduces scan times.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON object representing the UTXO details (if found):
+- `best_block` - (string) The hash of the best block tip.
+- `confirmations` - (numeric) The number of confirmations.
+- `value` - (numeric) The output value in BTC.
+- `script_pubkey` - (json object) Information about the output script:
+  - `asm` - (string) Assembly representation of the scriptPubKey.
+  - `hex` - (string) Hex representation of the scriptPubKey.
+  - `descriptor` - (string, optional) Descriptor with checksum.
+  - `address` - (string, optional) The associated Bitcoin address.
+  - `type` - (string) The script type (e.g. pubkeyhash).
+- `coinbase` - (boolean) Whether the output was created in a coinbase transaction.
+
+If the UTXO is not found, an empty JSON object `{}` is returned.
+
+### Error Enum
+
+* `JsonRpcError::InInitialBlockDownload` - If the node is currently in Initial Block Download (IBD) mode.
+* `JsonRpcError::NoBlockFilters` - If compact block filters are not enabled (`blockfilters=1` option).
+
+## Notes
+
+- This is a Floresta-flavored RPC method and is not part of the standard Bitcoin Core RPC interface.
+- It scans the compact block filters (`BIP 157/158`) matching the provided `script`. If there is a match, the node downloads the corresponding block, processes it to update the wallet state, and retrieves the UTXO details.
+- To use this RPC, you must have enabled block filters by setting the `blockfilters=1` option in your configuration.

--- a/doc/rpc/gettransaction.md
+++ b/doc/rpc/gettransaction.md
@@ -1,0 +1,70 @@
+# `gettransaction`
+
+Returns detailed information about a transaction cached in the watch-only wallet database.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli gettransaction <txid> [verbose]
+```
+
+### Examples
+
+```bash
+# Get transaction details
+floresta-cli gettransaction "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+
+# Get verbose transaction details
+floresta-cli gettransaction "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b" true
+```
+
+## Arguments
+
+- `txid` - (string, required) The transaction ID (hex-encoded).
+- `verbose` - (boolean, optional, default=false) If true, returns detailed JSON information. If false, returns a similar structure but with default verbosity. Note that in Floresta both verbose and non-verbose settings return a detailed transaction JSON object if the transaction is found.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON object:
+- `in_active_chain` - (boolean) Whether the transaction is in the active chain.
+- `hex` - (string) The serialized, hex-encoded transaction data.
+- `txid` - (string) The transaction ID (hex-encoded).
+- `hash` - (string) The witness transaction ID (wtxid, hex-encoded).
+- `size` - (numeric) The total transaction size in bytes.
+- `vsize` - (numeric) The virtual transaction size in vbytes.
+- `weight` - (numeric) The transaction weight.
+- `version` - (numeric) The transaction version.
+- `locktime` - (numeric) The lock time.
+- `vin` - (json array) The transaction inputs:
+  - `txid` - (string) The transaction ID of the spent output.
+  - `vout` - (numeric) The output index of the spent output.
+  - `script_sig` - (json object) The script signature:
+    - `asm` - (string) Assembly representation of the scriptSig.
+    - `hex` - (string) Hex representation of the scriptSig.
+  - `sequence` - (numeric) The input sequence number.
+  - `witness` - (json array of strings) Hex-encoded witness stack elements.
+- `vout` - (json array) The transaction outputs:
+  - `value` - (numeric) The output value in satoshis.
+  - `n` - (numeric) The output index.
+  - `script_pub_key` - (json object) The locking script:
+    - `asm` - (string) Assembly representation of the scriptPubKey.
+    - `hex` - (string) Hex representation of the scriptPubKey.
+    - `req_sigs` - (numeric) Number of required signatures (deprecated).
+    - `type` - (string) The scriptPubKey type (e.g. pubkeyhash, scripthash, witness_v0_keyhash, etc.).
+    - `address` - (string, optional) The Bitcoin address associated with this output.
+- `blockhash` - (string) The hash of the block containing this transaction.
+- `confirmations` - (numeric) The number of confirmations.
+- `blocktime` - (numeric) The block time expressed in UNIX epoch time.
+- `time` - (numeric) Same as blocktime.
+
+### Error Enum `TxNotFound`
+
+* `JsonRpcError::TxNotFound` - The transaction was not found in the watch-only wallet cache.
+
+## Notes
+
+- This command only returns transactions that are cached or tracked by the watch-only wallet. It does not scan the entire blockchain for arbitrary untracked transactions.


### PR DESCRIPTION


### Description and Notes

This PR is Part 3 of the RPC documentation cleanup. It adds detailed markdown documentation for the following three RPC methods:
* **`gettransaction`**
* **`findtxout`**

**Changes introduced:**
* Added new markdown documentation files in `doc/rpc/` for each method, detailing synopsis, usage, arguments, returns, and notes.
* Wired the markdown files into `bin/floresta-cli/src/main.rs` using `#[doc = include_str!(...)]` to integrate them directly into Clap's CLI help menu.
* Wired the markdown files to their corresponding methods inside the `FlorestaRPC` trait definition in `crates/floresta-rpc/src/rpc.rs`.

---

### How to verify the changes

1. **CLI Help Output**: You can build the project and check that the documentation displays properly in the CLI help messages:
   ```bash
   cargo run --bin floresta-cli -- help gettransaction
   cargo run --bin floresta-cli -- help findtxout
   ```
2. **Compilation**: Checked that all crates compile successfully:
   ```bash
   cargo check
   ```
3. **Tests**: Ran the library and unit tests (ran with single-threaded execution to prevent parallel port conflict errors):
   ```bash
   cargo test -p floresta-rpc --lib -- --test-threads=1
   ```