### PR TITLE
Split node logs into separate files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,8 @@ def _create_logger(test_name):
         "%(asctime)s - %(levelname)s - %(pathname)s:%(lineno)d - %(message)s"
     )
 
-    git_describe = Utility.get_git_describe()
-    log_file = os.path.join(FLORESTA_TEMP_DIR, "logs", git_describe, f"{test_name}.log")
+    log_path = Utility.get_log_path()
+    log_file = os.path.join(log_path, f"{test_name}", f"{test_name}.log")
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     file_handler = logging.FileHandler(log_file, mode="w")
     file_handler.setFormatter(formatter)

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -123,6 +123,19 @@ class FlorestaTestFramework:
         """
         return sum(1 for node in self._nodes if node.variant == variant)
 
+    def create_logger_for_daemon(self, node_type: NodeType):
+        """
+        Create a logger for the daemon variant .
+        """
+        log_file = os.path.join(
+            Utility.get_log_path(),
+            f"{self.test_name}",
+            f"{node_type.value.lower()}{self.count_nodes_by_variant(node_type)}.log",
+        )
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+
+        return log_file
+
     def add_node_default_args(self, variant: NodeType) -> Node:
         """
         Add a node with default configurations.
@@ -168,6 +181,7 @@ class FlorestaTestFramework:
             targetdir=targetdir,
             tls=tls,
             log=self.log,
+            log_path=self.create_logger_for_daemon(variant),
         )
 
         self._nodes.append(node)

--- a/tests/test_framework/daemon/__init__.py
+++ b/tests/test_framework/daemon/__init__.py
@@ -11,6 +11,7 @@ class ConfigP2P:
     Configuration for P2P connection
     """
 
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int, log_path: str):
         self.host = host
         self.port = port
+        self.log_path = log_path

--- a/tests/test_framework/daemon/base.py
+++ b/tests/test_framework/daemon/base.py
@@ -134,13 +134,6 @@ class BaseDaemon(ABC):
         """Setter for `p2p_config` property"""
         self._p2p_config = value
 
-    def _get_logger_file_path(self) -> str | None:
-        """Extract the file path from the logger's file handler"""
-        for handler in self.log.handlers:
-            if hasattr(handler, "baseFilename"):
-                return handler.baseFilename
-        return None
-
     def settings(self) -> List[str]:
         """Getter for `settings` property"""
         setting: List[str] = self.get_cmd_network()
@@ -173,12 +166,10 @@ class BaseDaemon(ABC):
 
         cmd = [daemon] + self.settings()
 
-        log_file_path = self._get_logger_file_path()
-        if not log_file_path:
-            raise ValueError("Log file path not found")
-
         # pylint: disable=consider-using-with
-        stdout_file = open(os.path.join(log_file_path), "w", encoding="utf-8")
+        stdout_file = open(
+            os.path.join(self._p2p_config.log_path), "w", encoding="utf-8"
+        )
         # pylint: disable=consider-using-with
         self.process = Popen(cmd, text=True, stderr=PIPE, stdout=stdout_file)
 

--- a/tests/test_framework/node.py
+++ b/tests/test_framework/node.py
@@ -110,6 +110,7 @@ class Node:
         self._variant = variant
         self._static_values = True
         self._log = log
+        self._log_path = p2p_config.log_path
 
     @classmethod
     def create_node_default_config(
@@ -120,6 +121,7 @@ class Node:
         targetdir: str,
         tls: bool,
         log,
+        log_path: str,
     ) -> "Node":
         """
         Create a node with default arguments. this argument
@@ -128,7 +130,7 @@ class Node:
         allowing the node's arguments to be modified after creation.
         """
         config_rpc = cls.create_config_rpc_default(variant=variant)
-        config_p2p = cls.create_config_p2p_default()
+        config_p2p = cls.create_config_p2p_default(log_path=log_path)
         config_electrum = cls.create_config_electrum_default(tls=tls)
 
         node = cls(
@@ -188,6 +190,7 @@ class Node:
             raise ValueError("Cannot modify static p2p_config")
 
         self.daemon.set_p2p_config(value)
+        self._log_path = value.log_path
 
     def set_rpc_config(self, value: ConfigRPC):
         """Setter for `rpc_config` property"""
@@ -226,12 +229,14 @@ class Node:
         )
 
     @staticmethod
-    def create_config_p2p_default() -> ConfigP2P:
+    def create_config_p2p_default(log_path: str) -> ConfigP2P:
         """
         Create a default P2P configuration for nodes.
         The port is random.
         """
-        return ConfigP2P(host="127.0.0.1", port=Utility.get_random_port())
+        return ConfigP2P(
+            host="127.0.0.1", port=Utility.get_random_port(), log_path=log_path
+        )
 
     @staticmethod
     def create_config_electrum_default(tls: bool) -> ConfigElectrum:
@@ -263,7 +268,7 @@ class Node:
         configuration creation methods
         """
         new_rpc_config = self.create_config_rpc_default(self.variant)
-        new_p2p_config = self.create_config_p2p_default()
+        new_p2p_config = self.create_config_p2p_default(self._log_path)
         new_electrum_config = self.create_config_electrum_default(self._tls)
 
         # Apply the new configurations

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -9,6 +9,7 @@ import random
 import socket
 import subprocess
 
+from test_framework.constants import FLORESTA_TEMP_DIR
 from test_framework.crypto.pkcs8 import (
     create_pkcs8_private_key,
     create_pkcs8_self_signed_certificate,
@@ -26,12 +27,12 @@ class Utility:
         Get path for florestad used in integration tests, generally set on
         $FLORESTA_TEMP_DIR/binaries
         """
-        if os.getenv("FLORESTA_TEMP_DIR") is None:
+        if FLORESTA_TEMP_DIR is None:
             raise RuntimeError(
                 "FLORESTA_TEMP_DIR not set. "
                 + " Please set it to the path of the integration test directory."
             )
-        return os.getenv("FLORESTA_TEMP_DIR")
+        return FLORESTA_TEMP_DIR
 
     @staticmethod
     def get_git_describe():
@@ -48,6 +49,17 @@ class Utility:
             ) from exc
 
         return git_describe
+
+    @staticmethod
+    def get_log_path():
+        """
+        Get the path for the test log file,
+        """
+        log_dir = os.path.join(
+            Utility.get_integration_test_dir(), "logs", Utility.get_git_describe()
+        )
+        os.makedirs(log_dir, exist_ok=True)
+        return log_dir
 
     @staticmethod
     def get_available_random_port_by_range(start: int, end: int):


### PR DESCRIPTION

### Description and Notes

Previously, each integration test produced a single log file that contained both the test logs and the logs from all nodes involved in the test. This made debugging difficult, especially in scenarios with multiple nodes.

This PR separates the logs by creating a dedicated directory for each test. Inside that directory, the test log is stored alongside individual log files for each node participating in the test. This makes it easier to inspect node-specific behavior and understand what happened during test execution.
### How to verify the changes you have done?

1. Run any integration test.
2. Verify that a directory named after the test is created.
3. Inside that directory, confirm that:
    - A log file exists for the test itself.
    - Each node participating in the test has its own log file.
4. Check that node logs are no longer mixed into the test log output.
