### PR TITLE
Weekly Bumps [2026-06-24]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20-poly1305"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +680,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1012,7 +1032,7 @@ dependencies = [
  "lru",
  "memmap2",
  "metrics",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustreexo",
  "serde",
  "serde_json",
@@ -1040,7 +1060,7 @@ name = "floresta-common"
 version = "0.5.0"
 dependencies = [
  "bitcoin",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "sha2",
  "spin",
  "tracing",
@@ -1074,7 +1094,7 @@ dependencies = [
  "floresta-mempool",
  "floresta-watch-only",
  "floresta-wire",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rcgen",
  "rustreexo",
  "serde",
@@ -1106,7 +1126,7 @@ dependencies = [
  "floresta-chain",
  "floresta-common",
  "floresta-domain",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustreexo",
  "tracing",
 ]
@@ -1152,7 +1172,7 @@ dependencies = [
  "clap",
  "corepc-types",
  "jsonrpc",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rcgen",
  "serde",
  "serde_json",
@@ -1167,7 +1187,7 @@ dependencies = [
  "floresta-common",
  "kv",
  "miniscript",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tracing",
@@ -1187,7 +1207,7 @@ dependencies = [
  "floresta-domain",
  "floresta-mempool",
  "metrics",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustls",
  "rustreexo",
  "serde",
@@ -1352,6 +1372,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1408,9 +1429,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1716,7 +1742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1804,7 +1830,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1901,11 +1927,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2353,18 +2379,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2378,16 +2405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,12 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2716,15 +2730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ dns-lookup = "=2.1.1"
 hex = "=0.4.3"
 kv = "=0.24.0"
 miniscript = { version = "=12.3.6", default-features = false }
-rand = "=0.9.4"
+rand = "=0.10.1"
 rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "pem"] }
 rustreexo = "=0.5.0"
 serde = { version = "=1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,25 +50,25 @@ readme = "README.md"
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
 bitcoin = { version = "=0.32.8", default-features = false }
 clap = { version = "=4.6.1", default-features = false, features = ["derive", "std"] }
-corepc-types = "=0.11.0"
+corepc-types = { version = "=0.11.0" }
 console-subscriber = { version = "=0.5.0", default-features = false }
-dns-lookup = "=2.1.1"
-hex = "=0.4.3"
-kv = "=0.24.0"
+dns-lookup = { version = "=2.1.1" }
+hex = { version = "=0.4.3" }
+kv = { version = "=0.24.0" }
 miniscript = { version = "=12.3.6", default-features = false }
-rand = "=0.10.1"
+rand = { version = "=0.10.1" }
 rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "pem"] }
-rustreexo = "=0.5.0"
+rustreexo = { version = "=0.5.0" }
 serde = { version = "=1.0.228", features = ["derive"] }
-serde_json = "=1.0.150"
+serde_json = { version = "=1.0.150" }
 sha2 = { version = "=0.10.9", default-features = false }
 spin = { version = "=0.10.0", default-features = false, features = ["spin_mutex", "rwlock"] }
-tempfile = "=3.27.0"
+tempfile = { version = "=3.27.0" }
 tokio = { version = "=1.52.3", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["ring", "tls12"] }
 toml = { version = "=0.9.12", default-features = false, features = ["std", "parse", "serde"] }
 tracing = { version = "=0.1.44", default-features = false }
-zstd = "=0.13.3"
+zstd = { version = "=0.13.3" }
 # Pins for MSRV compatibility:
 time = { version = "=0.3.45" } # note: >0.3.45 requires Rust 1.88.0
 tonic = { version = "=0.14.5" } # note: >0.14.5 requires Rust 1.88.0

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
-anyhow = "=1.0.102"
+anyhow = { version = "=1.0.102" }
 bitcoin = { workspace = true }
 clap = { workspace = true, features = ["help"] }
 serde_json = { workspace = true }

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 bitcoinkernel = { version = "=0.2.1", optional = true }
-lru = { version = "=0.16.4", optional = true }
+lru = { version = "=0.17.0", optional = true }
 memmap2 = { version = "=0.9.10", optional = true }
 rustreexo = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -37,7 +37,7 @@ metrics = { workspace = true,  optional = true }
 
 [dev-dependencies]
 bitcoin = { workspace = true, features = ["serde"] }
-criterion = "=0.7.0"
+criterion = { version = "=0.7.0" }
 hex = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1543,7 +1543,7 @@ mod test {
     use bitcoin::constants::genesis_block;
     use floresta_common::assert_ok;
     use floresta_common::bhash;
-    use rand::Rng;
+    use rand::RngExt;
     use rustreexo::proof::Proof;
     use rustreexo::stump::Stump;
 

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -298,7 +298,7 @@ mod tests {
     use bitcoin::consensus::Encodable;
     use bitcoin::hashes::Hash;
     use rand;
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::*;
 

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -979,12 +979,12 @@ mod tests {
     use bitcoin::transaction::Version;
     use floresta_common::assert_err;
     use floresta_common::assert_ok;
-    use rand::RngCore;
+    use rand::Rng;
     use rand::SeedableRng;
-    use rand::TryRngCore;
     use rand::prelude::IndexedMutRandom;
-    use rand::rngs::OsRng;
+    use rand::rand_core::UnwrapErr;
     use rand::rngs::StdRng;
+    use rand::rngs::SysRng;
     use rand::seq::SliceRandom;
 
     use super::*;
@@ -1624,7 +1624,7 @@ mod tests {
         // All blocks except 9 and 170 just have a single, unspent TxOut
         let default_unspent_idx = HashSet::from_iter(vec![0]);
 
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let salt = SipHashKeys::new(
             rng.next_u64(),
             rng.next_u64(),
@@ -1763,7 +1763,7 @@ mod tests {
 
     #[test]
     fn test_swift_sync_hash_midstate() {
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
 
         for _ in 0..10_000 {
             let keys = SipHashKeys::new(

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true # Floresta/README.md
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
-hashbrown = { version = "=0.16.1" }
+hashbrown = { version = "=0.17.0" }
 sha2 = { workspace = true }
 spin = { workspace = true }
 tracing = { workspace = true }

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -358,7 +358,7 @@ mod tests {
     use bitcoin::transaction::Version;
     use floresta_common::bhash;
     use floresta_domain::mempool::MempoolBase;
-    use rand::Rng;
+    use rand::RngExt;
     use rand::SeedableRng;
 
     use super::Mempool;

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -38,13 +38,13 @@ floresta-wire = { workspace = true }
 metrics = { workspace = true,  optional = true }
 
 [dev-dependencies]
-pretty_assertions = "=1.4.1"
+pretty_assertions = { version = "=1.4.1" }
 
 [target.'cfg(target_env = "gnu")'.dependencies]
-libc = "=0.2.186"
+libc = { version = "=0.2.186" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-libc = "=0.2.186"
+libc = { version = "=0.2.186" }
 
 [features]
 compact-filters = ["dep:floresta-compact-filters"]

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -25,7 +25,7 @@ rustls = { version = "=0.23.40", default-features = false, features = ["ring", "
 rustreexo = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha3 = { version = "0.10", default-features = false, features = ["asm"] }
+sha3 = { version = "=0.10.9", default-features = false, features = ["asm"] }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 ureq = { version = "=3.3.0", features = ["socks-proxy", "json", "rustls-no-provider"], default-features = false }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -23,7 +23,7 @@ use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::address::AddrV2Message;
 use floresta_chain::DnsSeed;
 use floresta_common::service_flags;
-use rand::Rng;
+use rand::RngExt;
 use rand::seq::IteratorRandom;
 use serde::Deserialize;
 use serde::Serialize;
@@ -1344,7 +1344,7 @@ mod test {
     use floresta_chain::get_chain_dns_seeds;
     use floresta_common::assert_ok;
     use floresta_common::service_flags;
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::AddressState;
     use super::LocalAddress;

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -14,7 +14,7 @@ use floresta_common::Ema;
 use floresta_common::service_flags;
 use floresta_common::try_and_log;
 use floresta_domain::mempool::MempoolBase;
-use rand::Rng;
+use rand::RngExt;
 use tokio::net::tcp::WriteHalf;
 use tokio::spawn;
 use tokio::sync::Mutex;

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -585,7 +585,7 @@ where
             .peers
             .values()
             .filter(|peer| peer.is_regular_peer() && !peer.has_any_service(protected_services))
-            .choose_multiple(&mut rng, n);
+            .sample(&mut rng, n);
 
         for peer in peers {
             let _ = peer.channel.send(NodeRequest::Shutdown);

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -786,7 +786,7 @@ pub(super) mod peer_utils {
     use bitcoin::p2p::message_network::VersionMessage;
     use floresta_common::PROTOCOL_VERSION;
     use floresta_common::advertised_services;
-    use rand::Rng;
+    use rand::RngExt;
     use rand::rng;
 
     use crate::address_man::LocalAddress;

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -24,9 +24,9 @@ use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_common::Ema;
 use floresta_common::service_flags;
 use floresta_mempool::Mempool;
-use rand::RngCore;
-use rand::TryRngCore;
-use rand::rngs::OsRng;
+use rand::Rng;
+use rand::rand_core::UnwrapErr;
+use rand::rngs::SysRng;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::Mutex;
@@ -216,7 +216,7 @@ pub fn serialize(root: UtreexoRoots) -> Vec<u8> {
 
 pub fn create_false_acc(tip: usize) -> Vec<u8> {
     let mut bytes = [0u8; 32];
-    let mut rng = OsRng.unwrap_err();
+    let mut rng = UnwrapErr(SysRng);
     rng.fill_bytes(&mut bytes);
     let node_hash = encode::serialize_hex(&bytes);
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 # All dependencies MUST be pinned precisely with `X.Y.z`
 arbitrary = { version = "=1.4.2", features = ["derive"] }
 bitcoin = { workspace = true }
-libfuzzer-sys = "=0.4.12"
+libfuzzer-sys = { version = "=0.4.12" }
 tempfile = { workspace = true }
 
 # Local dependencies

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 axum = { workspace = true }
-prometheus-client = "=0.22.3"
+prometheus-client = { version = "=0.22.3" }
 sysinfo = { version = "=0.36.1", default-features = false, features = ["system"] }
 tokio = { workspace = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = [
   "jsonrpclib>=0.2.1",
-  "requests>=2.32.3",
+  "requests>=2.33.1",
   "black>=26.3.1",
   "pylint>=3.3.2",
   "cryptography>=46.0.5",

--- a/tests/test_framework/netutil.py
+++ b/tests/test_framework/netutil.py
@@ -71,13 +71,13 @@ def _convert_ip_port(addr_string):
     return host_out, int(port, 16)
 
 
-def netstat(typ="tcp"):
+def netstat(protocol="tcp"):
     """
     Function to return a list with status of tcp connections at linux systems
     To get pid of all network process running on system, you must run this script
     as superuser
     """
-    with open("/proc/net/" + typ, "r", encoding="utf-8") as f:
+    with open("/proc/net/" + protocol, "r", encoding="utf-8") as f:
         content = f.readlines()
         content.pop(0)
     result = []

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ requires-dist = [
     { name = "pyopenssl", specifier = ">=25.0.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "requests", specifier = ">=2.33.1" },
 ]
 
 [[package]]
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -492,9 +492,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changelog

```
# Unrelated 

- Use `<pkg> = { version = "<version>" }` syntax for all cargo deps
- Fix typo on `netstat()` (test framework)

# Cargo

- floresta-chain:
  *  Bump `lru` from v0.16.4 to v0.17.0
- floresta-common:
  * Bump `hashbrown` from v0.16.1 to v0.17.0
- floresta-wire:
  * Pin `sha3` to v0.10.9
- Workspace:
  * Bump `rand` from v0.9.4 to v0.10.1

# Nix
- Bump `nixpkgs.url` from `github:NixOS/nixpkgs/nixos-25.11` to `github:NixOS/nixpkgs/nixos-26.05`

# uv
- Bump `requests` from v2.32.3 to v2.33.1
```


