### PR TITLE
docs(rpc): document, test and wired getmemoryinfo RPC

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -404,10 +404,13 @@ pub enum Methods {
         height_hint: Option<u32>,
     },
 
-    /// Returns statistics about Floresta's memory usage.
-    ///
-    /// Returns zeroed values for all runtimes that are not *-gnu or MacOS.
-    #[command(name = "getmemoryinfo")]
+    #[doc = include_str!("../../../doc/rpc/getmemoryinfo.md")]
+    #[command(
+        name = "getmemoryinfo",
+        about = "Returns statistics about Floresta's memory usage.",
+        long_about = Some(include_str!("../../../doc/rpc/getmemoryinfo.md")),
+        disable_help_subcommand = true
+    )]
     GetMemoryInfo { mode: Option<String> },
 
     /// Returns information about the RPC server

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -146,9 +146,7 @@ pub trait FlorestaRPC {
         script: String,
         height_hint: u32,
     ) -> Result<Value>;
-    /// Returns statistics about Floresta's memory usage.
-    ///
-    /// Returns zeroed values for all runtimes that are not *-gnu or MacOS.
+    #[doc = include_str!("../../../doc/rpc/getmemoryinfo.md")]
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
     /// Returns stats about our RPC server
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;

--- a/doc/rpc/getmemoryinfo.md
+++ b/doc/rpc/getmemoryinfo.md
@@ -1,0 +1,64 @@
+# getmemoryinfo
+
+Returns statistics about the node's memory usage.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getmemoryinfo [mode]
+```
+
+### Examples
+
+```bash
+# Get memory statistics (default mode = "stats")
+floresta-cli getmemoryinfo
+
+# Get XML-formatted malloc information (if supported by the allocator)
+floresta-cli getmemoryinfo "mallocinfo"
+```
+
+## Arguments
+
+- `mode` - (string, optional, default="stats") The information to retrieve.
+  - `"stats"`: Returns general memory stats regarding the memory pool.
+  - `"mallocinfo"`: Returns XML-formatted malloc information.
+
+## Returns
+
+### Ok Response (for mode = "stats")
+
+Returns a JSON object:
+- `locked` - (json object) Information about locked memory:
+  - `used` - (numeric) Memory currently in use (in bytes).
+  - `free` - (numeric) Memory currently free (in bytes).
+  - `total` - (numeric) Total memory allocated (in bytes).
+  - `locked` - (numeric) Total memory locked (in bytes).
+  - `chunks_used` - (numeric) Number of memory chunks currently in use.
+  - `chunks_free` - (numeric) Number of memory chunks currently free.
+
+### Ok Response (for mode = "mallocinfo")
+
+A string containing XML-formatted malloc information.
+
+Example:
+```xml
+<malloc version="2.0">
+  <heap nr="1">
+    <allocated>28499968</allocated>
+    <free>780560</free>
+    <total>1636080</total>
+    <locked>2416640</locked>
+    <chunks nr="28499968">
+      <used>21</used>
+      <free>2</free>
+    </chunks>
+  </heap>
+</malloc>
+```
+
+## Notes
+
+- Floresta returns zeroed memory statistics for systems/runtimes that are not MacOS or Linux glibc-based.


### PR DESCRIPTION
### Description and Notes

This PR adds complete documentation for the `getmemoryinfo` JSON-RPC method, which returns statistics about the node's memory usage.

Specifically, this PR:
1. Creates the markdown documentation file `doc/rpc/getmemoryinfo.md` detailing the usage, arguments, returns, and platform-specific behavior of the RPC.
2. Integrates the documentation into `floresta-cli` using `#[doc = include_str!(...)]` on the `GetMemoryInfo` command variant, allowing it to render correctly in `--help`.
3. Integrates the documentation into `floresta-rpc` on the `get_memory_info` trait method in `rpc.rs`.

**Side No.te (to reviewers:)**
- This method has a stable signature that is unaffected by the ongoing RPC traits refactoring in PR #1067.
- Links to: Ref #799

---

### How to verify the changes

1. **Verify CLI Help Formatting**:
   Verify that Clap renders the newly added documentation correctly in the terminal:
   ```bash
   cargo run --bin floresta-cli -- getmemoryinfo --help
   ```

2. **Verify RPC Integration & Response**:
   Start the node daemon on a local `regtest` chain:
   ```bash
   cargo run --bin florestad -- --network regtest
   ```
   In the same or a sub/separate terminal tab, query the daemon using the CLI to confirm it resolves the RPC and returns memory statistics successfully:
   ```bash
   cargo run --bin floresta-cli -- -H http://127.0.0.1:18442 getmemoryinfo
   ```

3. **Verify Linter checks**:
   Verify that the workspace compiles with zero warnings under all features:
   ```bash
   cargo clippy --workspace --all-targets --all-features -- -D warnings
   ```

---

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - **[Ran manually]** `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above