### PR TITLE
Update memmap2 and anyhow to patched versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,9 +1957,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
-anyhow = { version = "=1.0.102" }
+anyhow = { version = "=1.0.103" }
 bitcoin = { workspace = true }
 clap = { workspace = true, features = ["help"] }
 serde_json = { workspace = true }

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 bitcoin = { workspace = true }
 bitcoinkernel = { version = "=0.2.1", optional = true }
 lru = { version = "=0.17.0", optional = true }
-memmap2 = { version = "=0.9.10", optional = true }
+memmap2 = { version = "=0.9.11", optional = true }
 rustreexo = { workspace = true }
 serde = { workspace = true, optional = true }
 sha2 = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Description and Notes

Closes #1171 and #1172.

Updates `memmap2` and `anyhow` to the latest patched releases, addressing two unsoundness advisories reported by the dependency update automation.

The changes include:

Updated `memmap2` from `0.9.10` to `0.9.11,` which fixes an unsoundness issue caused by insufficient validation of offset and length parameters in memory mapped range operations.
Updated anyhow from `1.0.102` to `1.0.103,` which fixes an unsoundness issue in `Error::downcast_mut()` when used after adding error context.

No functional changes are introduced. This PR only updates dependencies to include the upstream fixes.