### PR TITLE
ci: Add multi-arch docker build with dual-registry push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,20 +3,145 @@
 name: Docker Publish
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: ["master"]
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (tag, branch, or commit SHA)"
+        required: true
+        type: string
+      tag:
+        description: "Docker image tag (e.g. v0.10.0)"
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: floresta
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE || format('docker.io/{0}', github.repository) }}
+  IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || format('sha-{0}', github.sha) }}
 
 permissions: {}
 
 jobs:
   build:
+    name: Build and verify
     runs-on: ubuntu-latest
-
+    timeout-minutes: 15
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        id: build
+        with:
+          context: .
+          file: Dockerfile
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ env.DOCKERHUB_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ env.GHCR_IMAGE }}:${{ env.IMAGE_TAG }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.licenses=MIT OR Apache-2.0
+          cache-from: type=gha,scope=build-docker-amd64
+          cache-to: type=gha,scope=build-docker-amd64,mode=max
+          load: true
+
+      - name: Verify binaries
+        run: |
+          docker run --rm --entrypoint /bin/sh ${IMAGE_NAME}:${IMAGE_TAG} -c \
+            'test -f /usr/local/bin/florestad && test -f /usr/local/bin/floresta-cli && echo "Binaries OK" && sha256sum /usr/local/bin/florestad /usr/local/bin/floresta-cli'
+
+      - name: Run CLI
+        run: |
+          docker run --rm --entrypoint floresta-cli ${IMAGE_NAME}:${IMAGE_TAG} --help | head -n 1
+
+  multi-arch-build:
+    name: Build ${{ matrix.platform }}
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+            qemu: false
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            qemu: false
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
+            arch: armv7
+            qemu: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up QEMU
+        if: matrix.qemu
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.GHCR_IMAGE }}:${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.licenses=MIT OR Apache-2.0
+          cache-from: type=gha,scope=build-docker-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-docker-${{ matrix.arch }},mode=max
+          provenance: false
+          push: true
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: [multi-arch-build]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -24,13 +149,57 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          context: .
           file: contrib/docker/Dockerfile
-          push: true
-          tags: dlsz/floresta:latest
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine tags
+        id: tags
+        run: .github/workflows/docker/determine-tags.sh
+        env:
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_IMAGE }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      - name: Create and push multi-arch manifests
+        run: .github/workflows/docker/create-manifests.sh
+        env:
+          TAGS_GHCR: ${{ steps.tags.outputs.tags_ghcr }}
+          TAGS_DH: ${{ steps.tags.outputs.tags_dh }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_IMAGE }}
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          CLEANUP_TEMP_TAGS: ${{ vars.CLEANUP_TEMP_TAGS || 'true' }}
+
+      - name: Cleanup temp tags
+        if: success() || failure()
+        run: .github/workflows/docker/cleanup-temp-tags.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          CLEANUP_TEMP_TAGS: ${{ vars.CLEANUP_TEMP_TAGS || 'true' }}
+
+      - name: Verify manifest
+        run: |
+          GHCR="${GHCR_IMAGE}"
+          SHA="${IMAGE_TAG}"
+          echo "Checking platforms in $GHCR:$SHA"
+          docker buildx imagetools inspect "$GHCR:$SHA" --raw | grep -o '"architecture":"[^"]*"' | sort -u

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,20 +3,143 @@
 name: Docker Publish
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: ["master"]
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (tag, branch, or commit SHA)"
+        required: true
+        type: string
+      tag:
+        description: "Docker image tag (e.g. v0.10.0)"
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: floresta
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE || format('docker.io/{0}', github.repository) }}
+  IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || format('sha-{0}', github.sha) }}
 
 permissions: {}
 
 jobs:
   build:
+    name: Build and verify
     runs-on: ubuntu-latest
