### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+version: 2
+
+updates:
+    - package-ecosystem: "cargo"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          time: "00:00"
+      cooldown:
+          default-days: 60
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          time: "00:00"
+      cooldown:
+          default-days: 60
+
+    - package-ecosystem: "nix"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          time: "00:00"
+      cooldown:
+          default-days: 60
+
+    - package-ecosystem: "uv"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          time: "00:00"
+      cooldown:
+          default-days: 60

--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -208,19 +208,11 @@ which python
 * Install module dependencies:
 
 ```bash
-# installs dependencies listed in pyproject.toml.
-# in local development environment
-# it do not remove existing packages.
+# Install Python test dependencies declared
+# on `pyproject.toml` on a virtual environment
 uv pip install -r pyproject.toml
 
-# if you're a old-school pythonist,
-# install from requirements.txt
-# without remove existing packages.
-uv pip install -r tests/requirements.txt
-
-# Alternatively, you can synchronize it
-# uses the uv.lock file to enforce
-# reproducible installations.
+# Alternatively, synchronize dependencies from `pyproject.toml` and `uv.lock`
 uv sync
 ```
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,0 @@
-jsonrpclib>=0.2.1
-requests>=2.32.3
-black>=24.10.0
-pylint>=3.3.2
-pyOpenSSL>=25.0.0
-pytest>=9.0.0
-pytest-xdist>=3.8.0


### PR DESCRIPTION
Closes #945 
Closes #1049 

## Changelog
```
- Add `.github/dependabot.yml`:
    - Support for cargo, github-actions, nix and uv ecosystems
    - 2 month cooldown period to curb supply-chain attacks
 
- Drop `requirements.txt` references in light of the move to pytest
```