### PR TITLE
chore(deps): Weekly Bumps [2026-06-29]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tower-http",
  "tracing",
  "zmq",
@@ -1233,7 +1233,7 @@ dependencies = [
  "floresta-node",
  "libc",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3107,17 +3107,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3131,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
 dependencies = [
  "dtoa",
  "itoa",
@@ -2310,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ spin = { version = "=0.10.0", default-features = false, features = ["spin_mutex"
 tempfile = { version = "=3.27.0" }
 tokio = { version = "=1.52.3", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["ring", "tls12"] }
-toml = { version = "=0.9.12", default-features = false, features = ["std", "parse", "serde"] }
+toml = { version = "=1.1.2", default-features = false, features = ["std", "parse", "serde"] }
 tracing = { version = "=0.1.44", default-features = false }
 zstd = { version = "=0.13.3" }
 # Pins for MSRV compatibility:

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 axum = { workspace = true }
-prometheus-client = { version = "=0.22.3" }
+prometheus-client = { version = "=0.24.1" }
 sysinfo = { version = "=0.36.1", default-features = false, features = ["system"] }
 tokio = { workspace = true }
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -28,7 +28,7 @@ impl AppMetrics {
         let block_height = Gauge::default();
         let peer_count = Gauge::<f64, AtomicU64>::default();
         let avg_block_processing_time = Gauge::<f64, AtomicU64>::default();
-        let message_times = Histogram::new([0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0].into_iter());
+        let message_times = Histogram::new([0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0]);
 
         registry.register("block_height", "Current block height", block_height.clone());
         registry.register(


### PR DESCRIPTION
### Changelog

```
# Cargo

prometheus-client from 0.22.3 to 0.24.1
~~sysinfo from 036.1 to 038.4~~ (not MSRV-compatible)
toml from 0.9.12+spec-1.1.0 to 1.1.2+spec-1.1.0
~~time from 0.3.45 to 0.3.47~~ (not MSRV-compatible

# Misc

Removed a call to `into_iter` in `metrics` due to a function now taking a reference rather than an owned iterator
```