-
+    timeout-minutes: 15
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        id: build
+        with:
+          file: contrib/docker/Dockerfile
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ env.DOCKERHUB_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ env.GHCR_IMAGE }}:${{ env.IMAGE_TAG }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.licenses=MIT OR Apache-2.0
+          cache-from: type=gha,scope=build-docker-amd64
+          cache-to: type=gha,scope=build-docker-amd64,mode=max
+          load: true
+
+      - name: Verify binaries
+        run: |
+          docker run --rm --entrypoint /bin/sh ${IMAGE_NAME}:${IMAGE_TAG} -c \
+            'test -f /usr/local/bin/florestad && test -f /usr/local/bin/floresta-cli && echo "Binaries OK" && sha256sum /usr/local/bin/florestad /usr/local/bin/floresta-cli'
+
+      - name: Run CLI
+        run: |
+          docker run --rm --entrypoint floresta-cli ${IMAGE_NAME}:${IMAGE_TAG} --help | head -n 1
+
+  multi-arch-build:
+    name: Build ${{ matrix.platform }}
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+            qemu: false
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            qemu: false
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
+            arch: armv7
+            qemu: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up QEMU
+        if: matrix.qemu
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          file: contrib/docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.GHCR_IMAGE }}:${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.licenses=MIT OR Apache-2.0
+          cache-from: type=gha,scope=build-docker-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-docker-${{ matrix.arch }},mode=max
+          provenance: false
+          push: true
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: [multi-arch-build]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -24,13 +147,54 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          context: .
           file: contrib/docker/Dockerfile
-          push: true
-          tags: dlsz/floresta:latest
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine tags
+        id: tags
+        run: .github/workflows/docker/determine-tags.sh
+        env:
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_IMAGE }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      - name: Create and push multi-arch manifests
+        run: .github/workflows/docker/create-manifests.sh
+        env:
+          TAGS_GHCR: ${{ steps.tags.outputs.tags_ghcr }}
+          TAGS_DH: ${{ steps.tags.outputs.tags_dh }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_IMAGE }}
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          CLEANUP_TEMP_TAGS: ${{ vars.CLEANUP_TEMP_TAGS || 'true' }}
+
+      - name: Cleanup temp tags
+        if: success() || failure()
+        run: .github/workflows/docker/cleanup-temp-tags.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          CLEANUP_TEMP_TAGS: ${{ vars.CLEANUP_TEMP_TAGS || 'true' }}
+
+      - name: Verify manifest
+        run: |
+          GHCR="${GHCR_IMAGE}"
+          SHA="${IMAGE_TAG}"
+          echo "Checking platforms in $GHCR:$SHA"
+          docker buildx imagetools inspect "$GHCR:$SHA" --raw | grep -o '"architecture":"[^"]*"' | sort -u

--- a/.github/workflows/docker/cleanup-temp-tags.sh
+++ b/.github/workflows/docker/cleanup-temp-tags.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+set -euo pipefail
+
+if [[ "${CLEANUP_TEMP_TAGS:-true}" == "false" || "${CLEANUP_TEMP_TAGS:-true}" == "0" ]]; then
+  echo "CLEANUP_TEMP_TAGS=${CLEANUP_TEMP_TAGS}, skipping cleanup"
+  exit 0
+fi
+
+OWNER="${GITHUB_REPOSITORY_OWNER}"
+PKG="${GITHUB_REPOSITORY##*/}"
+
+if gh api "/orgs/${OWNER}" --silent 2>/dev/null; then
+  BASE="/orgs/${OWNER}/packages/container/${PKG}"
+else
+  BASE="/users/${OWNER}/packages/container/${PKG}"
+fi
+
+for ARCH in amd64 arm64 armv7; do
+  TAG="${IMAGE_SHA}-${ARCH}"
+  VID=$(gh api "${BASE}/versions" \
+    --jq ".[] | select(.metadata.container.tags | index(\"${TAG}\")) | .id" \
+    2>/dev/null || true)
+  if [[ -n "${VID}" ]]; then
+    gh api --method DELETE "${BASE}/versions/${VID}" --silent 2>/dev/null || true
+    echo "Deleted ${TAG} (version ${VID})"
+  else
+    echo "Tag ${TAG} not found, skipping"
+  fi
+done

