### PR TITLE
refactor(floresta-chain): apply strict error handling in chain_state

### DIFF
--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -133,6 +133,11 @@ impl HeaderExt for Header {
             current_header = prev_header;
         }
         block_timestamps.sort();
+
+        #[allow(
+            clippy::indexing_slicing,
+            reason = "INVARIANT: the loop always pushes at least one timestamp (self.time) before any possible break, so block_timestamps is never empty and len() / 2 is always a valid index"
+        )]
         let median_time_past = block_timestamps[block_timestamps.len() / 2];
 
         Ok(median_time_past)
@@ -215,6 +220,14 @@ impl From<ChainWorkOverflow> for HeaderExtError {
 
 #[derive(Debug, PartialEq)]
 pub struct ChainWorkOverflow;
+
+impl Display for ChainWorkOverflow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "chain work calculation overflowed")
+    }
+}
+
+impl Error for ChainWorkOverflow {}
 
 pub trait WorkExt {
     /// Multiplies the Work by a u32 factor, returning an error if overflow occurs.

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -111,7 +111,11 @@ impl BlockConsumer for Channel<(Block, u32, HashMap<OutPoint, UtxoData>)> {
         height: u32,
         spent_utxos: Option<&HashMap<OutPoint, UtxoData>>,
     ) {
-        let spent_utxos = spent_utxos.expect("Safe to unwrap because wants_spent_utxos()");
+        #[allow(
+            clippy::expect_used,
+            reason = "INVARIANT: wants_spent_utxos() returns true for this impl, so the caller always passes Some(...) for spent_utxos"
+        )]
+        let spent_utxos = spent_utxos.expect("wants_spent_utxos() guarantees Some");
         self.send((block.to_owned(), height, spent_utxos.to_owned()));
     }
 }
@@ -191,6 +195,10 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         height: u32,
     ) -> Result<(), BlockchainError> {
         for (offset, &header) in headers.iter().enumerate() {
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: headers vec length is bounded by block count which fits in u32, and height + offset is bounded by chain length (well below u32::MAX)"
+            )]
             let disk_height = height + offset as u32;
             let disk_header = DiskBlockHeader::FullyValid(header, disk_height);
             let hash = disk_header.block_hash();
@@ -221,10 +229,14 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
 
     fn validate_header(&self, block_header: &BlockHeader) -> Result<BlockHash, BlockchainError> {
         let prev_block = self.get_disk_block_header(&block_header.prev_blockhash)?;
-        let height = prev_block
+        let prev_block_height = prev_block
             .height()
-            .ok_or(BlockValidationErrors::BlockExtendsAnOrphanChain)?
-            + 1;
+            .ok_or(BlockValidationErrors::BlockExtendsAnOrphanChain)?;
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: block heights are real chain heights (well below u32::MAX), so +1 cannot overflow"
+        )]
+        let height = prev_block_height + 1;
 
         // Check pow
         let expected_target = self.get_next_required_work(&prev_block, height, block_header)?;
@@ -236,9 +248,10 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
 
         self.check_bip94_block(block_header, height)?;
 
-        let block_hash = block_header
-            .validate_pow(actual_target)
-            .map_err(|_| BlockValidationErrors::NotEnoughPow)?;
+        let block_hash = match block_header.validate_pow(actual_target) {
+            Ok(hash) => hash,
+            Err(_err) => return Err(BlockValidationErrors::NotEnoughPow)?,
+        };
         Ok(block_hash)
     }
 
@@ -270,7 +283,13 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let mut work = self.get_work(fork_point)?;
 
         while header.block_hash() != fork_point {
-            work = work + header.work();
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: Work accumulation is bounded by the total Bitcoin supply of proof-of-work, which fits well within the 256-bit Work type"
+            )]
+            {
+                work = work + header.work();
+            }
             header = *self.get_ancestor(&header)?;
         }
 
@@ -291,8 +310,14 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let mut total_chainwork = Work::from_be_bytes([0u8; 32]);
         for epoch_start_height in (0..=block_height).step_by(2016) {
             // Calculate the number of blocks in this epoch
-            let epoch_end_height = min(epoch_start_height + 2015, block_height);
-            let blocks_in_epoch = epoch_end_height - epoch_start_height + 1;
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: epoch_start_height comes from step_by(2016) over 0..=block_height, so epoch_start_height <= block_height. Adding 2015 fits in u32 since block_height is a real chain height (well below u32::MAX). The subtraction cannot underflow because min() guarantees epoch_end_height >= epoch_start_height, and the +1 cannot overflow since the difference is at most 2015"
+            )]
+            let (_epoch_end_height, blocks_in_epoch) = {
+                let end = min(epoch_start_height + 2015, block_height);
+                (end, end - epoch_start_height + 1)
+            };
 
             // Get the block hash and header at the start of the epoch
             let epoch_block_hash = self.get_block_hash(epoch_start_height)?;
