### PR TITLE
docs(rpc): add documentation for findtxout, getmemoryinfo, getrpcinfo…

### DIFF
--- a/doc/rpc/findtxout.md
+++ b/doc/rpc/findtxout.md
@@ -1,0 +1,51 @@
+# `findtxout`
+
+Searches for a specific unspent transaction output (UTXO) using compact block filters.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli findtxout <txid> <vout> <script> <height_hint>
+```
+
+### Examples
+
+```bash
+# Look for the output 0 of a given transaction, locking script and a height hint to start the search from
+floresta-cli findtxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 76a914...88ac 800000
+```
+
+## Arguments
+
+`txid` - (string, required) The id of the transaction containing the output.
+
+`vout` - (numeric, required) The index of the output to look for.
+
+`script` - (string, required) The hex-encoded `scriptPubKey` that locks the output, used to match against the compact block filters.
+
+`height_hint` - (numeric, required) A block height to start the filter search from. Providing a height close to when the output was created speeds up the search.
+
+## Returns
+
+### Ok Response
+
+* `value` - (numeric) The output value, in satoshis;
+* `script_pubkey` - (string) The hex-encoded locking script of the output.
+
+Returns an empty object if the output could not be found.
+
+### Error Enum `CommandError`
+
+* `JsonRpcError::InvalidScript`
+* `JsonRpcError::InInitialBlockDownload`
+* `JsonRpcError::NoBlockFilters`
+* `JsonRpcError::Filters`
+* `JsonRpcError::Node`
+
+## Notes
+
+* This command requires block filters to be enabled, by setting the `blockfilters=1` option in the configuration.
+* If the node is still in the initial block download, the search can't be performed since the local filter index isn't complete yet, and `JsonRpcError::InInitialBlockDownload` is returned.
+* Floresta first checks its own wallet cache for the output before falling back to a filter-based search.

--- a/doc/rpc/getmemoryinfo.md
+++ b/doc/rpc/getmemoryinfo.md
@@ -1,0 +1,59 @@
+# `getmemoryinfo`
+
+Returns statistics about Floresta's memory usage.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getmemoryinfo <mode>
+```
+
+### Examples
+
+```bash
+# Get memory usage statistics (default mode)
+floresta-cli getmemoryinfo
+
+# Get the same information, explicitly
+floresta-cli getmemoryinfo stats
+
+# Get a raw XML dump of the allocator statistics
+floresta-cli getmemoryinfo mallocinfo
+```
+
+## Arguments
+
+`mode` - (string, optional, default=`stats`) Determines the format of the returned information.
+
+  * `stats` - Returns a structured breakdown of memory usage.
+
+  * `mallocinfo` - Returns a raw XML string with the allocator statistics, in the same format as glibc's `malloc_info`.
+
+## Returns
+
+### Ok Response
+
+If `mode` is `stats`:
+
+* `locked` - (json object)
+  * `used` - (numeric) Memory currently in use, in bytes;
+  * `free` - (numeric) Memory currently free, in bytes;
+  * `total` - (numeric) Total memory allocated, in bytes;
+  * `locked` - (numeric) Total memory locked, in bytes;
+  * `chunks_used` - (numeric) How many chunks are currently in use;
+  * `chunks_free` - (numeric) How many chunks are currently free.
+
+If `mode` is `mallocinfo`:
+
+* (string) A raw XML string with the allocator statistics.
+
+### Error Enum `CommandError`
+
+* `JsonRpcError::InvalidMemInfoMode`
+
+## Notes
+
+* This command relies on the system allocator, and is only implemented for `*-gnu` Linux targets and macOS. On any other runtime, all numeric fields are returned as zero.
+* Any `mode` value other than `stats` or `mallocinfo` results in an error.

--- a/doc/rpc/getrpcinfo.md
+++ b/doc/rpc/getrpcinfo.md
@@ -1,0 +1,40 @@
+# `getrpcinfo`
+
+Returns information about the running RPC server.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getrpcinfo
+```
+
+### Examples
+
+```bash
+# Get the current state of the RPC server
+floresta-cli getrpcinfo
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+* `active_commands` - (json array) All commands currently being processed by the server;
+  * `method` - (string) The name of the RPC command;
+  * `duration` - (numeric) How long the command has been running for, in microseconds.
+* `logpath` - (string) The full path to the node's debug log file.
+
+### Error Enum `CommandError`
+
+This command typically does not return any specific logic errors under normal operation.
+
+## Notes
+
+* `active_commands` only lists commands that are still in flight at the moment this RPC is called, so an empty array is the common case for a node that isn't under heavy RPC load.
+* `logpath` is useful for locating the debug log without having to know the node's data directory layout in advance.

--- a/doc/rpc/listdescriptors.md
+++ b/doc/rpc/listdescriptors.md
@@ -1,0 +1,37 @@
+# `listdescriptors`
+
+Returns a list of all descriptors currently loaded in the watch-only wallet.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli listdescriptors
+```
+
+### Examples
+
+```bash
+# List every descriptor currently tracked by the wallet
+floresta-cli listdescriptors
+```
+
+## Arguments
+
+This command takes no arguments.
+
+## Returns
+
+### Ok Response
+
+Returns a JSON array of strings, each one a descriptor currently loaded in the wallet.
+
+### Error Enum `CommandError`
+
+* `JsonRpcError::Wallet`
+
+## Notes
+
+* Descriptors are added with [`loaddescriptor`](loaddescriptor.md). This command lets you confirm which ones are currently active before deciding whether to load more.
+* Returns an empty array if no descriptor has been loaded yet.


### PR DESCRIPTION
### Description and Notes
Adds RPC documentation pages for four endpoints that were missing docs: findtxout, getmemoryinfo, getrpcinfo, and listdescriptors. 
Closes #799.

### How to verify the changes you have done?
Review the rendered markdown in `doc/rpc/findtxout.md`, `doc/rpc/getmemoryinfo.md`, `doc/rpc/getrpcinfo.md`, and `doc/rpc/listdescriptors.md`, and cross-check the documented parameters/responses against each method's implementation.

### Contributor Checklist
- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above