--- a/.github/workflows/docker/create-manifests.sh
+++ b/.github/workflows/docker/create-manifests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+set -euo pipefail
+
+REPO_GHCR="ghcr.io/${GITHUB_REPOSITORY}"
+REPO_DH="${DOCKERHUB_IMAGE}"
+SRC_TAG="${REPO_GHCR}:${IMAGE_SHA}"
+DH_TAG="${REPO_DH}:${IMAGE_SHA}"
+ANN_SOURCE="index:org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+ANN_DESC="index:org.opencontainers.image.description=A lightweight and embeddable Bitcoin client, built for sovereignty!"
+
+echo "=== 1/5 GHCR: merge per-arch temps into multi-arch manifest ==="
+docker buildx imagetools create \
+  -t "${SRC_TAG}" \
+  --annotation "${ANN_SOURCE}" \
+  --annotation "${ANN_DESC}" \
+  "${SRC_TAG}-amd64" \
+  "${SRC_TAG}-arm64" \
+  "${SRC_TAG}-armv7"
+
+echo "=== 2/5 Docker Hub: copy multi-arch manifest (self-contained) ==="
+docker buildx imagetools create -t "${DH_TAG}" "${SRC_TAG}"
+
+echo "=== 3/5 Cleanup: delete per-arch temp tags from GHCR ==="
+.github/workflows/docker/cleanup-temp-tags.sh
+
+echo "=== 4/5 GHCR: copy back from Docker Hub (self-contained) ==="
+docker buildx imagetools create -t "${SRC_TAG}" "${DH_TAG}"
+
+echo "=== 5/5 Tag version + latest on both registries ==="
+for tag in ${TAGS_GHCR}; do
+  [[ "${tag}" == "${SRC_TAG}" ]] && continue
+  echo "  GHCR: ${tag}"
+  docker buildx imagetools create -t "${tag}" "${SRC_TAG}"
+done
+for tag in ${TAGS_DH}; do
+  [[ "${tag}" == "${DH_TAG}" ]] && continue
+  echo "  Docker Hub: ${tag}"
+  docker buildx imagetools create -t "${tag}" "${DH_TAG}"
+done

--- a/.github/workflows/docker/determine-tags.sh
+++ b/.github/workflows/docker/determine-tags.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+set -euo pipefail
+
+REPO_GHCR="ghcr.io/${GITHUB_REPOSITORY}"
+REPO_DH="${DOCKERHUB_IMAGE}"
+
+TAGS_GHCR="${REPO_GHCR}:${IMAGE_SHA}"
+TAGS_DH="${REPO_DH}:${IMAGE_SHA}"
+
+if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+  TAGS_GHCR="${TAGS_GHCR} ${REPO_GHCR}:${DISPATCH_TAG} ${REPO_GHCR}:latest"
+  TAGS_DH="${TAGS_DH} ${REPO_DH}:${DISPATCH_TAG} ${REPO_DH}:latest"
+elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+  TAGS_GHCR="${TAGS_GHCR} ${REPO_GHCR}:${GITHUB_REF_NAME} ${REPO_GHCR}:latest"
+  TAGS_DH="${TAGS_DH} ${REPO_DH}:${GITHUB_REF_NAME} ${REPO_DH}:latest"
+else
+  TAGS_GHCR="${TAGS_GHCR} ${REPO_GHCR}:master"
+  TAGS_DH="${TAGS_DH} ${REPO_DH}:master"
+fi
+
+echo "tags_ghcr=${TAGS_GHCR}" >> "${GITHUB_OUTPUT}"
+echo "tags_dh=${TAGS_DH}" >> "${GITHUB_OUTPUT}"

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -44,4 +44,9 @@ EXPOSE 50001
 EXPOSE 8332
 EXPOSE 3333
 
+LABEL org.opencontainers.image.description="A lightweight and embeddable Bitcoin client, built for sovereignty!"
+LABEL org.opencontainers.image.documentation="https://raw.githubusercontent.com/getfloresta/Floresta/refs/heads/master/README.md"
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+LABEL org.opencontainers.image.source="https://github.com/getfloresta/Floresta"
+
 CMD [ "florestad" ]

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -43,4 +43,9 @@ EXPOSE 50001
 EXPOSE 8332
 EXPOSE 3333
 
+LABEL org.opencontainers.image.description="A lightweight and embeddable Bitcoin client, built for sovereignty!"
+LABEL org.opencontainers.image.documentation="https://raw.githubusercontent.com/getfloresta/Floresta/refs/heads/master/README.md"
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+LABEL org.opencontainers.image.source="https://github.com/getfloresta/Floresta"
+
 CMD [ "florestad" ]


### PR DESCRIPTION
### Description and Notes

Adds a matrix build for linux/amd64, linux/arm64, and linux/arm/v7 (most common
linux server archs) to the Docker workflow.
Per-arch images are pushed to both GHCR and DockerHub, then merged into multi-arch manifests with proper
version and branch tags. Supports manual workflow_dispatch to rebuild and
publish images for previous tags.

The merge logic is externalized into shell scripts under .github/workflows/docker/ for maintainability. The manifest creation uses
a self-contained 5-step process (merge to GHCR, copy to Docker Hub, cleanup
temp tags, copy back, tag versions) to avoid dangling references from deleted
per-arch temp tags. A catch-all cleanup step runs regardless of success/failure.

Also adds OCI labels to the Dockerfile following best practices.

Related to #588 

### How to verify the changes you have done?

See my fork. https://github.com/johnnyasantoss/floresta/actions/runs/27847196957


### Contributor Checklist

<!-- Please remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
