### PR TITLE
fix: apply new clippy suggestion

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -3,6 +3,7 @@
 use core::error;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -614,7 +615,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 });
 
                 info!("Catching up with addresses {:?}", self.addresses_to_scan);
-                let addresses: Vec<_> = self.addresses_to_scan.drain(..).collect();
+                let addresses: Vec<_> = mem::take(&mut self.addresses_to_scan);
                 self.rescan_for_addresses(addresses).await?;
             }
         }


### PR DESCRIPTION
This avoid using `drain(..).collect()`, as this will create a new allocation for all elements in the original collection. Using `mem::take` will only allocate one empty vector that will be placed where the old one was.