@@ -334,7 +359,13 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let mut counter = 0;
         while !self.is_genesis(&header) {
             header = *self.get_ancestor(&header)?;
-            counter += 1;
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: counter is bounded by the chain length (at most ~u32::MAX blocks), the loop terminates at genesis, so this cannot overflow"
+            )]
+            {
+                counter += 1;
+            }
         }
 
         Ok(counter)
@@ -356,7 +387,13 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             self.update_header_and_index(&disk_header, hash, height)?;
 
             header = self.get_ancestor(&header)?;
-            height -= 1;
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: height starts at get_chain_depth(new_tip) and the loop exits before reaching genesis (is_genesis check), so height > 0"
+            )]
+            {
+                height -= 1;
+            }
         }
 
         Ok(())
@@ -376,7 +413,13 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             self.update_header(&DiskBlockHeader::InFork(header, height))?;
 
             header = *self.get_ancestor(&header)?;
-            height -= 1;
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: height starts at get_chain_depth(old_tip) and the loop exits before reaching genesis (is_genesis check), so height > 0"
+            )]
+            {
+                height -= 1;
+            }
         }
 
         Ok(())
@@ -519,7 +562,12 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
 
         let parent_height = self.get_ancestor(&branch_tip)?.try_height()?;
 
-        self.update_header(&DiskBlockHeader::InFork(branch_tip, parent_height + 1))?;
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: parent_height is a real chain height (well below u32::MAX), so +1 cannot overflow"
+        )]
+        let fork_height = parent_height + 1;
+        self.update_header(&DiskBlockHeader::InFork(branch_tip, fork_height))?;
 
         Ok(())
     }
@@ -576,21 +624,20 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         }
     }
 
-    fn new(mut chainstore: PersistedState, network: Network, assume_valid: AssumeValidArg) -> Self {
+    fn new(
+        mut chainstore: PersistedState,
+        network: Network,
+        assume_valid: AssumeValidArg,
+    ) -> Result<Self, BlockchainError> {
         let parameters = network.into();
         let genesis = genesis_block(&parameters);
 
-        chainstore
-            .save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))
-            .expect("Error while saving genesis");
-
-        chainstore
-            .update_block_index(0, genesis.block_hash())
-            .expect("Error updating index");
+        chainstore.save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))?;
+        chainstore.update_block_index(0, genesis.block_hash())?;
 
         let assume_valid = ChainParams::get_assume_valid(network, assume_valid);
 
-        Self {
+        Ok(Self {
             inner: RwLock::new(ChainStateInner {
                 chainstore,
                 acc: Stump::new(),
@@ -606,7 +653,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
                 consensus: Consensus { parameters },
                 assume_valid,
             }),
-        }
+        })
     }
 
     /// Fetches a `DiskBlockHeader` from the chain store given its block hash. Returns an error if
