### PR TITLE
chore: bump bip324 0.10.0 -> 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,14 +242,13 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bip324"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e93f07cf774278cf032e8f1d97343a08d079017a33bb20097df380fd55d26c"
+checksum = "a03c45ad0d13f5df3aff10b7fdf6897dba1e9fc819cf932589d48ddba2536c94"
 dependencies = [
- "bitcoin",
  "bitcoin_hashes 0.15.0",
  "chacha20-poly1305",
- "rand 0.8.6",
+ "secp256k1",
  "tokio",
 ]
 
@@ -2618,6 +2617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes 0.14.1",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography::cryptocurrencies", "network-programming"]
 
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
-bip324 = { version = "=0.10.0", features = [ "tokio" ] }
+bip324 = { version = "=0.11.0", features = [ "tokio" ] }
 bitcoin = { workspace = true, features = ["serde"] }
 dns-lookup = { workspace = true }
 rand = { workspace = true }

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -92,6 +92,7 @@ pub mod address_man;
 pub mod bitcoin_socket_addr;
 pub mod block_proof;
 pub mod error;
+pub mod network_message_ext;
 pub mod node;
 pub mod node_context;
 pub mod node_handle;

--- a/crates/floresta-wire/src/p2p_wire/network_message_ext.rs
+++ b/crates/floresta-wire/src/p2p_wire/network_message_ext.rs
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use core::fmt;
+use core::fmt::Formatter;
+
+use bitcoin::VarInt;
+use bitcoin::consensus::Decodable;
+use bitcoin::consensus::Encodable;
+use bitcoin::consensus::encode;
+use bitcoin::p2p::message::CommandString;
+use bitcoin::p2p::message::NetworkMessage;
+
+#[derive(Debug)]
+/// V2 message serialization error.
+pub enum V2MessageError {
+    /// Failed to deserialize a V2 message.
+    Deserialize(encode::Error),
+
+    /// Unknown V2 short message ID.
+    UnknownShortID(u8),
+}
+
+impl fmt::Display for V2MessageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Deserialize(e) => write!(f, "unable to deserialize V2 message: {e}"),
+            Self::UnknownShortID(b) => write!(f, "unrecognized short ID: {b}"),
+        }
+    }
+}
+
+impl core::error::Error for V2MessageError {}
+
+impl From<encode::Error> for V2MessageError {
+    fn from(e: encode::Error) -> Self {
+        Self::Deserialize(e)
+    }
+}
+
+/// Utilities to work with [`NetworkMessage`]s from/to p2p V2.
+///
+/// This code can be removed after we migrate to the enw `bitcoin-p2p` crate.
+pub trait NetworkMessageExt: Sized {
+    /// Serialize a [`NetworkMessage`] into a V2-encoded buffer.
+    ///
+    /// Uses BIP-324 short message IDs for known message types.
+    fn serialize_v2(&self) -> Vec<u8>;
+
+    /// Deserialize a [`NetworkMessage`] from a V2-encoded buffer.
+    fn deserialize_v2(buffer: &[u8]) -> Result<Self, V2MessageError>;
+}
+
+impl NetworkMessageExt for NetworkMessage {
+    /// Serialize a [`NetworkMessage`] into a V2-encoded buffer.
+    ///
+    /// Uses BIP-324 short message IDs for known message types.
+    fn serialize_v2(&self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+
+        // TODO: remove this once https://github.com/rust-bitcoin/rust-bitcoin/pull/5671 and
+        // https://github.com/rust-bitcoin/rust-bitcoin/pull/5009 make it into a release
+        if let Self::Unknown { command, payload } = self {
+            /// P2PV2 BIP-0324 message type for `getuproof`.
+            const P2PV2_GETUPROOF_MSG_TYPE: u8 = 30;
+            // The legacy cmd string for get utreexo proof
+            let get_utreexo_proof_cmd_string: CommandString =
+                CommandString::try_from_static("getuproof")
+                    .expect("`getuproof` is a valid command string");
+
+            if *command == get_utreexo_proof_cmd_string {
+                buffer.push(P2PV2_GETUPROOF_MSG_TYPE);
+                buffer.extend(payload);
+                return buffer;
+            }
+
+            // fall through, will handle this at the bottom of that match bellow.
+        }
+
+        match self {
+            Self::Addr(_) => buffer.push(1u8),
+            Self::Inv(_) => buffer.push(14u8),
+            Self::GetData(_) => buffer.push(11u8),
+            Self::NotFound(_) => buffer.push(17u8),
+            Self::GetBlocks(_) => buffer.push(9u8),
+            Self::GetHeaders(_) => buffer.push(12u8),
+            Self::MemPool => buffer.push(15u8),
+            Self::Tx(_) => buffer.push(21u8),
+            Self::Block(_) => buffer.push(2u8),
+            Self::Headers(_) => buffer.push(13u8),
+            Self::Ping(_) => buffer.push(18u8),
+            Self::Pong(_) => buffer.push(19u8),
+            Self::MerkleBlock(_) => buffer.push(16u8),
+            Self::FilterLoad(_) => buffer.push(8u8),
+            Self::FilterAdd(_) => buffer.push(6u8),
+            Self::FilterClear => buffer.push(7u8),
+            Self::GetCFilters(_) => buffer.push(22u8),
+            Self::CFilter(_) => buffer.push(23u8),
+            Self::GetCFHeaders(_) => buffer.push(24u8),
+            Self::CFHeaders(_) => buffer.push(25u8),
+            Self::GetCFCheckpt(_) => buffer.push(26u8),
+            Self::CFCheckpt(_) => buffer.push(27u8),
+            Self::SendCmpct(_) => buffer.push(20u8),
+            Self::CmpctBlock(_) => buffer.push(4u8),
+            Self::GetBlockTxn(_) => buffer.push(10u8),
+            Self::BlockTxn(_) => buffer.push(3u8),
+            Self::FeeFilter(_) => buffer.push(5u8),
+            Self::AddrV2(_) => buffer.push(28u8),
+            Self::Version(_)
+            | Self::Verack
+            | Self::SendHeaders
+            | Self::GetAddr
+            | Self::WtxidRelay
+            | Self::SendAddrV2
+            | Self::Alert(_)
+            | Self::Reject(_) => {
+                buffer.push(0u8);
+                self.command()
+                    .consensus_encode(&mut buffer)
+                    .expect("Encoding to Vec<u8> never fails");
+            }
+            Self::Unknown {
+                command,
+                payload: _,
+            } => {
+                buffer.push(0u8);
+                command
+                    .consensus_encode(&mut buffer)
+                    .expect("Encoding to Vec<u8> never fails");
+            }
+        }
+
+        self.consensus_encode(&mut buffer)
+            .expect("Encoding to Vec<u8> never fails");
+
+        buffer
+    }
+
+    /// Deserialize a [`NetworkMessage`] from a V2-encoded buffer.
+    fn deserialize_v2(buffer: &[u8]) -> Result<Self, V2MessageError> {
+        if buffer.is_empty() {
+            return Err(V2MessageError::Deserialize(encode::Error::Io(
+                bitcoin::io::Error::new(
+                    bitcoin::io::ErrorKind::UnexpectedEof,
+                    "Missing short_id for message",
+                ),
+            )));
+        }
+
+        let short_id = buffer[0];
+        let mut payload_buffer = &buffer[1..];
+
+        // TODO: remove this once https://github.com/rust-bitcoin/rust-bitcoin/pull/5671
+        // and https://github.com/rust-bitcoin/rust-bitcoin/pull/5009 make it into a release
+        /// P2PV2 BIP-0324 message type for `uproof`.
+        const P2PV2_UPROOF_MSG_TYPE: u8 = 29;
+        if short_id == P2PV2_UPROOF_MSG_TYPE {
+            let msg = Self::Unknown {
+                command: CommandString::try_from_static("uproof")
+                    .expect("`uproof` is a valid command string"),
+                payload: payload_buffer.to_vec(),
+            };
+
+            return Ok(msg);
+        }
+
+        match short_id {
+            0u8 => {
+                let mut command_buffer = &buffer[1..13];
+                let command = CommandString::consensus_decode(&mut command_buffer)
+                    .map_err(V2MessageError::Deserialize)?;
+                payload_buffer = &buffer[13..];
+                match command.as_ref() {
+                    "version" => Ok(Self::Version(Decodable::consensus_decode(
+                        &mut payload_buffer,
+                    )?)),
+                    "verack" => Ok(Self::Verack),
+                    "sendheaders" => Ok(Self::SendHeaders),
+                    "getaddr" => Ok(Self::GetAddr),
+                    "wtxidrelay" => Ok(Self::WtxidRelay),
+                    "sendaddrv2" => Ok(Self::SendAddrV2),
+                    "alert" => Ok(Self::Alert(Decodable::consensus_decode(
+                        &mut payload_buffer,
+                    )?)),
+                    "reject" => Ok(Self::Reject(Decodable::consensus_decode(
+                        &mut payload_buffer,
+                    )?)),
+                    _ => Ok(Self::Unknown {
+                        command,
+                        payload: payload_buffer.to_vec(),
+                    }),
+                }
+            }
+            1u8 => Ok(Self::Addr(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            2u8 => Ok(Self::Block(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            3u8 => Ok(Self::BlockTxn(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            4u8 => Ok(Self::CmpctBlock(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            5u8 => Ok(Self::FeeFilter(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            6u8 => Ok(Self::FilterAdd(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            7u8 => Ok(Self::FilterClear),
+            8u8 => Ok(Self::FilterLoad(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            9u8 => Ok(Self::GetBlocks(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            10u8 => Ok(Self::GetBlockTxn(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            11u8 => Ok(Self::GetData(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            12u8 => Ok(Self::GetHeaders(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            13u8 => {
+                let len = VarInt::consensus_decode(&mut payload_buffer)?.0;
+                let mut headers = Vec::with_capacity(core::cmp::min(1024 * 16, len as usize));
+                for _ in 0..len {
+                    headers.push(Decodable::consensus_decode(&mut payload_buffer)?);
+                    if u8::consensus_decode(&mut payload_buffer)? != 0u8 {
+                        return Err(V2MessageError::Deserialize(encode::Error::ParseFailed(
+                            "Headers message should not contain transactions",
+                        )));
+                    }
+                }
+                Ok(Self::Headers(headers))
+            }
+            14u8 => Ok(Self::Inv(Decodable::consensus_decode(&mut payload_buffer)?)),
+            15u8 => Ok(Self::MemPool),
+            16u8 => Ok(Self::MerkleBlock(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            17u8 => Ok(Self::NotFound(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            18u8 => Ok(Self::Ping(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            19u8 => Ok(Self::Pong(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            20u8 => Ok(Self::SendCmpct(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            21u8 => Ok(Self::Tx(Decodable::consensus_decode(&mut payload_buffer)?)),
+            22u8 => Ok(Self::GetCFilters(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            23u8 => Ok(Self::CFilter(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            24u8 => Ok(Self::GetCFHeaders(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            25u8 => Ok(Self::CFHeaders(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            26u8 => Ok(Self::GetCFCheckpt(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            27u8 => Ok(Self::CFCheckpt(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            28u8 => Ok(Self::AddrV2(Decodable::consensus_decode(
+                &mut payload_buffer,
+            )?)),
+            unknown => Err(V2MessageError::UnknownShortID(unknown)),
+        }
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
-use bip324::serde::CommandString;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
@@ -21,6 +20,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::p2p::PROTOCOL_VERSION;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::p2p::address::AddrV2Message;
+use bitcoin::p2p::message::CommandString;
 use bitcoin::p2p::message::NetworkMessage;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::p2p::message_filter::CFHeaders;
@@ -907,10 +907,10 @@ mod tests {
     use std::time::Duration;
     use std::time::Instant;
 
-    use bip324::serde::NetworkMessage;
     use bitcoin::Network;
     use bitcoin::p2p::ServiceFlags;
     use bitcoin::p2p::address::AddrV2;
+    use bitcoin::p2p::message::NetworkMessage;
     use floresta_mempool::Mempool;
     use tokio::sync::Mutex;
     use tokio::sync::mpsc::UnboundedReceiver;

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -13,9 +13,6 @@ use bip324::futures::ProtocolWriter;
 use bip324::io::Payload;
 use bip324::io::ProtocolError;
 use bip324::io::ProtocolFailureSuggestion;
-use bip324::serde::CommandString;
-use bip324::serde::deserialize as deserialize_v2;
-use bip324::serde::serialize as serialize_v2;
 use bitcoin::Network;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::Encodable;
@@ -27,6 +24,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256d;
 use bitcoin::hex::DisplayHex;
 use bitcoin::p2p::Magic;
+use bitcoin::p2p::message::CommandString;
 use bitcoin::p2p::message::MAX_MSG_SIZE;
 use bitcoin::p2p::message::NetworkMessage;
 use bitcoin::p2p::message::RawNetworkMessage;
@@ -45,6 +43,8 @@ use tokio::net::ToSocketAddrs;
 use tracing::debug;
 use tracing::error;
 
+use super::network_message_ext::NetworkMessageExt;
+use super::network_message_ext::V2MessageError;
 use super::socks::Socks5Addr;
 use super::socks::Socks5Error;
 use super::socks::Socks5StreamBuilder;
@@ -101,8 +101,8 @@ pub enum TransportError {
     /// V2 protocol error
     Protocol(ProtocolError),
 
-    /// V2 serde error
-    SerdeV2(bip324::serde::Error),
+    /// V2 message serialization error
+    SerdeV2(V2MessageError),
 
     /// V1 serde error
     SerdeV1(encode::Error),
@@ -163,7 +163,7 @@ impl Display for TransportError {
 
 impl_error_from!(TransportError, io::Error, Io);
 impl_error_from!(TransportError, ProtocolError, Protocol);
-impl_error_from!(TransportError, bip324::serde::Error, SerdeV2);
+impl_error_from!(TransportError, V2MessageError, SerdeV2);
 impl_error_from!(TransportError, encode::Error, SerdeV1);
 impl_error_from!(TransportError, Socks5Error, Proxy);
 
@@ -290,7 +290,9 @@ async fn try_connection<A: ToSocketAddrs>(
                 TransportProtocol::V1,
             ))
         }
-        false => match Protocol::new(network, Role::Initiator, None, None, reader, writer).await {
+        false => match Protocol::new(network.magic(), Role::Initiator, None, None, reader, writer)
+            .await
+        {
             Ok(protocol) => {
                 debug!("Established a P2PV2 connection with peer={peer_addr}");
                 let (reader_protocol, writer_protocol) = protocol.into_split();
@@ -371,7 +373,9 @@ async fn try_proxy_connection<A: ToSocketAddrs + Clone + Debug>(
                 TransportProtocol::V1,
             ))
         }
-        false => match Protocol::new(network, Role::Initiator, None, None, reader, writer).await {
+        false => match Protocol::new(network.magic(), Role::Initiator, None, None, reader, writer)
+            .await
+        {
             Ok(protocol) => {
                 debug!(
                     "Established a P2PV2 connection over SOCKS5 using proxy={proxy_addr:?} with peer={target_addr:?}"
@@ -404,20 +408,7 @@ where
                 let payload = protocol.read().await?;
                 let contents = payload.contents();
 
-                // TODO: remove this once https://github.com/rust-bitcoin/rust-bitcoin/pull/5671
-                // and https://github.com/rust-bitcoin/rust-bitcoin/pull/5009 make it into a release
-                /// P2PV2 BIP-0324 message type for `uproof`.
-                const P2PV2_UPROOF_MSG_TYPE: u8 = 29;
-                if contents.len() > 1 && contents[0] == P2PV2_UPROOF_MSG_TYPE {
-                    let msg = NetworkMessage::Unknown {
-                        command: CommandString::try_from_static("uproof")
-                            .expect("`uproof` is a valid command string"),
-                        payload: contents[1..].to_vec(),
-                    };
-                    return Ok(msg);
-                }
-
-                let msg = deserialize_v2(contents)?;
+                let msg = NetworkMessage::deserialize_v2(contents)?;
                 Ok(msg)
             }
             Self::V1(reader, network) => {
@@ -465,28 +456,7 @@ where
     pub async fn write_message(&mut self, message: NetworkMessage) -> Result<(), TransportError> {
         match self {
             Self::V2(protocol) => {
-                // TODO: remove this once https://github.com/rust-bitcoin/rust-bitcoin/pull/5671 and
-                // https://github.com/rust-bitcoin/rust-bitcoin/pull/5009 make it into a release
-                if let NetworkMessage::Unknown { command, payload } = message {
-                    /// P2PV2 BIP-0324 message type for `getuproof`.
-                    const P2PV2_GETUPROOF_MSG_TYPE: u8 = 30;
-
-                    let expected_cmd = CommandString::try_from_static("getuproof")
-                        .expect("`getuproof` is a valid command string");
-                    assert_eq!(
-                        command, expected_cmd,
-                        "getuproof is supported as unknown message"
-                    );
-
-                    let mut data = vec![];
-                    data.push(P2PV2_GETUPROOF_MSG_TYPE);
-                    data.extend(payload);
-                    protocol.write(&Payload::genuine(data)).await?;
-
-                    return Ok(());
-                }
-
-                let data = serialize_v2(message);
+                let data = message.serialize_v2();
                 protocol.write(&Payload::genuine(data)).await?;
             }
             Self::V1(writer, network) => {
@@ -554,7 +524,7 @@ pub(crate) mod test_transport {
     use std::task::Context;
     use std::task::Poll;
 
-    use bip324::Network;
+    use bitcoin::Network;
     use tokio::io::AsyncRead;
     use tokio::io::AsyncWrite;
     use tokio::io::ReadBuf;
@@ -641,7 +611,7 @@ pub(crate) mod test_transport {
 mod tests {
     use std::io::ErrorKind;
 
-    use bip324::Network;
+    use bitcoin::Network;
     use bitcoin::consensus::serialize;
     use bitcoin::p2p::message::NetworkMessage;
     use bitcoin::p2p::message::RawNetworkMessage;


### PR DESCRIPTION
### Description and Notes

This commit bumps bip324, specifically to fix https://github.com/rust-bitcoin/bip324/issues/168 which causes our node to use 100% CPU some times due to an infinite loop inside `read`.

They are currently stripping `bitcoin`-related code and moving it to a `bitcoin-p2p` crate. However this crate is still WIP. To allow easy conversion between `bitcoin`'s `NetworkMessage` and what we receive from `bip324`'s interface, I've create a `NetworkMessageExt`. The logic is pretty much what they used to do, and can be removed after `bitcoin-p2p is stable and integrated by us.