### PR TITLE
build: configure workspace error-handling lints as a status board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,22 @@ metrics = { path = "metrics" }
 [workspace.lints.clippy]
 unused_async = "deny"
 use_self = "deny"
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+unreachable = "warn"
+todo = "deny"
+unimplemented = "warn"
+indexing_slicing = "warn"
+arithmetic_side_effects = "warn"
+map_err_ignore = "warn"
+wildcard_enum_match_arm = "warn"
+result_unit_err = "deny"
+
+# Documentation & payload - always warn
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+result_large_err = "warn"
 
 [profile.release]
 opt-level = 3     # maximum optimization level


### PR DESCRIPTION
## Description

this PR adds the core error-handling lints defined in the Systematic Error Handling Overhaul to the `[workspace.lints.clippy]` block in the root `Cargo.toml`

## Notes to reviewers

- **DO NOT MERGE.** this is a "living status board" PR, meant to stay open while the individual module-refactoring PRs are in progress
- **Expected CI failure.** our CI enforces `-D warnings`, so this PR is intentionally designed to fail CI, the failing job is the point - it surfaces the true, workspace-wide backlog of error-handling violations
- lints with zero violations workspace-wide (`todo`, `result_unit_err`) are set to `deny`, and everything else is set to `warn` for now
- as module-refactoring PRs (e.g. #1075 , #1133 ) land on `master`, we'll rebase this branch and the warning count will shrink, once the workspace is fully clean and CI passes on this branch, we'll ratchet the remaining lints from `warn` to `deny` and merge

## How to verify

To check the lint configuration locally without treating warnings as fatal (which `just pcc` does), run:

```bash
cargo clippy --workspace --all-targets
```

this exits successfully (code 0) but prints the full list of remaining violations across the workspace

## Contributor checklist

- [x] I've followed the [[contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
  - **Note:** CI and `just pcc` are intentionally expected to fail on this PR due to `-D warnings`, as explained above.
- [x] I've linked the related issue(s) above