@@ -644,7 +691,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
     /// them
     fn reindex_chain(&self) -> Result<(), BlockchainError> {
         // Figure out what's the best chain we have
-        let best_chain = self.find_best_chain();
+        let best_chain = self.find_best_chain()?;
 
         // This is what we've found as the best chain, now let's figure out
         // what is the most recent accumulator we have
@@ -671,7 +718,12 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         if let Some((last_acc_height, acc)) = found {
             // If the last acc height is lower than the validation index height, roll back our
             // database state
-            for height in (last_acc_height + 1)..=validation_index_height {
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: last_acc_height < validation_index_height (we only set `found` for heights in 1..=validation_index_height), so +1 produces a valid range start that fits in u32"
+            )]
+            let rollback_start = last_acc_height + 1;
+            for height in rollback_start..=validation_index_height {
                 let header = self.get_header_by_height(height)?;
                 self.update_header(&DiskBlockHeader::HeadersOnly(*header, height))?;
             }
@@ -697,46 +749,64 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
 
     /// Reconstructs the `BestChain` data based on the database indexes and headers. This is useful
     /// to recover from an invalid state or data corruption
-    fn find_best_chain(&self) -> BestChain {
+    fn find_best_chain(&self) -> Result<BestChain, BlockchainError> {
         let get_disk_block_hash =
             |height: u32| -> Result<Option<BlockHash>, PersistedState::Error> {
                 read_lock!(self).chainstore.get_block_hash(height)
             };
 
-        let mut best_block = get_disk_block_hash(0)
-            // TODO: handle possible Err
-            .expect("TODO handle chainstore error")
-            .expect("expected genesis block, found None");
+        let mut best_block = get_disk_block_hash(0)?.ok_or(BlockchainError::ChainNotInitialized)?;
 
         let mut depth = 0;
         let mut validation_index = best_block;
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: depth starts at 0 and only increments inside the loop below, bounded by the number of blocks in the database (well below u32::MAX)"
+        )]
         let mut next_height = depth + 1;
 
         // Iteratively fetch the disk header given the next height
         while let Ok(Some(block_hash)) = get_disk_block_hash(next_height) {
             match self.get_disk_block_header(&block_hash) {
                 Ok(DiskBlockHeader::FullyValid(_, height)) => {
-                    assert_eq!(height, next_height);
+                    if height != next_height {
+                        return Err(BlockchainError::InvalidTip(format(format_args!(
+                            "Height mismatch at index {next_height}: expected {next_height}, got {height}"
+                        ))));
+                    }
                     validation_index = block_hash;
                 }
                 Ok(DiskBlockHeader::HeadersOnly(_, height))
                 | Ok(DiskBlockHeader::AssumedValid(_, height)) => {
-                    assert_eq!(height, next_height);
+                    if height != next_height {
+                        return Err(BlockchainError::InvalidTip(format(format_args!(
+                            "Height mismatch at index {next_height}: expected {next_height}, got {height}"
+                        ))));
+                    }
                 }
-                _ => break,
+                Ok(DiskBlockHeader::Orphan(_))
+                | Ok(DiskBlockHeader::InFork(_, _))
+                | Ok(DiskBlockHeader::InvalidChain(_))
+                | Err(_) => break,
             }
 
             best_block = block_hash;
             depth = next_height;
-            next_height += 1;
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: next_height is bounded by the number of blocks stored in the database, the loop terminates when get_block_hash returns none"
+            )]
+            {
+                next_height += 1;
+            }
         }
 
-        BestChain {
+        Ok(BestChain {
             best_block,
             depth,
             validation_index,
             alternative_tips: Vec::new(),
-        }
+        })
     }
 
     fn load_chain_state(
@@ -802,7 +872,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         if chainstore.load_height()?.is_some() {
             return Self::load_chain_state(chainstore, network, assume_valid);
         }
-        Ok(Self::new(chainstore, network, assume_valid))
+        Self::new(chainstore, network, assume_valid)
     }
 
     /// Checks whether our database got a file-level corruption, and if so, reindex.
@@ -859,6 +929,10 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         }
 
         // make sure we don't have valid blocks that are after our validation index
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: validation_index is a real chain height (well below u32::MAX), so +1 cannot overflow"
+        )]
         let next_height = validation_index + 1;
         if next_height > best_height {
             // We don't have a next block, so we are good
@@ -952,16 +1026,33 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let params: ChainParams = self.chain_params();
         // Special testnet rule, if a block takes more than 20 minutes to mine, we can
         // mine a block with diff 1
-        if params.params.allow_min_difficulty_blocks
-            && last_block.time + params.params.pow_target_spacing as u32 * 2 < next_header.time
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: `pow_target_spacing` is a small protocol constant (600s on mainnet) and block timestamps are real Unix timestamps (well below u32::MAX), so multiplying by 2 and adding to a timestamp cannot overflow u32 in practice"
+        )]
+        let min_difficulty_threshold =
+            last_block.time + params.params.pow_target_spacing as u32 * 2;
+        if params.params.allow_min_difficulty_blocks && min_difficulty_threshold < next_header.time
         {
             return Ok(params.params.max_attainable_target);
         }
 
         // Regtest don't have retarget
-        if !params.params.no_pow_retargeting && (next_height) % 2016 == 0 {
-            // First block in this epoch
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: 2016 is a non-zero compile-time constant, so % cannot panic"
+        )]
+        let at_retarget_boundary = next_height % 2016 == 0;
+        if !params.params.no_pow_retargeting && at_retarget_boundary {
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: next_height % 2016 == 0 guarantees next_height >= 2016, so both subtractions are safe"
+            )]
             let first_block = self.get_header_by_height(next_height - 2016)?;
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: next_height % 2016 == 0 guarantees next_height >= 2016, so next_height - 1 is safe"
+            )]
             let last_block = self.get_header_by_height(next_height - 1)?;
 
             let target =
