### PR TITLE
Move wallet errors to floresta-domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,7 @@ dependencies = [
  "bitcoin",
  "floresta-chain",
  "floresta-common",
+ "floresta-domain",
  "kv",
  "miniscript",
  "rand 0.10.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "floresta-chain",
  "floresta-common",
  "floresta-compact-filters",
+ "floresta-domain",
  "floresta-mempool",
  "floresta-watch-only",
  "floresta-wire",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,6 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "floresta-chain",
- "rustreexo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ floresta-rpc = { path = "crates/floresta-rpc" }
 floresta-watch-only = { path = "crates/floresta-watch-only" }
 floresta-wire = { path = "crates/floresta-wire" }
 floresta-mempool = { path = "crates/floresta-mempool" }
-floresta-domain = { path = "crates/floresta-domain" }
+floresta-domain = { path = "crates/floresta-domain", default-features = false}
 metrics = { path = "metrics" }
 
 [workspace.lints.clippy]

--- a/crates/floresta-domain/Cargo.toml
+++ b/crates/floresta-domain/Cargo.toml
@@ -23,8 +23,9 @@ bitcoin = { workspace = true, features = ["serde", "std"] }
 floresta-chain = { workspace = true }
 
 [features]
-default = ["mempool"]
+default = ["mempool", "wallet"]
 mempool = []
+wallet = []
 
 [lints]
 workspace = true

--- a/crates/floresta-domain/Cargo.toml
+++ b/crates/floresta-domain/Cargo.toml
@@ -19,12 +19,12 @@ categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 bitcoin = { workspace = true, features = ["serde", "std"] }
-rustreexo = { workspace = true }
 
 floresta-chain = { workspace = true }
 
 [features]
-default = []
+default = ["mempool"]
+mempool = []
 
 [lints]
 workspace = true

--- a/crates/floresta-domain/src/lib.rs
+++ b/crates/floresta-domain/src/lib.rs
@@ -14,3 +14,6 @@
 
 #[cfg(feature = "mempool")]
 pub mod mempool;
+
+#[cfg(feature = "wallet")]
+pub mod wallet;

--- a/crates/floresta-domain/src/lib.rs
+++ b/crates/floresta-domain/src/lib.rs
@@ -12,4 +12,5 @@
     html_favicon_url = "https://raw.githubusercontent.com/getfloresta/floresta-media/master/logo_png/Icon-Green(main).png"
 )]
 
+#[cfg(feature = "mempool")]
 pub mod mempool;

--- a/crates/floresta-domain/src/wallet/error.rs
+++ b/crates/floresta-domain/src/wallet/error.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use core::error::Error;
+use core::fmt;
+use core::fmt::Display;
+use core::fmt::Formatter;
+
+#[derive(PartialEq, Debug)]
+pub enum WatchOnlyError {
+    DatabaseError(String),
+    DuplicateDescriptor { descriptor: String },
+    InvalidDescriptor(String),
+    InternalError(String),
+}
+
+impl Display for WatchOnlyError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DatabaseError(e) => {
+                write!(f, "Database error: {e}")
+            }
+            Self::DuplicateDescriptor { descriptor } => {
+                write!(f, "Descriptor is already cached: {descriptor}")
+            }
+            Self::InvalidDescriptor(e) => {
+                write!(f, "Invalid descriptor: {e}")
+            }
+            Self::InternalError(e) => write!(f, "Internal Error: {e}"),
+        }
+    }
+}
+
+impl Error for WatchOnlyError {}

--- a/crates/floresta-domain/src/wallet/mod.rs
+++ b/crates/floresta-domain/src/wallet/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+pub mod error;

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 floresta-chain = { workspace = true, features = ["bitcoinkernel"] }
 floresta-compact-filters = { workspace = true }
 floresta-common = { workspace = true }