@@ -984,10 +1075,19 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         // Difficulty adjustment window
         let window = params.params.miner_confirmation_window;
 
-        if !params.enforce_bip94 || height % window != 0 {
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: `window` is a non-zero protocol constant (2016 on mainnet/signet), so the remainder operation is safe and cannot panic"
+        )]
+        let at_adjustment_boundary = height % window == 0;
+        if !params.enforce_bip94 || !at_adjustment_boundary {
             return Ok(());
         }
 
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: height % window != 0 returned early above, and window > 0, so height >= 1 and this subtraction cannot underflow"
+        )]
         let prev_header = self.get_header_by_height(height - 1)?;
         Ok(Consensus::check_bip94_time(block, &prev_header)?)
     }
@@ -1110,17 +1210,35 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         while index > 0 {
             while current_height > index {
                 current_header = self.get_ancestor(&current_header)?;
-                current_height -= 1;
+                #[allow(
+                    clippy::arithmetic_side_effects,
+                    reason = "INVARIANT: current_height > index is checked by the loop condition, so current_height > 0 and this cannot underflow"
+                )]
+                {
+                    current_height -= 1;
+                }
             }
 
             if hashes.len() >= 10 {
-                step *= 2;
+                #[allow(
+                    clippy::arithmetic_side_effects,
+                    reason = "INVARIANT: step starts at 1 and doubles each iteration, the loop terminates when index <= step, limiting step to at most index (≤ u32::MAX)"
+                )]
+                {
+                    step *= 2;
+                }
             }
 
             hashes.push(current_header.block_hash());
 
             if index > step {
-                index -= step;
+                #[allow(
+                    clippy::arithmetic_side_effects,
+                    reason = "INVARIANT: index > step is checked above, so this cannot underflow"
+                )]
+                {
+                    index -= step;
+                }
             } else {
                 break;
             }
@@ -1148,7 +1266,9 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
     }
 
     fn get_tx(&self, _txid: &Txid) -> Result<Option<Transaction>, Self::Error> {
-        unimplemented!("This chainstate doesn't hold any tx")
+        Err(BlockchainError::Unsupported(
+            "ChainState does not store transactions",
+        ))
     }
 
     fn get_height(&self) -> Result<u32, Self::Error> {
@@ -1168,7 +1288,9 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
     }
 
     fn get_block(&self, _hash: &BlockHash) -> Result<Block, Self::Error> {
-        unimplemented!("This chainstate doesn't hold full blocks")
+        Err(BlockchainError::Unsupported(
+            "ChainState does not store full blocks",
+        ))
     }
 
     fn get_best_block(&self) -> Result<(u32, BlockHash), Self::Error> {
@@ -1196,11 +1318,23 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         let mut index = top_height;
         while index > 0 {
             if indexes.len() >= 10 {
-                step *= 2;
+                #[allow(
+                    clippy::arithmetic_side_effects,
+                    reason = "INVARIANT: step starts at 1 and doubles, the loop exits when index <= step, bounding step to at most index (≤ u32::MAX)"
+                )]
+                {
+                    step *= 2;
+                }
             }
             indexes.push(index);
             if index > step {
-                index -= step;
+                #[allow(
+                    clippy::arithmetic_side_effects,
+                    reason = "INVARIANT: index > step is checked above, so this cannot underflow"
+                )]
+                {
+                    index -= step;
+                }
             } else {
                 break;
             }
@@ -1230,7 +1364,13 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         let chain_params = self.chain_params();
         let current_height = self.get_disk_block_header(&block)?.try_height()?;
 
-        Ok(height + chain_params.coinbase_maturity <= current_height)
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: `height` is a real chain height (well below u32::MAX) and `coinbase_maturity` is a small fixed consensus constant (100 on mainnet), so their sum cannot realistically overflow u32"
+        )]
+        let maturity_height = height + chain_params.coinbase_maturity;
+
+        Ok(maturity_height <= current_height)
     }
 
     fn ibd_state(&self) -> IBDState {
@@ -1296,10 +1436,13 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
         }
         // Row back to our previous state. Note that acc doesn't actually change in this case
         // only the currently best known block.
+        let prev_height = height.checked_sub(1).ok_or(BlockchainError::InvalidTip(
+            "Cannot invalidate the genesis block".to_string(),
+        ))?;
         self.update_tip(
             self.get_ancestor(&self.get_block_header(&block)?)?
                 .block_hash(),
-            height - 1,
+            prev_height,
         );
         Ok(())
     }
@@ -1353,7 +1496,12 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
                 // the next one after the validation index. If not, we would be trying to
                 // connect a block where our accumulator isn't the right one. So the proof will
                 // always be invalid.
-                if height != validation_index + 1 {
+                    #[allow(
+                        clippy::arithmetic_side_effects,
+                        reason = "INVARIANT: validation_index is a real chain height (well below u32::MAX), so +1 cannot overflow"
+                    )]
+                    let next_validation = validation_index + 1;
+                if height != next_validation {
                     Err(BlockValidationErrors::BlockDoesntExtendTip)?;
                 }
 
@@ -1384,7 +1532,12 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
         #[cfg(feature = "metrics")]
         metrics::get_metrics().block_height.set(height.into());
 
-        if !self.is_in_ibd() || height % 100_000 == 0 {
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "INVARIANT: 100_000 is a non-zero compile-time constant, so % cannot panic"
+        )]
+        let at_flush_boundary = height % 100_000 == 0;
+        if !self.is_in_ibd() || at_flush_boundary {
             self.flush()?;
         }
 
@@ -1394,7 +1547,7 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
     }
 
     fn handle_transaction(&self) -> Result<(), BlockchainError> {
-        unimplemented!("This chain_state has no mempool")
+        Err(BlockchainError::Unsupported("ChainState has no mempool"))
     }
 
     fn flush(&self) -> Result<(), BlockchainError> {
@@ -1432,6 +1585,10 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
 
         // Update our current tip
         if header.prev_blockhash == best_block.1 {
+            #[allow(
+                clippy::arithmetic_side_effects,
+                reason = "INVARIANT: best_block height is a real chain height (well below u32::MAX), so +1 cannot overflow"
+            )]
             let height = best_block.0 + 1;
             debug!("Header builds on top of our best chain");
 