+floresta-domain = {workspace = true, features = ["wallet"]}
 floresta-watch-only = { workspace = true }
 floresta-wire = { workspace = true }
 

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -328,7 +328,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             "blockchain.relayfee" => json_rpc_res!(request, 0.00001),
             "blockchain.scripthash.get_balance" => {
                 let script_hash = get_arg!(request, sha256::Hash, 0);
-                let balance = self.address_cache.get_address_balance(&script_hash);
+                let balance = self.address_cache.get_address_balance(&script_hash)?;
                 let result = json!({
                     "confirmed": balance,
                     "unconfirmed": 0
@@ -338,7 +338,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             "blockchain.scripthash.get_history" => {
                 let script_hash = get_arg!(request, sha256::Hash, 0);
                 self.address_cache
-                    .get_address_history(&script_hash)
+                    .get_address_history(&script_hash)?
                     .map(|transactions| {
                         let res = Self::process_history(&transactions);
                         json_rpc_res!(request, res)
@@ -354,7 +354,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             "blockchain.scripthash.get_mempool" => json_rpc_res!(request, []),
             "blockchain.scripthash.listunspent" => {
                 let hash = get_arg!(request, sha256::Hash, 0);
-                let utxos = self.address_cache.get_address_utxos(&hash);
+                let utxos = self.address_cache.get_address_utxos(&hash)?;
                 if utxos.is_none() {
                     return json_rpc_res!(request, []);
                 }
@@ -376,7 +376,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let hash = get_arg!(request, sha256::Hash, 0);
                 self.client_addresses.insert(hash, client);
 
-                let history = self.address_cache.get_address_history(&hash);
+                let history = self.address_cache.get_address_history(&hash)?;
                 match history {
                     Some(transactions) if !transactions.is_empty() => {
                         let res = get_status(transactions);
@@ -398,8 +398,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let script = get_arg!(request, ScriptBuf, 0);
                 let hash = get_spk_hash(&script);
 
-                if !self.address_cache.is_address_cached(&hash) {
-                    self.address_cache.cache_address(script.clone());
+                if !self.address_cache.is_address_cached(&hash)? {
+                    self.address_cache.cache_address(script.clone())?;
                     self.addresses_to_scan.push(script);
                     let res = json!({
                         "confirmed": 0,
@@ -408,7 +408,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     return json_rpc_res!(request, res);
                 }
 
-                let balance = self.address_cache.get_address_balance(&hash);
+                let balance = self.address_cache.get_address_balance(&hash)?;
                 let result = json!({
                     "confirmed": balance,
                     "unconfirmed": 0
@@ -419,14 +419,14 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let script = get_arg!(request, ScriptBuf, 0);
                 let hash = get_spk_hash(&script);
 
-                if !self.address_cache.is_address_cached(&hash) {
-                    self.address_cache.cache_address(script.clone());
+                if !self.address_cache.is_address_cached(&hash)? {
+                    self.address_cache.cache_address(script.clone())?;
                     self.addresses_to_scan.push(script);
                     return json_rpc_res!(request, null);
                 }
 
                 self.address_cache
-                    .get_address_history(&hash)
+                    .get_address_history(&hash)?
                     .map(|transactions| {
                         let res = Self::process_history(&transactions);
                         json_rpc_res!(request, res)
@@ -444,7 +444,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let hash = get_spk_hash(&script);
                 self.client_addresses.insert(hash, client);
 
-                let history = self.address_cache.get_address_history(&hash);
+                let history = self.address_cache.get_address_history(&hash)?;
                 match history {
                     Some(transactions) if !transactions.is_empty() => {
                         let res = get_status(transactions);
@@ -486,17 +486,17 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
 
                 let updated = self
                     .address_cache
-                    .cache_mempool_transaction(&tx)
+                    .cache_mempool_transaction(&tx)?
                     .into_iter()
                     .map(|spend| (tx.clone(), spend))
                     .collect::<Vec<_>>();
 
-                self.wallet_notify(&updated);
+                self.wallet_notify(&updated)?;
                 json_rpc_res!(request, txid)
             }
             "blockchain.transaction.get" => {
                 let tx_id = get_arg!(request, Txid, 0);
-                let tx = self.address_cache.get_cached_transaction(&tx_id);
+                let tx = self.address_cache.get_cached_transaction(&tx_id)?;
                 if let Some(tx) = tx {
                     return json_rpc_res!(request, tx);
                 }
@@ -505,8 +505,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }
             "blockchain.transaction.get_merkle" => {
                 let tx_id = get_arg!(request, Txid, 0);
-                let proof = self.address_cache.get_merkle_proof(&tx_id);
-                let height = self.address_cache.get_height(&tx_id);
+                let proof = self.address_cache.get_merkle_proof(&tx_id)?;
+                let height = self.address_cache.get_height(&tx_id)?;
                 if let Some(proof) = proof {
                     let result = json!({
                         "merkle": proof.hashes,
@@ -575,7 +575,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
 
         loop {
             for (block, height) in blocks.recv() {
-                self.handle_block(block, height);
+                if let Err(e) = self.handle_block(block, height) {
+                    error!("Error in processing block: {e}")
+                }
             }
 
             // handles client requests
@@ -611,7 +613,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 }
 
                 self.addresses_to_scan.iter().for_each(|address| {
-                    self.address_cache.cache_address(address.clone());
+                    if let Err(e) = self.address_cache.cache_address(address.clone()) {
+                        error!("Error in cache address: {e}")
+                    }
                 });
 
                 info!("Catching up with addresses {:?}", self.addresses_to_scan);
@@ -681,7 +685,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 .flatten()
                 .unwrap();
 
-            self.handle_block(block, height);
+            self.handle_block(block, height)?;
         }
 
         Ok(())
@@ -708,7 +712,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         res
     }
 
-    fn handle_block(&self, block: bitcoin::Block, height: u32) {
+    fn handle_block(&self, block: bitcoin::Block, height: u32) -> Result<(), super::error::Error> {
         let result = json!({
             "jsonrpc": "2.0",
             "method": "blockchain.headers.subscribe",
@@ -718,10 +722,10 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }]
         });
 
-        let current_height = self.address_cache.get_cache_height();
+        let current_height = self.address_cache.get_cache_height()?;
 
         if (!self.chain.is_in_ibd() || height % 1000 == 0) && (height > current_height) {
-            self.address_cache.bump_height(height);
+            self.address_cache.bump_height(height)?;
         }
 
         if self.chain.get_height().unwrap() == height {
@@ -730,9 +734,9 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
             }
         }
 
-        let transactions = self.address_cache.block_process(&block, height);
+        let transactions = self.address_cache.block_process(&block, height)?;
 
-        self.wallet_notify(&transactions);
+        self.wallet_notify(&transactions)
     }
 
     /// Handles each kind of Message
@@ -822,13 +826,19 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         Ok(())
     }
 
-    fn wallet_notify(&self, transactions: &[(Transaction, TxOut)]) {
+    fn wallet_notify(
+        &self,
+        transactions: &[(Transaction, TxOut)],
+    ) -> Result<(), crate::error::Error> {
         for (_, out) in transactions {
             let hash = get_spk_hash(&out.script_pubkey);
             if let Some(client) = self.client_addresses.get(&hash) {
-                let history = self.address_cache.get_address_history(&hash);
+                let history = self
+                    .address_cache
+                    .get_address_history(&hash)?
+                    .ok_or(crate::error::Error::InvalidParams)?;
 
-                let status_hash = get_status(history.unwrap());
+                let status_hash = get_status(history);
                 let notify = json!({
                     "jsonrpc": "2.0",
                     "method": "blockchain.scripthash.subscribe",
@@ -838,6 +848,8 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 try_and_log!(client.write(serde_json::to_string(&notify).unwrap().as_bytes()));
             }
         }
+
+        Ok(())
     }
 }
 
@@ -1038,16 +1050,18 @@ mod test {
 
         // Inserting test transactions in the wallet
         let (transaction, proof) = get_test_transaction();
-        cache.cache_transaction(
-            &transaction,
-            118511,
-            transaction.output[0].value.to_sat(),
-            proof,
-            1,
-            0,
-            false,
-            get_spk_hash(&transaction.output[0].script_pubkey),
-        );
+        cache
+            .cache_transaction(
+                &transaction,
+                118511,
+                transaction.output[0].value.to_sat(),
+                proof,
+                1,
+                0,
+                false,
+                get_spk_hash(&transaction.output[0].script_pubkey),
+            )
+            .unwrap();
 
         Arc::new(cache)
     }

--- a/crates/floresta-electrum/src/error.rs
+++ b/crates/floresta-electrum/src/error.rs
@@ -4,6 +4,7 @@ use core::error;
 use core::fmt;
 
 use floresta_common::impl_error_from;
+use floresta_domain::wallet::error::WatchOnlyError;
 use tokio::sync::oneshot;
 
 #[derive(Debug)]
@@ -20,6 +21,8 @@ pub enum Error {
     Mempool(Box<dyn error::Error + Send + 'static>),
     /// The node is unresponsive.
     NodeHandle(oneshot::error::RecvError),
+    /// Wallet error
+    WalletError(WatchOnlyError),
 }
 
 impl fmt::Display for Error {
@@ -31,6 +34,7 @@ impl fmt::Display for Error {
             Self::Io(e) => write!(f, "IO error: {e}"),
             Self::Mempool(e) => writeln!(f, "Mempool error: {e}"),
             Self::NodeHandle(e) => write!(f, "The node is unresponsive: {e}"),
+            Self::WalletError(e) => write!(f, "Wallet error: {e}"),
         }
     }
 }
@@ -44,6 +48,7 @@ impl error::Error for Error {
             Self::Io(e) => Some(e),
             Self::Mempool(e) => Some(e.as_ref()),
             Self::NodeHandle(e) => Some(e),
+            Self::WalletError(e) => Some(e),
         }
     }
 }
@@ -51,3 +56,4 @@ impl error::Error for Error {
 impl_error_from!(Error, serde_json::Error, Parsing);
 impl_error_from!(Error, std::io::Error, Io);
 impl_error_from!(Error, oneshot::error::RecvError, NodeHandle);
+impl_error_from!(Error, WatchOnlyError, WalletError);

--- a/crates/floresta-mempool/Cargo.toml
+++ b/crates/floresta-mempool/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 
 # Local dependencies
 floresta-chain = { workspace = true }
-floresta-domain = { workspace = true }
+floresta-domain = { workspace = true, features = ["mempool"] }
 
 [dev-dependencies]
 floresta-common = { workspace = true }

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -30,7 +30,7 @@ time = { workspace = true }
 floresta-chain = { workspace = true, features = ["bitcoinkernel"] }
 floresta-compact-filters = { workspace = true, optional = true }
 floresta-common = { workspace = true }
-floresta-domain = { workspace = true }
+floresta-domain = { workspace = true, features = ["mempool"] }
 floresta-electrum = { workspace = true }
 floresta-mempool = { workspace = true }
 floresta-watch-only = { workspace = true }

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -30,7 +30,7 @@ time = { workspace = true }
 floresta-chain = { workspace = true, features = ["bitcoinkernel"] }
 floresta-compact-filters = { workspace = true, optional = true }
 floresta-common = { workspace = true }
-floresta-domain = { workspace = true, features = ["mempool"] }
+floresta-domain = { workspace = true, features = ["mempool", "wallet"] }
 floresta-electrum = { workspace = true }
 floresta-mempool = { workspace = true }
 floresta-watch-only = { workspace = true }

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -12,8 +12,7 @@ use floresta_chain::BlockValidationErrors;
 use floresta_chain::BlockchainError;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::IterableFilterStoreError;
-use floresta_watch_only::WatchOnlyError;
-use floresta_watch_only::descriptor::DescriptorError;
+use floresta_domain::wallet::error::WatchOnlyError;
 use floresta_watch_only::kv_database::KvDatabaseError;
 use tokio_rustls::rustls::pki_types;
 
@@ -45,9 +44,6 @@ pub enum FlorestadError {
 
     /// TOML parsing error.
     TomlParsing(toml::de::Error),
-
-    /// Parsing registered HD version bytes from slip132.
-    WalletInput(DescriptorError),
 
     /// Parsing a bitcoin address.
     AddressParsing(bitcoin::address::ParseError),
@@ -137,7 +133,6 @@ impl Display for FlorestadError {
                 write!(f, "Error with our blockchain backend: {err:?}")
             }
             Self::SerdeJson(err) => write!(f, "Error serializing object {err}"),
-            Self::WalletInput(err) => write!(f, "Error while parsing user input {err:?}"),
             Self::TomlParsing(err) => write!(f, "Error deserializing toml file {err}"),
             Self::AddressParsing(err) => write!(f, "Invalid address {err}"),
             Self::Miniscript(err) => write!(f, "Miniscript error: {err}"),
@@ -248,7 +243,6 @@ impl_from_error!(Io, std::io::Error);
 impl_from_error!(ScriptValidation, bitcoin::blockdata::script::Error);
 impl_from_error!(Blockchain, BlockchainError);
 impl_from_error!(SerdeJson, serde_json::Error);
-impl_from_error!(WalletInput, DescriptorError);
 impl_from_error!(TomlParsing, toml::de::Error);
 impl_from_error!(BlockValidation, BlockValidationErrors);
 impl_from_error!(AddressParsing, bitcoin::address::ParseError);

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -83,7 +83,7 @@ pub enum FlorestadError {
     CouldNotOpenKvDatabase(KvDatabaseError),
 
     /// Initializing the watch-only wallet.
-    CouldNotInitializeWallet(WatchOnlyError<KvDatabaseError>),
+    CouldNotInitializeWallet(WatchOnlyError),
 
     /// Setting up the watch-only wallet.
     CouldNotSetupWallet(String),
@@ -105,7 +105,7 @@ pub enum FlorestadError {
     CouldNotCreateTLSDataDir(PathBuf, std::io::Error),
 
     /// Failed to obtain the wallet cache.
-    CouldNotObtainWalletCache(WatchOnlyError<KvDatabaseError>),
+    CouldNotObtainWalletCache(WatchOnlyError),
 
     /// Failed to push a descriptor to the wallet.
     CouldNotPushDescriptor(String),
@@ -253,6 +253,6 @@ impl_from_error!(TomlParsing, toml::de::Error);
 impl_from_error!(BlockValidation, BlockValidationErrors);
 impl_from_error!(AddressParsing, bitcoin::address::ParseError);
 impl_from_error!(Miniscript, miniscript::Error);
-impl_from_error!(CouldNotObtainWalletCache, WatchOnlyError<KvDatabaseError>);
+impl_from_error!(CouldNotObtainWalletCache, WatchOnlyError);
 
 impl error::Error for FlorestadError {}

--- a/crates/floresta-node/src/error.rs
+++ b/crates/floresta-node/src/error.rs
@@ -13,7 +13,6 @@ use floresta_chain::BlockchainError;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::IterableFilterStoreError;
 use floresta_domain::wallet::error::WatchOnlyError;
-use floresta_watch_only::kv_database::KvDatabaseError;
 use tokio_rustls::rustls::pki_types;
 
 #[derive(Debug)]
@@ -74,9 +73,6 @@ pub enum FlorestadError {
 
     /// Data directory doesn't exist or is not writable.
     InvalidDataDir(PathBuf),
-
-    /// Obtaining a lock on the data directory.
-    CouldNotOpenKvDatabase(KvDatabaseError),
 
     /// Initializing the watch-only wallet.
     CouldNotInitializeWallet(WatchOnlyError),
@@ -170,9 +166,6 @@ impl Display for FlorestadError {
                     "Data directory at path={} doesn't exist or is not writable",
                     path.display()
                 )
-            }
-            Self::CouldNotOpenKvDatabase(err) => {
-                write!(f, "Cannot open a key-value database: {err}")
             }
             Self::CouldNotInitializeWallet(err) => {
                 write!(f, "Could not initialize wallet: {err}")

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -753,7 +753,7 @@ impl Florestad {
         }
 
         for address in self.get_addresses()? {
-            wallet.cache_address(address);
+            wallet.cache_address(address)?;
         }
 
         info!("Wallet setup completed!");

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -733,7 +733,7 @@ impl Florestad {
         for descriptor in self.get_descriptors() {
             match wallet.push_descriptor(&descriptor) {
                 Ok(_) => info!("Added descriptor to wallet: {descriptor}"),
-                Err(WatchOnlyError::DuplicateDescriptor(_)) => {
+                Err(WatchOnlyError::DuplicateDescriptor { descriptor: _ }) => {
                     warn!("Descriptor already exists in wallet, skipping: {descriptor}");
                 }
                 Err(e) => {
@@ -745,7 +745,7 @@ impl Florestad {
         for xpub in self.get_xpubs() {
             match wallet.push_xpub(&xpub, self.config.network) {
                 Ok(()) => info!("Added xpubs to wallet: {xpub}"),
-                Err(WatchOnlyError::DuplicateDescriptor(_)) => warn!(
+                Err(WatchOnlyError::DuplicateDescriptor { descriptor: _ }) => warn!(
                     "Descriptor for the provided XPUB already exists in the wallet. Skipping: {xpub}"
                 ),
                 Err(e) => return Err(FlorestadError::from(e)),

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -720,10 +720,7 @@ impl Florestad {
 
     /// Setup the wallet by initializing the database and adding descriptors, xpubs, and addresses.
     fn setup_wallet(&self) -> Result<AddressCache<KvDatabase>, FlorestadError> {
-        let database = KvDatabase::new(&self.config.datadir)
-            .map_err(FlorestadError::CouldNotOpenKvDatabase)?;
-
-        let wallet = AddressCache::new(database);
+        let wallet = AddressCache::<KvDatabase>::new_default(&self.config.datadir)?;
 
         wallet
             .setup()

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -32,11 +32,11 @@ use floresta_common::try_and_log;
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::network_filters::NetworkFilters;
+use floresta_domain::wallet::error::WatchOnlyError;
 use floresta_electrum::electrum_protocol::ElectrumServer;
 use floresta_electrum::electrum_protocol::client_accept_loop;
 use floresta_mempool::Mempool;
 use floresta_watch_only::AddressCache;
-use floresta_watch_only::WatchOnlyError;
 use floresta_watch_only::kv_database::KvDatabase;
 use floresta_wire::UtreexoNodeConfig;
 use floresta_wire::address_man::AddressMan;

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -71,7 +71,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     pub fn get_block_by_txid(&self, txid: &Txid) -> Result<Block, JsonRpcError> {
         let height = self
             .wallet
-            .get_height(txid)
+            .get_height(txid)?
             .ok_or(JsonRpcError::TxNotFound)?;
         let blockhash = self
             .chain
@@ -542,12 +542,12 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         _include_mempool: bool,
     ) -> Result<Option<GetTxOut>, JsonRpcError> {
         let res = match (
-            self.wallet.get_transaction(&txid),
-            self.wallet.get_height(&txid),
+            self.wallet.get_transaction(&txid)?,
+            self.wallet.get_height(&txid)?,
             self.wallet.get_utxo(&OutPoint {
                 txid,
                 vout: outpoint,
-            }),
+            })?,
         ) {
             (Some(cached_tx), Some(height), Some(txout)) => {
                 let is_coinbase = cached_tx.tx.is_coinbase();
@@ -666,7 +666,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         script: ScriptBuf,
         height: u32,
     ) -> Result<Value, JsonRpcError> {
-        if let Some(txout) = self.wallet.get_utxo(&OutPoint { txid, vout }) {
+        if let Some(txout) = self.wallet.get_utxo(&OutPoint { txid, vout })? {
             return Ok(serde_json::to_value(txout).expect(SERIALIZATION_EXPECT_MSG));
         }
 
@@ -680,7 +680,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             return Err(JsonRpcError::NoBlockFilters);
         };
 
-        self.wallet.cache_address(script.clone());
+        self.wallet.cache_address(script.clone())?;
         let filter_key = script.to_bytes();
         let candidates = cfilters
             .match_any(
@@ -709,7 +709,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 return Err(JsonRpcError::BlockNotFound);
             };
 
-            self.wallet.block_process(&candidate, height);
+            self.wallet.block_process(&candidate, height)?;
         }
 
         let val = match self.get_tx_out(txid, vout, false)? {

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -494,8 +494,8 @@ pub mod jsonrpc_interface {
     }
 
     impl_error_from!(JsonRpcError, miniscript::Error, InvalidDescriptor);
-    impl<T: fmt::Debug> From<WatchOnlyError<T>> for JsonRpcError {
-        fn from(e: WatchOnlyError<T>) -> Self {
+    impl From<WatchOnlyError> for JsonRpcError {
+        fn from(e: WatchOnlyError) -> Self {
             Self::Wallet(e.to_string())
         }
     }

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -44,7 +44,7 @@ pub mod jsonrpc_interface {
     use floresta_chain::extensions::HeaderExtError;
     use floresta_common::impl_error_from;
     use floresta_domain::mempool::MempoolError;
-    use floresta_watch_only::WatchOnlyError;
+    use floresta_domain::wallet::error::WatchOnlyError;
     use floresta_wire::bitcoin_socket_addr::InvalidAddressError;
     use serde::Deserialize;
     use serde::Serialize;

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -106,7 +106,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
         let tx = self
             .wallet
-            .get_transaction(&tx_id)
+            .get_transaction(&tx_id)?
             .ok_or(JsonRpcError::TxNotFound)?;
 
         match verbosity {
@@ -123,7 +123,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         info!("Descriptor pushed: {descriptor}");
         debug!("Rescanning with block filters for addresses: {addresses:?}");
 
-        let addresses = self.wallet.get_cached_addresses();
+        let addresses = self.wallet.get_cached_addresses()?;
         let wallet = self.wallet.clone();
         let cfilters = self
             .block_filter_storage
@@ -160,7 +160,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             return Err(JsonRpcError::InInitialBlockDownload);
         }
 
-        let addresses = self.wallet.get_cached_addresses();
+        let addresses = self.wallet.get_cached_addresses()?;
 
         if addresses.is_empty() {
             return Err(JsonRpcError::NoAddressesToRescan);
@@ -528,7 +528,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                     .map_err(|_| JsonRpcError::Chain)?
                     .ok_or(JsonRpcError::BlockNotFound)?;
 
-                wallet.block_process(&block, height);
+                wallet.block_process(&block, height)?;
             }
         }
 

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -22,6 +22,7 @@ miniscript = { workspace = true, features = ["compiler", "std"] }
 # Local dependencies
 floresta-chain = { workspace = true }
 floresta-common = { workspace = true }
+floresta-domain = { workspace = true, features = ["wallet"] }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/floresta-watch-only/src/descriptor/mod.rs
+++ b/crates/floresta-watch-only/src/descriptor/mod.rs
@@ -4,10 +4,12 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::str::FromStr;
+use std::fmt::Debug;
 
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
 use floresta_common::impl_error_from;
+use floresta_domain::wallet::error::WatchOnlyError;
 use miniscript::Descriptor;
 use miniscript::DescriptorPublicKey;
 use miniscript::Error as MiniscriptError;
@@ -15,9 +17,9 @@ use miniscript::descriptor::NonDefiniteKeyError;
 
 mod slip132;
 
+use super::descriptor::slip132::Error as Slip132Error;
 use super::descriptor::slip132::generate_descriptor_from_xpub;
 use super::descriptor::slip132::is_xpub_mainnet;
-use crate::descriptor::slip132::Error as Slip132Error;
 
 #[derive(Debug)]
 pub enum DescriptorError {
@@ -36,6 +38,12 @@ pub enum DescriptorError {
 impl_error_from!(DescriptorError, Slip132Error, XpubParseError);
 impl_error_from!(DescriptorError, MiniscriptError, MiniscriptError);
 impl_error_from!(DescriptorError, NonDefiniteKeyError, DeriveDescriptorError);
+
+impl From<DescriptorError> for WatchOnlyError {
+    fn from(e: DescriptorError) -> Self {
+        Self::InvalidDescriptor(e.to_string())
+    }
+}
 
 impl Display for DescriptorError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/crates/floresta-watch-only/src/descriptor/slip132.rs
+++ b/crates/floresta-watch-only/src/descriptor/slip132.rs
@@ -134,6 +134,9 @@ impl Display for Error {
     }
 }
 
+impl_error_from!(Error, base58::Error, Base58);
+impl_error_from!(Error, bip32::Error, Bip32);
+
 /// Extracts the 4-byte prefix from the SLIP132-encoded string and validates it.
 fn extract_slip132_prefix(s: &str) -> Result<[u8; 4], Error> {
     let data = base58::decode_check(s)?;
@@ -167,9 +170,6 @@ fn validate_slip132_prefix(prefix: [u8; 4]) -> Result<(), Error> {
         _ => Err(Error::UnknownSlip32Prefix),
     }
 }
-
-impl_error_from!(Error, base58::Error, Base58);
-impl_error_from!(Error, bip32::Error, Bip32);
 
 /// Trait for building standard BIP32 extended keys from SLIP132 variant.
 pub trait FromSlip132 {

--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -13,6 +13,7 @@ use bitcoin::consensus::serialize;
 use bitcoin::hashes::Hash;
 use floresta_common::impl_error_from;
 use floresta_common::prelude::*;
+use floresta_domain::wallet::error::WatchOnlyError;
 use kv::Bucket;
 use kv::Config;
 use kv::Store;
@@ -21,7 +22,6 @@ use super::AddressCacheDatabase;
 use super::CachedAddress;
 use super::CachedTransaction;
 use super::Stats;
-use crate::WatchOnlyError;
 
 /// A key-value database for the watch-only wallet.
 pub struct KvDatabase(Store, Bucket<'static, String, Vec<u8>>);

--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -21,6 +21,7 @@ use super::AddressCacheDatabase;
 use super::CachedAddress;
 use super::CachedTransaction;
 use super::Stats;
+use crate::WatchOnlyError;
 
 /// A key-value database for the watch-only wallet.
 pub struct KvDatabase(Store, Bucket<'static, String, Vec<u8>>);
@@ -75,6 +76,12 @@ impl Error for KvDatabaseError {}
 impl_error_from!(KvDatabaseError, serde_json::Error, SerdeJsonError);
 impl_error_from!(KvDatabaseError, kv::Error, KvError);
 impl_error_from!(KvDatabaseError, EncodingError, DeserializeError);
+
+impl From<KvDatabaseError> for WatchOnlyError {
+    fn from(e: KvDatabaseError) -> Self {
+        Self::DatabaseError(e.to_string())
+    }
+}
 
 type Result<T> = floresta_common::prelude::Result<T, KvDatabaseError>;
 

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -57,28 +57,20 @@ const DERIVATION_COUNT: u32 = 100;
 const INDEX_INITIAL: u32 = 0;
 
 #[derive(Debug)]
-pub enum WatchOnlyError<DatabaseError: Debug> {
-    WalletNotInitialized,
-    TransactionNotFound,
-    DatabaseError(DatabaseError),
-    DuplicateDescriptor(String),
+pub enum WatchOnlyError {
+    DatabaseError(String),
+    DuplicateDescriptor { descriptor: String },
     InvalidDescriptor(DescriptorError),
 }
 
-impl<DatabaseError: Debug> Display for WatchOnlyError<DatabaseError> {
+impl Display for WatchOnlyError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::WalletNotInitialized => {
-                write!(f, "Wallet isn't initialized")
-            }
-            Self::TransactionNotFound => {
-                write!(f, "Transaction not found")
-            }
             Self::DatabaseError(e) => {
-                write!(f, "Database error: {e:?}")
+                write!(f, "Database error: {e}")
             }
-            Self::DuplicateDescriptor(desc) => {
-                write!(f, "Descriptor is already cached: {desc}")
+            Self::DuplicateDescriptor { descriptor } => {
+                write!(f, "Descriptor is already cached: {descriptor}")
             }
             Self::InvalidDescriptor(e) => {
                 write!(f, "Invalid descriptor: {e:?}")
@@ -87,13 +79,7 @@ impl<DatabaseError: Debug> Display for WatchOnlyError<DatabaseError> {
     }
 }
 
-impl<DatabaseError: Debug> From<DatabaseError> for WatchOnlyError<DatabaseError> {
-    fn from(e: DatabaseError) -> Self {
-        Self::DatabaseError(e)
-    }
-}
-
-impl<T: Debug> Error for WatchOnlyError<T> {}
+impl Error for WatchOnlyError {}
 
 /// Every address contains zero or more associated transactions, this struct defines what
 /// data we store for those.
@@ -205,7 +191,10 @@ struct AddressCacheInner<D: AddressCacheDatabase> {
     utxo_index: HashMap<OutPoint, Hash>,
 }
 
-impl<D: AddressCacheDatabase> AddressCacheInner<D> {
+impl<D: AddressCacheDatabase> AddressCacheInner<D>
+where
+    WatchOnlyError: From<<D as AddressCacheDatabase>::Error>,
+{
     /// Iterates through a block, finds transactions destined to ourselves.
     /// Returns all transactions we found.
     fn block_process(&mut self, block: &Block, height: u32) -> Vec<(Transaction, TxOut)> {
@@ -360,14 +349,14 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
 
     /// Setup is the first command that should be executed. In a new cache. It sets our wallet's
     /// state, like the height we should start scanning and the wallet's descriptor.
-    fn setup(&self) -> Result<(), WatchOnlyError<D::Error>> {
+    fn setup(&self) -> Result<(), WatchOnlyError> {
         if self.database.get_descriptors().is_err() {
             self.database.set_cache_height(0)?;
         }
         Ok(())
     }
 
-    fn derive_addresses(&mut self) -> Result<(), WatchOnlyError<D::Error>> {
+    fn derive_addresses(&mut self) -> Result<(), WatchOnlyError> {
         let mut stats = self.database.get_stats()?;
         let descriptors = self.database.get_descriptors()?;
 
@@ -396,7 +385,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
         }
     }
 
-    fn find_unconfirmed(&self) -> Result<Vec<Transaction>, WatchOnlyError<D::Error>> {
+    fn find_unconfirmed(&self) -> Result<Vec<Transaction>, WatchOnlyError> {
         let transactions = self.database.list_transactions()?;
         let mut unconfirmed = Vec::new();
 
@@ -585,7 +574,10 @@ pub struct AddressCache<D: AddressCacheDatabase> {
     inner: RwLock<AddressCacheInner<D>>,
 }
 
-impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressCache<D> {
+impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressCache<D>
+where
+    WatchOnlyError: From<<D as AddressCacheDatabase>::Error>,
+{
     fn wants_spent_utxos(&self) -> bool {
         false
     }
@@ -600,7 +592,10 @@ impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressC
     }
 }
 
-impl<D: AddressCacheDatabase> AddressCache<D> {
+impl<D: AddressCacheDatabase> AddressCache<D>
+where
+    WatchOnlyError: From<<D as AddressCacheDatabase>::Error>,
+{
     pub fn new(database: D) -> Self {
         Self {
             inner: RwLock::new(AddressCacheInner::new(database)),
@@ -651,7 +646,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
     }
 
     /// Tells whether or not a descriptor is already cached
-    pub fn is_cached(&self, desc: &str) -> Result<bool, WatchOnlyError<D::Error>> {
+    pub fn is_cached(&self, desc: &str) -> Result<bool, WatchOnlyError> {
         let inner = self.inner.read().expect("poisoned lock");
         let known_descs = inner.database.get_descriptors()?;
         Ok(known_descs.iter().any(|s| s == desc))
@@ -664,12 +659,11 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
     }
 
     /// Push a descriptor into the wallet checking whether it is already cached, returning an error if so
-    pub fn push_descriptor(
-        &self,
-        descriptor: &str,
-    ) -> Result<Vec<ScriptBuf>, WatchOnlyError<D::Error>> {
+    pub fn push_descriptor(&self, descriptor: &str) -> Result<Vec<ScriptBuf>, WatchOnlyError> {
         if self.is_cached(descriptor)? {
-            return Err(WatchOnlyError::DuplicateDescriptor(descriptor.to_string()));
+            return Err(WatchOnlyError::DuplicateDescriptor {
+                descriptor: descriptor.to_string(),
+            });
         }
 
         let address_descriptors =
@@ -688,7 +682,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
 
     /// Adds an XPUB to the wallet, derives descriptors from it, saves these descriptors persistently,
     /// derives addresses, and caches them if they're not cached already.
-    pub fn push_xpub(&self, xpub: &str, network: Network) -> Result<(), WatchOnlyError<D::Error>> {
+    pub fn push_xpub(&self, xpub: &str, network: Network) -> Result<(), WatchOnlyError> {
         let descriptors = parse_xpub(xpub, network).map_err(WatchOnlyError::InvalidDescriptor)?;
 
         for descriptor in descriptors {
@@ -714,7 +708,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         Some(serialize_hex(&tx.tx))
     }
 
-    pub fn setup(&self) -> Result<(), WatchOnlyError<D::Error>> {
+    pub fn setup(&self) -> Result<(), WatchOnlyError> {
         let inner = self.inner.read().expect("poisoned lock");
         inner.setup()
     }
@@ -747,17 +741,14 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         inner.get_merkle_proof(txid)
     }
 
-    pub fn derive_addresses(&self) -> Result<(), WatchOnlyError<D::Error>> {
+    pub fn derive_addresses(&self) -> Result<(), WatchOnlyError> {
         let mut inner = self.inner.write().expect("poisoned lock");
         inner.derive_addresses()
     }
 
-    pub fn get_stats(&self) -> Result<Stats, WatchOnlyError<D::Error>> {
+    pub fn get_stats(&self) -> Result<Stats, WatchOnlyError> {
         let inner = self.inner.read().expect("poisoned lock");
-        inner
-            .database
-            .get_stats()
-            .map_err(WatchOnlyError::DatabaseError)
+        Ok(inner.database.get_stats()?)
     }
 
     pub fn maybe_derive_addresses(&self) {
@@ -765,7 +756,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         inner.maybe_derive_addresses()
     }
 
-    pub fn find_unconfirmed(&self) -> Result<Vec<Transaction>, WatchOnlyError<D::Error>> {
+    pub fn find_unconfirmed(&self) -> Result<Vec<Transaction>, WatchOnlyError> {
         let inner = self.inner.read().expect("poisoned lock");
         inner.find_unconfirmed()
     }
@@ -805,12 +796,9 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         )
     }
 
-    pub fn get_descriptors(&self) -> Result<Vec<String>, WatchOnlyError<D::Error>> {
+    pub fn get_descriptors(&self) -> Result<Vec<String>, WatchOnlyError> {
         let inner = self.inner.read().expect("poisoned lock");
-        inner
-            .database
-            .get_descriptors()
-            .map_err(WatchOnlyError::DatabaseError)
+        Ok(inner.database.get_descriptors()?)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -10,6 +10,8 @@
 
 use core::cmp::Ordering;
 use core::fmt::Debug;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
 
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
@@ -544,6 +546,22 @@ pub struct AddressCache<D: AddressCacheDatabase> {
     inner: RwLock<AddressCacheInner<D>>,
 }
 
+impl<D: AddressCacheDatabase> AddressCache<D> {
+    fn get_inner(&self) -> Result<RwLockReadGuard<'_, AddressCacheInner<D>>, WatchOnlyError> {
+        self.inner
+            .read()
+            .map_err(|e| WatchOnlyError::InternalError(format!("lock poisoned: {e}")))
+    }
+
+    fn get_inner_write(
+        &self,
+    ) -> Result<RwLockWriteGuard<'_, AddressCacheInner<D>>, WatchOnlyError> {
+        self.inner
+            .write()
+            .map_err(|e| WatchOnlyError::InternalError(format!("lock poisoned: {e}")))
+    }
+}
+
 impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressCache<D>
 where
     WatchOnlyError: From<<D as AddressCacheDatabase>::Error>,
@@ -558,10 +576,13 @@ where
         height: u32,
         _spent_utxos: Option<&HashMap<OutPoint, UtxoData>>,
     ) {
-        self.block_process(block, height);
+        if let Err(err) = self.block_process(block, height) {
+            error!("Error processing block: {err:?}");
+        }
     }
 }
 
+pub type AddressUtxos = Vec<(TxOut, OutPoint)>;
 impl<D: AddressCacheDatabase> AddressCache<D>
 where
     WatchOnlyError: From<<D as AddressCacheDatabase>::Error>,
@@ -572,60 +593,62 @@ where
         }
     }
 
-    pub fn get_utxo(&self, outpoint: &OutPoint) -> Option<TxOut> {
-        let inner = self.inner.read().expect("poisoned lock");
+    pub fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<TxOut>, WatchOnlyError> {
+        let inner = self.get_inner()?;
         // a dirty way to check if the utxo is still unspent
-        let _ = inner.utxo_index.get(outpoint)?;
-        let tx = inner.get_transaction(&outpoint.txid)?;
+        if !inner.utxo_index.contains_key(outpoint) {
+            return Ok(None);
+        }
+        let tx = inner.get_transaction(&outpoint.txid);
 
-        Some(tx.tx.output[outpoint.vout as usize].clone())
+        match tx {
+            None => Ok(None),
+            Some(tx) => Ok(Some(tx.tx.output[outpoint.vout as usize].clone())),
+        }
     }
 
-    pub fn n_cached_addresses(&self) -> usize {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.address_map.len()
+    pub fn n_cached_addresses(&self) -> Result<usize, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.address_map.len())
     }
 
     /// Returns the balance of this address, debts (spends) are taken in account
-    pub fn get_address_balance(&self, script_hash: &Hash) -> Option<u64> {
-        let inner = self.inner.read().expect("poisoned lock");
-
-        Some(inner.address_map.get(script_hash)?.balance)
+    pub fn get_address_balance(&self, script_hash: &Hash) -> Result<Option<u64>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.address_map.get(script_hash).map(|a| a.balance))
     }
 
-    pub fn get_cached_addresses(&self) -> Vec<ScriptBuf> {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner
+    pub fn get_cached_addresses(&self) -> Result<Vec<ScriptBuf>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner
             .address_map
             .values()
             .map(|address| address.script.clone())
-            .collect()
+            .collect())
     }
 
-    pub fn bump_height(&self, height: u32) {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner
-            .database
-            .set_cache_height(height)
-            .expect("Database is not working");
+    pub fn bump_height(&self, height: u32) -> Result<(), WatchOnlyError> {
+        let inner = self.get_inner()?;
+        inner.database.set_cache_height(height)?;
+        Ok(())
     }
 
-    pub fn get_cache_height(&self) -> u32 {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.database.get_cache_height().unwrap_or(0)
+    pub fn get_cache_height(&self) -> Result<u32, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.database.get_cache_height().unwrap_or(0))
     }
 
     /// Tells whether or not a descriptor is already cached
     pub fn is_cached(&self, desc: &str) -> Result<bool, WatchOnlyError> {
-        let inner = self.inner.read().expect("poisoned lock");
+        let inner = self.get_inner()?;
         let known_descs = inner.database.get_descriptors()?;
         Ok(known_descs.iter().any(|s| s == desc))
     }
 
     /// Tells whether an address is already cached
-    pub fn is_address_cached(&self, script_hash: &Hash) -> bool {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.address_map.contains_key(script_hash)
+    pub fn is_address_cached(&self, script_hash: &Hash) -> Result<bool, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.address_map.contains_key(script_hash))
     }
 
     /// Push a descriptor into the wallet checking whether it is already cached, returning an error if so
@@ -640,10 +663,13 @@ where
             derive_addresses_from_descriptor(descriptor, INDEX_INITIAL, DERIVATION_COUNT)?;
 
         for address in address_descriptors.clone() {
-            self.cache_address(address);
+            self.cache_address(address).map_err(|e| {
+                error!("Error caching address: {e:?}");
+                e
+            })?;
         }
 
-        let inner = self.inner.write().expect("poisoned lock");
+        let inner = self.get_inner_write()?;
         inner.database.save_descriptor(descriptor)?;
 
         Ok(address_descriptors)
@@ -661,88 +687,110 @@ where
         Ok(())
     }
 
-    pub fn get_position(&self, txid: &Txid) -> Option<u32> {
-        let inner = self.inner.read().expect("poisoned lock");
-        Some(inner.get_transaction(txid)?.position)
+    pub fn get_position(&self, txid: &Txid) -> Result<Option<u32>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_transaction(txid).map(|tx| tx.position))
     }
 
-    pub fn get_height(&self, txid: &Txid) -> Option<u32> {
-        let inner = self.inner.read().expect("poisoned lock");
-        Some(inner.get_transaction(txid)?.height)
+    pub fn get_height(&self, txid: &Txid) -> Result<Option<u32>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_transaction(txid).map(|tx| tx.height))
     }
 
-    pub fn get_cached_transaction(&self, txid: &Txid) -> Option<String> {
-        let inner = self.inner.read().expect("poisoned lock");
-        let tx = inner.get_transaction(txid)?;
-        Some(serialize_hex(&tx.tx))
+    pub fn get_cached_transaction(&self, txid: &Txid) -> Result<Option<String>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_transaction(txid).map(|tx| serialize_hex(&tx.tx)))
     }
 
     pub fn setup(&self) -> Result<(), WatchOnlyError> {
-        let inner = self.inner.read().expect("poisoned lock");
+        let inner = self.get_inner()?;
         inner.setup()
     }
 
-    pub fn block_process(&self, block: &Block, height: u32) -> Vec<(Transaction, TxOut)> {
-        let mut inner = self.inner.write().expect("poisoned lock");
-        inner.block_process(block, height)
+    pub fn block_process(
+        &self,
+        block: &Block,
+        height: u32,
+    ) -> Result<Vec<(Transaction, TxOut)>, WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
+        Ok(inner.block_process(block, height))
     }
 
-    pub fn get_address_utxos(&self, script_hash: &Hash) -> Option<Vec<(TxOut, OutPoint)>> {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.get_address_utxos(script_hash)
+    pub fn get_address_utxos(
+        &self,
+        script_hash: &Hash,
+    ) -> Result<Option<AddressUtxos>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_address_utxos(script_hash))
     }
 
-    pub fn get_transaction(&self, txid: &Txid) -> Option<CachedTransaction> {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.get_transaction(txid)
+    pub fn get_transaction(
+        &self,
+        txid: &Txid,
+    ) -> Result<Option<CachedTransaction>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_transaction(txid))
     }
 
-    pub fn get_address_history(&self, script_hash: &Hash) -> Option<Vec<CachedTransaction>> {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.get_address_history(script_hash)
+    pub fn get_address_history(
+        &self,
+        script_hash: &Hash,
+    ) -> Result<Option<Vec<CachedTransaction>>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_address_history(script_hash))
     }
 
     /// Returns the Merkle Proof for a given txid.
     ///
     /// Fails if a given Txid is an unconfirmed transaction.
-    pub fn get_merkle_proof(&self, txid: &Txid) -> Option<MerkleProof> {
-        let inner = self.inner.read().expect("poisoned lock");
-        inner.get_merkle_proof(txid)
+    pub fn get_merkle_proof(&self, txid: &Txid) -> Result<Option<MerkleProof>, WatchOnlyError> {
+        let inner = self.get_inner()?;
+        Ok(inner.get_merkle_proof(txid))
     }
 
     pub fn derive_addresses(&self) -> Result<(), WatchOnlyError> {
-        let mut inner = self.inner.write().expect("poisoned lock");
+        let mut inner = self.get_inner_write()?;
         inner.derive_addresses()
     }
 
     pub fn get_stats(&self) -> Result<Stats, WatchOnlyError> {
-        let inner = self.inner.read().expect("poisoned lock");
+        let inner = self.get_inner()?;
         Ok(inner.database.get_stats()?)
     }
 
-    pub fn maybe_derive_addresses(&self) {
-        let mut inner = self.inner.write().expect("poisoned lock");
-        inner.maybe_derive_addresses()
+    pub fn maybe_derive_addresses(&self) -> Result<(), WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
+        inner.maybe_derive_addresses();
+        Ok(())
     }
 
     pub fn find_unconfirmed(&self) -> Result<Vec<Transaction>, WatchOnlyError> {
-        let inner = self.inner.read().expect("poisoned lock");
+        let inner = self.get_inner()?;
         inner.find_unconfirmed()
     }
 
-    pub fn cache_address(&self, script_pk: ScriptBuf) {
-        let mut inner = self.inner.write().expect("poisoned lock");
-        inner.cache_address(script_pk)
+    pub fn cache_address(&self, script_pk: ScriptBuf) -> Result<(), WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
+        inner.cache_address(script_pk);
+        Ok(())
     }
 
-    pub fn cache_mempool_transaction(&self, transaction: &Transaction) -> Vec<TxOut> {
-        let mut inner = self.inner.write().expect("poisoned lock");
-        inner.cache_mempool_transaction(transaction)
+    pub fn cache_mempool_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<Vec<TxOut>, WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
+        Ok(inner.cache_mempool_transaction(transaction))
     }
 
-    pub fn save_mempool_tx(&self, hash: Hash, transaction_to_cache: CachedTransaction) {
-        let mut inner = self.inner.write().expect("poisoned lock");
-        inner.save_mempool_tx(hash, transaction_to_cache)
+    pub fn save_mempool_tx(
+        &self,
+        hash: Hash,
+        transaction_to_cache: CachedTransaction,
+    ) -> Result<(), WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
+        inner.save_mempool_tx(hash, transaction_to_cache);
+        Ok(())
     }
 
     pub fn save_non_mempool_tx(
@@ -753,8 +801,8 @@ where
         index: usize,
         hash: Hash,
         transaction_to_cache: CachedTransaction,
-    ) {
-        let mut inner = self.inner.write().expect("poisoned lock");
+    ) -> Result<(), WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
         inner.save_non_mempool_tx(
             transaction,
             is_spend,
@@ -762,11 +810,12 @@ where
             index,
             hash,
             transaction_to_cache,
-        )
+        );
+        Ok(())
     }
 
     pub fn get_descriptors(&self) -> Result<Vec<String>, WatchOnlyError> {
-        let inner = self.inner.read().expect("poisoned lock");
+        let inner = self.get_inner()?;
         Ok(inner.database.get_descriptors()?)
     }
 
@@ -781,8 +830,8 @@ where
         index: usize,
         is_spend: bool,
         hash: sha256::Hash,
-    ) {
-        let mut inner = self.inner.write().expect("poisoned lock");
+    ) -> Result<(), WatchOnlyError> {
+        let mut inner = self.get_inner_write()?;
         inner.cache_transaction(
             transaction,
             height,
@@ -792,7 +841,8 @@ where
             index,
             is_spend,
             hash,
-        )
+        );
+        Ok(())
     }
 }
 
@@ -848,13 +898,16 @@ mod test {
         let (address, script_hash) = get_test_address();
         let cache = get_test_cache();
         // Should have no address before caching
-        assert_eq!(cache.n_cached_addresses(), 0);
+        assert_eq!(cache.n_cached_addresses().unwrap(), 0);
 
-        cache.cache_address(address.script_pubkey());
+        cache.cache_address(address.script_pubkey()).unwrap();
         // Assert we indeed have one cached address
-        assert_eq!(cache.n_cached_addresses(), 1);
-        assert_eq!(cache.get_address_balance(&script_hash), Some(0));
-        assert_eq!(cache.get_address_history(&script_hash), Some(Vec::new()));
+        assert_eq!(cache.n_cached_addresses().unwrap(), 1);
+        assert_eq!(cache.get_address_balance(&script_hash).unwrap(), Some(0));
+        assert_eq!(
+            cache.get_address_history(&script_hash).unwrap(),
+            Some(Vec::new())
+        );
     }
 
     #[test]
@@ -872,25 +925,30 @@ mod test {
         let (_, script_hash) = get_test_address();
         let cache = get_test_cache();
 
-        cache.cache_transaction(
-            &transaction,
-            118511,
-            transaction.output[0].value.to_sat(),
-            merkle_block,
-            1,
-            0,
-            false,
-            get_spk_hash(&transaction.output[0].script_pubkey),
-        );
+        cache
+            .cache_transaction(
+                &transaction,
+                118511,
+                transaction.output[0].value.to_sat(),
+                merkle_block,
+                1,
+                0,
+                false,
+                get_spk_hash(&transaction.output[0].script_pubkey),
+            )
+            .unwrap();
 
         assert_eq!(
             script_hash,
             get_spk_hash(&transaction.output[0].script_pubkey)
         );
 
-        let balance = cache.get_address_balance(&script_hash);
-        let history = cache.get_address_history(&script_hash).unwrap();
-        let cached_merkle_block = cache.get_merkle_proof(&transaction.compute_txid()).unwrap();
+        let balance = cache.get_address_balance(&script_hash).unwrap();
+        let history = cache.get_address_history(&script_hash).unwrap().unwrap();
+        let cached_merkle_block = cache
+            .get_merkle_proof(&transaction.compute_txid())
+            .unwrap()
+            .unwrap();
         assert_eq!(balance, Some(999890));
         assert_eq!(
             Ok(history[0].hash),
@@ -906,11 +964,20 @@ mod test {
         // TESTS FOR SMALL, HELPER FUNCTIONS
 
         // [get_position]
-        assert_eq!(cache.get_position(&transaction.compute_txid()).unwrap(), 1);
+        assert_eq!(
+            cache
+                .get_position(&transaction.compute_txid())
+                .unwrap()
+                .unwrap(),
+            1
+        );
 
         // [get_height]
         assert_eq!(
-            cache.get_height(&transaction.compute_txid()).unwrap(),
+            cache
+                .get_height(&transaction.compute_txid())
+                .unwrap()
+                .unwrap(),
             118511
         );
 
@@ -918,6 +985,7 @@ mod test {
         assert!(
             cache
                 .get_cached_transaction(&transaction.compute_txid())
+                .unwrap()
                 .is_some()
         );
 
@@ -928,7 +996,7 @@ mod test {
             vout: 0,
         };
         assert_eq!(
-            cache.get_address_utxos(&script_hash).unwrap(),
+            cache.get_address_utxos(&script_hash).unwrap().unwrap(),
             vec![(tx_out, outpoint)]
         );
 
@@ -937,16 +1005,18 @@ mod test {
         let transaction = Vec::from_hex(transaction).unwrap();
         let transaction = deserialize(&transaction).unwrap();
 
-        cache.cache_transaction(
-            &transaction,
-            0,
-            transaction.output[1].value.to_sat(),
-            MerkleProof::default(),
-            2,
-            1,
-            false,
-            get_spk_hash(&transaction.output[1].script_pubkey),
-        );
+        cache
+            .cache_transaction(
+                &transaction,
+                0,
+                transaction.output[1].value.to_sat(),
+                MerkleProof::default(),
+                2,
+                1,
+                false,
+                get_spk_hash(&transaction.output[1].script_pubkey),
+            )
+            .unwrap();
 
         assert_eq!(
             cache.find_unconfirmed().unwrap()[0].compute_txid(),
@@ -958,18 +1028,18 @@ mod test {
     fn test_process_block() {
         let (address, script_hash) = get_test_address();
         let cache = get_test_cache();
-        cache.cache_address(address.script_pubkey());
+        cache.cache_address(address.script_pubkey()).unwrap();
 
         let block = "000000203ea734fa2c8dee7d3194878c9eaf6e83a629f79b3076ec857793995e01010000eb99c679c0305a1ac0f5eb2a07a9f080616105e605b92b8c06129a2451899225ab5481633c4b011e0b26720102020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0403efce01feffffff026ef2052a01000000225120a1a1b1376d5165617a50a6d2f59abc984ead8a92df2b25f94b53dbc2151824730000000000000000776a24aa21a9ed1b4c48a7220572ff3ab3d2d1c9231854cb62542fbb1e0a4b21ebbbcde8d652bc4c4fecc7daa2490047304402204b37c41fce11918df010cea4151737868111575df07f7f2945d372e32a6d11dd02201658873a8228d7982df6bdbfff5d0cad1d6f07ee400e2179e8eaad8d115b7ed001000120000000000000000000000000000000000000000000000000000000000000000000000000020000000001017ca523c5e6df0c014e837279ab49be1676a9fe7571c3989aeba1e5d534f4054a0000000000fdffffff01d2410f00000000001600142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a02473044022071b8583ba1f10531b68cb5bd269fb0e75714c20c5a8bce49d8a2307d27a082df022069a978dac00dd9d5761aa48c7acc881617fa4d2573476b11685596b17d437595012103b193d06bd0533d053f959b50e3132861527e5a7a49ad59c5e80a265ff6a77605eece0100";
         let block = deserialize(&Vec::from_hex(block).unwrap()).unwrap();
-        cache.block_process(&block, 118511);
+        cache.block_process(&block, 118511).unwrap();
 
-        let balance = cache.get_address_balance(&script_hash);
-        let history = cache.get_address_history(&script_hash).unwrap();
+        let balance = cache.get_address_balance(&script_hash).unwrap();
+        let history = cache.get_address_history(&script_hash).unwrap().unwrap();
         let transaction_id =
             Txid::from_str("6bb0665122c7dcecc6e6c45b6384ee2bdce148aea097896e6f3e9e08070353ea")
                 .unwrap();
-        let cached_merkle_block = cache.get_merkle_proof(&transaction_id).unwrap();
+        let cached_merkle_block = cache.get_merkle_proof(&transaction_id).unwrap().unwrap();
         assert_eq!(balance, Some(999890));
         assert_eq!(
             history[0].hash,
@@ -986,8 +1056,8 @@ mod test {
         // TESTS FOR SMALL HELPER FUNCTIONS
 
         // [bump_height], [get_cache_height], [set_cache_height]
-        cache.bump_height(118511);
-        assert_eq!(cache.get_cache_height(), 118511);
+        cache.bump_height(118511).unwrap();
+        assert_eq!(cache.get_cache_height().unwrap(), 118511);
 
         // [is_cached], [push_descriptor]
         let desc = "wsh(sortedmulti(1,[54ff5a12/48h/1h/0h/2h]tpubDDw6pwZA3hYxcSN32q7a5ynsKmWr4BbkBNHydHPKkM4BZwUfiK7tQ26h7USm8kA1E2FvCy7f7Er7QXKF8RNptATywydARtzgrxuPDwyYv4x/<0;1>/*,[bcf969c0/48h/1h/0h/2h]tpubDEFdgZdCPgQBTNtGj4h6AehK79Jm4LH54JrYBJjAtHMLEAth7LuY87awx9ZMiCURFzFWhxToRJK6xp39aqeJWrG5nuW3eBnXeMJcvDeDxfp/<0;1>/*))#fuw35j0q";
@@ -1012,10 +1082,10 @@ mod test {
         let script_hash = get_spk_hash(&spk);
         let cache = get_test_cache();
 
-        cache.cache_address(spk);
+        cache.cache_address(spk).unwrap();
 
-        cache.block_process(&block1, 118511);
-        cache.block_process(&block2, 118509);
+        cache.block_process(&block1, 118511).unwrap();
+        cache.block_process(&block2, 118509).unwrap();
 
         let address = cache.inner.read().unwrap();
         let address = address.address_map.get(&script_hash).unwrap();

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -9,11 +9,7 @@
 #![allow(clippy::manual_is_multiple_of)]
 
 use core::cmp::Ordering;
-use core::error::Error;
-use core::fmt;
 use core::fmt::Debug;
-use core::fmt::Display;
-use core::fmt::Formatter;
 
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
@@ -39,13 +35,13 @@ use bitcoin::hashes::Hash as HashTrait;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::sha256::Hash;
 use floresta_common::prelude::*;
+use floresta_domain::wallet::error::WatchOnlyError;
 use merkle::MerkleProof;
 use serde::Deserialize;
 use serde::Serialize;
 use sync::RwLock;
 use tracing::error;
 
-use crate::descriptor::DescriptorError;
 use crate::descriptor::derive_addresses_from_descriptor;
 use crate::descriptor::derive_addresses_from_list_descriptors;
 use crate::descriptor::parse_xpub;
@@ -55,31 +51,6 @@ const DERIVATION_COUNT: u32 = 100;
 
 /// Initial index for address derivation.
 const INDEX_INITIAL: u32 = 0;
-
-#[derive(Debug)]
-pub enum WatchOnlyError {
-    DatabaseError(String),
-    DuplicateDescriptor { descriptor: String },
-    InvalidDescriptor(DescriptorError),
-}
-
-impl Display for WatchOnlyError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::DatabaseError(e) => {
-                write!(f, "Database error: {e}")
-            }
-            Self::DuplicateDescriptor { descriptor } => {
-                write!(f, "Descriptor is already cached: {descriptor}")
-            }
-            Self::InvalidDescriptor(e) => {
-                write!(f, "Invalid descriptor: {e:?}")
-            }
-        }
-    }
-}
-
-impl Error for WatchOnlyError {}
 
 /// Every address contains zero or more associated transactions, this struct defines what
 /// data we store for those.
@@ -364,8 +335,7 @@ where
             &descriptors,
             stats.derivation_index,
             DERIVATION_COUNT,
-        )
-        .map_err(WatchOnlyError::InvalidDescriptor)?;
+        )?;
 
         addresses.iter().for_each(|address| {
             self.cache_address(address.clone());
@@ -667,8 +637,7 @@ where
         }
 
         let address_descriptors =
-            derive_addresses_from_descriptor(descriptor, INDEX_INITIAL, DERIVATION_COUNT)
-                .map_err(WatchOnlyError::InvalidDescriptor)?;
+            derive_addresses_from_descriptor(descriptor, INDEX_INITIAL, DERIVATION_COUNT)?;
 
         for address in address_descriptors.clone() {
             self.cache_address(address);
@@ -683,7 +652,7 @@ where
     /// Adds an XPUB to the wallet, derives descriptors from it, saves these descriptors persistently,
     /// derives addresses, and caches them if they're not cached already.
     pub fn push_xpub(&self, xpub: &str, network: Network) -> Result<(), WatchOnlyError> {
-        let descriptors = parse_xpub(xpub, network).map_err(WatchOnlyError::InvalidDescriptor)?;
+        let descriptors = parse_xpub(xpub, network)?;
 
         for descriptor in descriptors {
             self.push_descriptor(&descriptor)?;

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -10,6 +10,7 @@
 
 use core::cmp::Ordering;
 use core::fmt::Debug;
+use std::path::Path;
 use std::sync::RwLockReadGuard;
 use std::sync::RwLockWriteGuard;
 
@@ -47,6 +48,7 @@ use tracing::error;
 use crate::descriptor::derive_addresses_from_descriptor;
 use crate::descriptor::derive_addresses_from_list_descriptors;
 use crate::descriptor::parse_xpub;
+use crate::kv_database::KvDatabase;
 
 /// How much descriptors to derive each time.
 const DERIVATION_COUNT: u32 = 100;
@@ -579,6 +581,13 @@ where
         if let Err(err) = self.block_process(block, height) {
             error!("Error processing block: {err:?}");
         }
+    }
+}
+
+impl AddressCache<KvDatabase> {
+    pub fn new_default(datadir: impl AsRef<Path>) -> Result<Self, WatchOnlyError> {
+        let database = KvDatabase::new(&datadir)?;
+        Ok(Self::new(database))
     }
 }
 

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -18,6 +18,7 @@ use super::AddressCacheDatabase;
 use super::CachedAddress;
 use super::CachedTransaction;
 use super::Stats;
+use crate::WatchOnlyError;
 
 #[derive(Debug, Default)]
 struct Inner {
@@ -48,6 +49,12 @@ impl Display for MemoryDatabaseError {
         match self {
             Self::PoisonedLock => write!(f, "Poisoned lock"),
         }
+    }
+}
+
+impl From<MemoryDatabaseError> for WatchOnlyError {
+    fn from(e: MemoryDatabaseError) -> Self {
+        Self::DatabaseError(e.to_string())
     }
 }
 

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -13,12 +13,12 @@ use bitcoin::Txid;
 use bitcoin::hashes::sha256;
 use floresta_common::prelude::sync::RwLock;
 use floresta_common::prelude::*;
+use floresta_domain::wallet::error::WatchOnlyError;
 
 use super::AddressCacheDatabase;
 use super::CachedAddress;
 use super::CachedTransaction;
 use super::Stats;
-use crate::WatchOnlyError;
 
 #[derive(Debug, Default)]
 struct Inner {

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -36,7 +36,7 @@ tonic-prost = { workspace = true }
 floresta-chain = { workspace = true, features = ["flat-chainstore"] }
 floresta-compact-filters = { workspace = true }
 floresta-common = { workspace = true }
-floresta-domain = { workspace = true }
+floresta-domain = { workspace = true, features = ["mempool"] }
 metrics = { workspace = true,  optional = true }
 
 [dev-dependencies]

--- a/crates/floresta/examples/watch-only.rs
+++ b/crates/floresta/examples/watch-only.rs
@@ -36,15 +36,17 @@ fn main() {
     // We can now add the descriptor to the wallet. This will generate the first 100 addresses
     // for us, and add them to the wallet.
     for i in 0..100 {
-        wallet.cache_address(bitcoin::ScriptBuf::from(
-            descriptor
-                .at_derivation_index(i)
-                .unwrap()
-                .explicit_script()
-                .unwrap()
-                .as_bytes()
-                .to_vec(),
-        ));
+        wallet
+            .cache_address(bitcoin::ScriptBuf::from(
+                descriptor
+                    .at_derivation_index(i)
+                    .unwrap()
+                    .explicit_script()
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            ))
+            .unwrap();
     }
     // We can now process some blocks. Here, we process the first 11 blocks of a custom
     // regtest network. Each coinbase some of the addresses derived above.
@@ -64,6 +66,7 @@ fn main() {
     // Fetch all txids that involve the address.
     let history = wallet
         .get_address_history(&hash)
+        .unwrap()
         .unwrap()
         .iter()
         .map(|tx| tx.hash)


### PR DESCRIPTION
### Description and Notes

This is the first step toward decoupling the wallet implementation from the rest of the Floresta crates by centralizing wallet related abstractions in `floresta-domain`.

The main changes are:

* Added a dedicated `wallet` feature to `floresta-domain`, following the same pattern already used by the `mempool` feature. This allows downstream crates to enable only the interfaces they need, avoiding unnecessary dependencies.

* Moved `WatchOnlyError` from `floresta-watch-only` to `floresta-domain`, making it the shared error type for wallet interfaces and allowing other crates to interact with wallet functionality without depending directly on `floresta-watch-only`.

* Removed the generic `DatabaseError<T>` variant from `WatchOnlyError`. Exposing the underlying database error type unnecessarily coupled consumers to the database implementation. The error is now represented as `DatabaseError(String)`, while database specific conversions are handled inside each backend.

* Added the `LockPoisoned` variant to `WatchOnlyError` and updated the Electrum server to propagate wallet cache related errors instead of silently ignoring them.

* Added a `new_wallet_default` helper to `floresta-watch-only`, encapsulating wallet initialization, including `KvDatabase` creation and `AddressCache` setup. This centralizes wallet construction inside the wallet crate and removes initialization details from `florestad`.

Overall, these changes move wallet specific implementation details behind the interfaces exposed by `floresta-domain`, reducing coupling between crates and preparing the codebase for future wallet modularization.

### How to verify the changes you have done?

Verify that wallet functionality continues to work as before by running the node and confirming that:

* Wallet initialization succeeds.
* Wallet operations behave as expected.
* The Electrum server continues to function correctly, including balance, history, and UTXO queries.
* Existing wallet related tests continue to pass.