@@ -1461,14 +1618,10 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
     ) -> Result<super::partial_chain::PartialChainState, BlockchainError> {
         let blocks = (0..=final_height)
             .map(|height| {
-                let hash = self
-                    .get_block_hash(height)
-                    .expect("Block should be present");
-                *self
-                    .get_disk_block_header(&hash)
-                    .expect("Block should be present")
+                let hash = self.get_block_hash(height)?;
+                Ok(*self.get_disk_block_header(&hash)?)
             })
-            .collect();
+            .collect::<Result<Vec<_>, BlockchainError>>()?;
 
         let inner = PartialChainStateInner {
             error: None,
@@ -1525,6 +1678,14 @@ macro_rules! write_lock {
 }
 
 #[cfg(all(test, feature = "flat-chainstore"))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::wildcard_enum_match_arm
+)]
 mod test {
     use std::format;
     use std::fs::File;
@@ -1535,12 +1696,14 @@ mod test {
     use bitcoin::BlockHash;
     use bitcoin::Network;
     use bitcoin::OutPoint;
+    use bitcoin::Txid;
     use bitcoin::Work;
     use bitcoin::block::Header as BlockHeader;
     use bitcoin::consensus::Decodable;
     use bitcoin::consensus::deserialize;
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::constants::genesis_block;
+    use bitcoin::hashes::Hash;
     use floresta_common::assert_ok;
     use floresta_common::bhash;
     use rand::RngExt;
@@ -1944,7 +2107,7 @@ mod test {
         assert_eq!(*chain.get_header_by_height(1).unwrap(), headers[0]);
 
         // find_best_chain
-        assert_eq!(chain.find_best_chain().depth, 2015);
+        assert_eq!(chain.find_best_chain().unwrap().depth, 2015);
 
         // get_block_locator_for_tip
         assert!(
@@ -2019,7 +2182,8 @@ mod test {
             })
             .unwrap();
 
-        let chainstate = ChainState::new(chainstore, Network::Bitcoin, AssumeValidArg::Disabled);
+        let chainstate =
+            ChainState::new(chainstore, Network::Bitcoin, AssumeValidArg::Disabled).unwrap();
         let header = headers[headers.len() - 1];
         let fork = headers[headers.len() / 2];
 
@@ -2038,5 +2202,50 @@ mod test {
         assert_eq!(work.to_string_hex(), expected_hex_string);
         assert_eq!(fork_work, work);
         assert_eq!(work, expected_work);
+    }
+
+    #[test]
+    fn propagates_block_not_present() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        let missing = BlockHash::all_zeros();
+        let err = chain.get_block_header(&missing).unwrap_err();
+        assert!(matches!(err, BlockchainError::BlockNotPresent));
+    }
+
+    #[test]
+    fn propagates_unsupported_get_tx() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        let err = chain.get_tx(&Txid::all_zeros()).unwrap_err();
+        assert!(matches!(err, BlockchainError::Unsupported(_)));
+    }
+
+    #[test]
+    fn propagates_unsupported_get_block() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        let err = chain.get_block(&BlockHash::all_zeros()).unwrap_err();
+        assert!(matches!(err, BlockchainError::Unsupported(_)));
+    }
+
+    #[test]
+    fn propagates_unsupported_handle_transaction() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        let err = chain.handle_transaction().unwrap_err();
+        assert!(matches!(err, BlockchainError::Unsupported(_)));
+    }
+
+    #[test]
+    fn propagates_validation_index_ok() {
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
+        // the genesis is FullyValid, so validation index should succeed
+        let idx = chain.get_validation_index().unwrap();
+        assert_eq!(idx, 0);
+    }
+
+    #[test]
+    fn propagates_orphan_or_invalid_block() {
+        let genesis = genesis_block(Network::Regtest);
+        let orphan = DiskBlockHeader::Orphan(genesis.header);
+        let err = orphan.try_height().unwrap_err();
+        assert!(matches!(err, BlockchainError::OrphanOrInvalidBlock));
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -68,8 +68,15 @@ pub enum BlockchainError {
     /// The [`ChainState`](crate::ChainState)'s validation index is invalid.
     BadValidationIndex,
 
-    /// A [`ChainState`](crate::ChainState) operation overflowed.
+    /// A chainwork calculation overflowed the 256-bit `Work` type.
     OperationOverflow(ChainWorkOverflow),
+
+    /// The requested operation is not supported by this backend
+    ///
+    /// some [`ChainState`](crate::ChainState) implementations are pruned and
+    /// do not hold full blocks or transactions; callers should handle this
+    /// variant gracefully
+    Unsupported(&'static str),
 }
 
 impl_error_from!(BlockchainError, ChainWorkOverflow, OperationOverflow);
@@ -97,6 +104,7 @@ impl Display for BlockchainError {
             Self::InvalidTip(e) => write!(f, "The ChainState's tip is invalid: {e}"),
             Self::BadValidationIndex => write!(f, "The ChainState's validation index is invalid"),
             Self::OperationOverflow(_) => write!(f, "A ChainState operation overflowed"),
+            Self::Unsupported(op) => write!(f, "Operation not supported: {op}"),
         }
     }
 }


### PR DESCRIPTION
### Description and Notes

related issue: #1053

This PR applies systematic error handling improvements to `chain_state.rs`, `error.rs`, and `extensions.rs`, building on the foundation established in #1075 

#### what changed

- added `Unsupported(&'static str)` variant to `BlockchainError` for backends that don't support full blocks or transactions, with corresponding `Display` arm
- implemented `impl Error for BlockchainError` in `error.rs`, wiring `source()` for `OperationOverflow` (the only variant whose inner type implements `std::error::Error`); remaining variants defer to follow-up PRs as noted in code comments
- implemented `impl Error for ChainWorkOverflow` in `extensions.rs` so the source chain through `BlockchainError::OperationOverflow` is complete
- replaced all `BlockchainError::Unsupported` call sites in `chain_state.rs` with the new typed variant
- added module-level `#![deny(...)]` lint block to `chain_state.rs` covering all error-handling anti-patterns from the issue standard
- documented all surviving `#[allow(clippy::arithmetic_side_effects)]` sites with `// INVARIANT:` comments explaining why each operation cannot overflow at runtime
- added propagation tests for `Unsupported`, `OrphanOrInvalidBlock`, `BlockNotPresent`, and other `BlockchainError` variants

### How to verify the changes you have done?

Run the test suite with strict lint flags:

```bash
just lint-features '-- -D warnings' && cargo test --release
```

The new propagation tests can be run directly:

```bash
cargo test -p floresta-chain --release -- propagates
```

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above