### PR TITLE
feat!: dynamically derive alternative tips

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -77,6 +77,7 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
+use std::collections::HashSet;
 use std::fs;
 use std::fs::DirBuilder;
 use std::fs::File;
@@ -965,19 +966,63 @@ impl FlatChainStore {
         metadata.depth = best_block.depth;
         metadata.validation_index = best_block.validation_index;
 
-        assert!(best_block.alternative_tips.len() <= 64);
+        Ok(())
+    }
 
-        unsafe {
-            metadata
-                .alternative_tips
-                .as_mut_ptr()
-                .copy_from_nonoverlapping(
-                    best_block.alternative_tips.as_ptr(),
-                    best_block.alternative_tips.len(),
-                );
+    /// Derives the current set of alternative chain tips by scanning stored fork headers.
+    ///
+    /// A fork header is considered a tip if no other fork header references it as its
+    /// parent (`prev_blockhash`). This mirrors how Bitcoin Core computes chain tips from
+    /// its block index rather than maintaining an explicit on-disk list.
+    ///
+    /// Orphan and invalid-chain headers are also stored in the fork headers file, and
+    /// they are included as `alternative_tips` for monitoring purposes being filtered by
+    /// `find_fork_point` so we dont switch into an invalid tip. Finding a main-chain
+    /// header in a fork slot means the database is corrupted.
+    ///
+    /// Blocks that were reorged into the main chain leave stale `InFork` copies in the
+    /// fork headers file, so candidate tips are checked against the block index (which
+    /// reorgs repoint to the main-chain slot) and kept only if still `InFork`.
+    ///
+    /// This is called once on startup (via `get_best_chain`) to populate the in-memory
+    /// `BestChain.alternative_tips` cache. At runtime, tips are maintained incrementally
+    /// by `ChainState::push_alt_tip`.
+    fn derive_alternative_tips(&self) -> Result<Vec<BlockHash>, FlatChainstoreError> {
+        let metadata = unsafe { self.get_metadata()? };
+        let fork_count = metadata.fork_count as usize;
+
+        let mut fork_hashes = HashSet::with_capacity(fork_count);
+        let mut parent_hashes = HashSet::with_capacity(fork_count);
+
+        for i in 0..fork_count {
+            let index = Index::new_fork(i as u32)?;
+            let hdr = unsafe { self.get_disk_header(index)? };
+            match hdr.header {
+                DiskBlockHeader::InFork(..)
+                | DiskBlockHeader::Orphan(..)
+                | DiskBlockHeader::InvalidChain(..) => {
+                    fork_hashes.insert(hdr.hash);
+                    parent_hashes.insert(hdr.header.prev_blockhash);
+                }
+                // These headers are never written to fork slots
+                DiskBlockHeader::FullyValid(..)
+                | DiskBlockHeader::HeadersOnly(..)
+                | DiskBlockHeader::AssumedValid(..) => {
+                    return Err(FlatChainstoreError::CorruptedDatabase);
+                }
+            }
         }
 
-        Ok(())
+        let mut tips = Vec::new();
+        for hash in fork_hashes.difference(&parent_hashes) {
+            // A reorged-in block leaves a stale `InFork` copy in the fork headers file;
+            // the block index is authoritative about its current status.
+            if let Some(DiskBlockHeader::InFork(..)) = unsafe { self.get_header_by_hash(*hash)? } {
+                tips.push(*hash);
+            }
+        }
+
+        Ok(tips)
     }
 
     unsafe fn get_best_chain(&self) -> Result<BestChain, FlatChainstoreError> {
@@ -987,11 +1032,7 @@ impl FlatChainStore {
             best_block: metadata.best_block,
             depth: metadata.depth,
             validation_index: metadata.validation_index,
-            alternative_tips: metadata
-                .alternative_tips
-                .into_iter()
-                .take_while(|tip| *tip != BlockHash::all_zeros())
-                .collect(),
+            alternative_tips: self.derive_alternative_tips()?,
         })
     }
 
@@ -1406,13 +1447,19 @@ mod tests {
 
     use bitcoin::Block;
     use bitcoin::BlockHash;
+    use bitcoin::CompactTarget;
     use bitcoin::Network;
+    use bitcoin::TxMerkleNode;
     use bitcoin::block::Header;
+    use bitcoin::block::Version;
     use bitcoin::consensus::Decodable;
     use bitcoin::consensus::deserialize;
     use bitcoin::constants::genesis_block;
     use bitcoin::hashes::Hash;
     use floresta_common::bhash;
+    use rand::RngExt;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
     use tempfile::TempDir;
     use twox_hash::XxHash3_64;
 
@@ -1929,5 +1976,187 @@ mod tests {
             Err(e) => panic!("Unexpected err: {e:?}"),
             Ok(_) => panic!("Should not have been able to save roots for a block we don't have"),
         }
+    }
+
+    /// Test helper that wraps a [`FlatChainStore`] with a seeded RNG and a fork slot
+    /// counter, providing ergonomic methods for building fork topologies.
+    struct ForkBuilder {
+        store: FlatChainStore,
+        rng: StdRng,
+        next_slot: u32,
+    }
+
+    impl ForkBuilder {
+        fn new(seed: u64) -> Self {
+            let mut store = get_test_chainstore(None).unwrap();
+            // The open-addressing hash map probes slots via `get_disk_header`.
+            // Position 0 must hold a valid header so probes that land there
+            // don't fail with `HeaderNotFound`.
+            let genesis = genesis_block(Network::Regtest);
+            store
+                .save_header(&DiskBlockHeader::FullyValid(genesis.header, 0))
+                .unwrap();
+            store.update_block_index(0, genesis.block_hash()).unwrap();
+            Self {
+                store,
+                rng: StdRng::seed_from_u64(seed),
+                next_slot: 0,
+            }
+        }
+
+        /// Save a single independent fork header branching off genesis and return its hash.
+        fn add_independent_fork(&mut self) -> BlockHash {
+            let genesis_hash = genesis_block(Network::Regtest).block_hash();
+            self.add_fork_child(genesis_hash)
+        }
+
+        /// Build a random header whose parent is `prev`.
+        fn make_header(&mut self, prev: BlockHash) -> Header {
+            Header {
+                version: Version::from_consensus(2),
+                prev_blockhash: prev,
+                merkle_root: TxMerkleNode::from_byte_array(self.rng.random()),
+                time: self.rng.random(),
+                bits: CompactTarget::from_consensus(self.rng.random()),
+                nonce: self.rng.random(),
+            }
+        }
+
+        /// Extend a fork chain: save a header whose parent is `prev` and return its hash.
+        fn add_fork_child(&mut self, prev: BlockHash) -> BlockHash {
+            let header = self.make_header(prev);
+            let hash = header.block_hash();
+            let slot = self.next_slot;
+            self.next_slot += 1;
+            self.store
+                .save_header(&DiskBlockHeader::InFork(header, slot))
+                .unwrap();
+            hash
+        }
+
+        /// Build a fork chain of `len` blocks branching off genesis and return the tip hash.
+        fn add_fork_chain(&mut self, len: usize) -> BlockHash {
+            let mut tip = genesis_block(Network::Regtest).block_hash();
+            for _ in 0..len {
+                tip = self.add_fork_child(tip);
+            }
+            tip
+        }
+
+        fn derive_tips(&self) -> std::collections::HashSet<BlockHash> {
+            self.store
+                .derive_alternative_tips()
+                .unwrap()
+                .into_iter()
+                .collect()
+        }
+    }
+
+    #[test]
+    fn derive_alternative_tips_no_forks() {
+        let fb = ForkBuilder::new(0x0f10_e57a_0000);
+        assert!(fb.derive_tips().is_empty());
+    }
+
+    #[test]
+    fn derive_alternative_tips_independent_forks() {
+        let mut fb = ForkBuilder::new(0x0f10_e57a_0001);
+
+        let expected: std::collections::HashSet<_> =
+            (0..5).map(|_| fb.add_independent_fork()).collect();
+
+        assert_eq!(fb.derive_tips(), expected);
+    }
+
+    #[test]
+    fn derive_alternative_tips_fork_chain() {
+        let mut fb = ForkBuilder::new(0x0f10_e57a_0002);
+
+        // Chain of 3: only the tip should be returned.
+        let tip = fb.add_fork_chain(3);
+
+        let tips = fb.derive_tips();
+        assert_eq!(tips.len(), 1);
+        assert!(tips.contains(&tip));
+    }
+
+    #[test]
+    fn derive_many_alternative_tips() {
+        let mut fb = ForkBuilder::new(0x0f10_e57a_0003);
+
+        // 300 tips, go brr and dont crash.
+        let expected: std::collections::HashSet<_> =
+            (0..300).map(|_| fb.add_independent_fork()).collect();
+
+        assert_eq!(fb.derive_tips(), expected);
+    }
+
+    #[test]
+    fn derive_alternative_tips_mixed_chains_and_independent() {
+        let mut fb = ForkBuilder::new(0x0f10_e57a_0004);
+
+        // Chain A→B (tip: B), independent C (tip: C), chain D→E→F (tip: F)
+        let tip_b = fb.add_fork_chain(2);
+        let tip_c = fb.add_independent_fork();
+        let tip_f = fb.add_fork_chain(3);
+
+        let expected: std::collections::HashSet<_> = [tip_b, tip_c, tip_f].into_iter().collect();
+        assert_eq!(fb.derive_tips(), expected);
+    }
+
+    #[test]
+    fn derive_alternative_tips_ignores_stale_promoted_forks() {
+        let mut fb = ForkBuilder::new(0x0f10_e57a_0007);
+
+        // Losing branch: stays in the fork file as a legit alternative tip.
+        let loser_tip = fb.add_fork_chain(2);
+
+        // Winning branch: two fork headers that later get promoted to the main chain,
+        // as `mark_chain_as_active` does during a reorg. Their stale `InFork` copies
+        // remain in the fork headers file.
+        let genesis_hash = genesis_block(Network::Regtest).block_hash();
+        let f1 = fb.make_header(genesis_hash);
+        let f2 = fb.make_header(f1.block_hash());
+        for (height, header) in [(1u32, f1), (2, f2)] {
+            fb.store
+                .save_header(&DiskBlockHeader::InFork(header, height))
+                .unwrap();
+        }
+
+        // Promote: re-save as main-chain headers and repoint the block index.
+        for (height, header) in [(1u32, f1), (2, f2)] {
+            fb.store
+                .save_header(&DiskBlockHeader::HeadersOnly(header, height))
+                .unwrap();
+            fb.store
+                .update_block_index(height, header.block_hash())
+                .unwrap();
+        }
+
+        let tips = fb.derive_tips();
+        assert_eq!(tips.len(), 1);
+        assert!(tips.contains(&loser_tip));
+    }
+
+    #[test]
+    fn derive_alternative_tips_corrupted_on_main_chain_variant() {
+        let mut fb = ForkBuilder::new(0x0f10_e57a_0006);
+
+        fb.add_independent_fork();
+
+        // `save_header` never routes main-chain variants to the fork headers file, so
+        // write one there directly to simulate a corrupted database.
+        let genesis_hash = genesis_block(Network::Regtest).block_hash();
+        let header = fb.make_header(genesis_hash);
+        unsafe {
+            fb.store
+                .save_fork_block(DiskBlockHeader::FullyValid(header, 1))
+                .unwrap();
+        }
+
+        assert!(matches!(
+            fb.store.derive_alternative_tips(),
+            Err(FlatChainstoreError::CorruptedDatabase)
+        ))
     }
 }

--- a/tests/p2p/p2p_dynamic_tips.py
+++ b/tests/p2p/p2p_dynamic_tips.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+p2p_dynamic_tips.py
+
+Verify that dynamically derived chain tips survive a florestad restart.
+
+After IBD completes, fork headers are injected via a P2P peer. The test
+confirms the fork headers are accepted (retrievable via getblockheader),
+then restarts florestad and verifies they are still available — proving
+that tips are correctly re-derived from the fork file on disk.
+"""
+
+import time
+from io import BytesIO
+
+import pytest
+from test_framework.messages import CBlock, CBlockHeader, msg_headers
+from test_framework.util import wait_until
+
+# Regtest nBits (difficulty 1 — nearly any nonce satisfies PoW)
+REGTEST_NBITS = 0x207FFFFF
+
+# Number of alternative tips to create, one fork per height starting at 1
+NUM_FORKS = 75
+
+
+def header_from_raw_hex(hex_str):
+    """Deserialize a raw 80-byte block header hex string into a CBlockHeader."""
+    header = CBlockHeader()
+    header.deserialize(BytesIO(bytes.fromhex(hex_str)))
+    return header
+
+
+def create_fork_header(parent_header):
+    """Create a valid regtest fork header building on the given parent.
+
+    Uses a different merkle root than the real chain so the block hash
+    differs from any existing block at the same height, while still
+    satisfying the PoW target.
+    """
+    block = CBlock()
+    block.hashPrevBlock = parent_header.hash_int
+    block.nTime = parent_header.nTime + 1
+    block.nBits = REGTEST_NBITS
+    block.hashMerkleRoot = 0xDEADBEEF
+    block.nNonce = 0
+    block.solve()
+    return CBlockHeader(block)
+
+
+def assert_fork_headers_present(rpc, fork_hashes, context):
+    """Assert all fork hashes are retrievable via getblockheader."""
+    for fh in fork_hashes:
+        assert (
+            rpc.get_blockheader(fh, False) is not None
+        ), f"Fork header {fh} not found {context}"
+
+
+@pytest.mark.p2p
+def test_dynamic_chain_tips_derivation_restart(
+    setup_logging,
+    node_manager,
+    florestad_bitcoind_utreexod_with_chain,
+):
+    """
+    Mine a main chain, inject fork headers via P2P, verify they are accepted,
+    restart florestad, and verify the fork headers are still retrievable
+    (re-derived from the fork file on disk).
+    """
+    log = setup_logging
+
+    # 1. Mine main chain, sync florestad through IBD
+    log.info("Mining 100 blocks and syncing nodes")
+    florestad_node, bitcoind_node, utreexod_node = (
+        florestad_bitcoind_utreexod_with_chain(floresta_descriptors=[])
+    )
+    node_manager.wait_for_sync_nodes(is_finished_ibd=True)
+    log.info("Florestad IBD complete")
+
+    # 2. Collect parent headers from bitcoind at heights 1..NUM_FORKS
+    log.info("Collecting parent headers for fork points")
+    parent_headers = [
+        header_from_raw_hex(
+            bitcoind_node.rpc.get_blockheader(bitcoind_node.rpc.get_blockhash(h), False)
+        )
+        for h in range(1, NUM_FORKS + 1)
+    ]
+
+    # 3. Create NUM_FORKS independent fork headers via CBlock.solve()
+    log.info("Creating %d fork headers", NUM_FORKS)
+    fork_headers = [create_fork_header(p) for p in parent_headers]
+    fork_hashes = [fh.hash_hex for fh in fork_headers]
+    assert (
+        len(set(fork_hashes)) == NUM_FORKS
+    ), f"Expected {NUM_FORKS} distinct fork hashes"
+
+    # 4. Disconnect peers, connect P2P peer, send fork headers
+    log.info("Disconnecting peers and connecting P2P peer")
+    florestad_node.rpc.disconnectnode(node_address=bitcoind_node.p2p_url)
+    florestad_node.rpc.disconnectnode(node_address=utreexod_node.p2p_url)
+    node_manager.wait_for_peers_connections(
+        florestad_node, bitcoind_node, is_connected=False
+    )
+    node_manager.wait_for_peers_connections(
+        florestad_node, utreexod_node, is_connected=False
+    )
+
+    peer = node_manager.add_p2p_connection_default(
+        node=florestad_node, p2p_idx=0, supports_v2_p2p=False
+    )
+
+    log.info("Sending fork headers via P2P")
+    for header in fork_headers:
+        peer.send_without_ping(msg_headers([header]))
+        time.sleep(0.1)
+    peer.sync_with_ping()
+    wait_until(
+        predicate=lambda: all(
+            florestad_node.rpc.get_blockheader(fh, False) is not None
+            for fh in fork_hashes
+        ),
+        error_msg="Fork headers not accepted after sending via P2P",
+    )
+
+    # 5. Verify forks accepted: getblockheader succeeds for each fork hash
+    log.info("Verifying fork headers are accepted")
+    best_hash = florestad_node.rpc.get_bestblockhash()
+    assert_fork_headers_present(florestad_node.rpc, fork_hashes, "before restart")
+    for fh in fork_hashes:
+        assert fh != best_hash, "Fork header should not be the best block"
+
+    # 6. Restart florestad
+    log.info("Restarting florestad")
+    florestad_node.stop()
+    florestad_node.start()
+    florestad_node.rpc.wait_on_socket(opened=True)
+
+    # 7. Verify forks survived restart (re-derived from fork file)
+    log.info("Verifying fork headers survived restart")
+    assert (
+        florestad_node.rpc.get_bestblockhash() == best_hash
+    ), "Best block hash changed after restart"
+    assert_fork_headers_present(florestad_node.rpc, fork_hashes, "after restart")
+
+    log.info("All fork headers survived restart — tips re-derived correctly")


### PR DESCRIPTION
### Description and Notes

This is related to my work on `getchaintips`, it helps to bring the (future) rpc closer to its Bitcoin Core equivalent since now we dynamically derive tips by checking if any other header descends from it. 

Since we now derive the tips on startup, alternative tips are now calculated at runtime and the db doesn't need to store them into the [Blockhash; 64] array, so that makes alternative tips restrained only by the network layer check that deny tips with more than 288 blocks of depth that already protect us against disk space exhaustion.

~BREAKING CHANGE: the alternative_tips field is removed, new migration strategy is introduced with tests, i also ran it locally with an old datadir and it migrated as expected. I introduced some `debug!`s so we have more information about migration and the database version on startup.~

Edit: 
To avoid complexity and migrations, the `alternative_tips` (from metadata.bin) is not the ground truth for alternative tips anymore, we derive them at runtime (from fork_headers.bin).

`alternative_tips` from metadata.bin is just left unused which make this PR the most simple fix for the bug while being backwards compatible with old versions of floresta. 

### How to verify the changes you have done?

~I didnt tested this on mainnet, I got satisfied only by the new tests on `fla_chain_store.rs`.~ 

Edit: I managed to start from an old datadir and accomplish IBD 
```Rust
macbook ~/floresta (dynamic_chain_tips) $ cargo run --bin floresta-cli -- getblockchaininfo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/floresta-cli getblockchaininfo`
{
  "chain": "main",
  "blocks": 962038,
  "headers": 962038,
  "bestblockhash": "00000000000000000001c149984ba741a6068ec178c06e0fc92de82aa24abc65",
  "bits": "1702353d",
  "target": "00000000000000000002353d0000000000000000000000000000000000000000",
  "difficulty": 127479855693691.4,
  "time": 1786469197,
  "mediantime": 1786467331,
  "verificationprogress": 1.0,
  "initialblockdownload": false,
  "chainwork": "00000000000000000000000000000000000000013eb4dd0cead3947427d668cb",
  "size_on_disk": 203114165,
  "pruned": true,
  "pruneheight": 962039,
  "automatic_pruning": true,
  "prune_target_size": 0,
  "signet_challenge": null,
  "warnings": []
}
```

Edit: The integration test made with the older approach in mind still pass

New tests include both alternative tip detection tests and db migration tests.

The CI passed on personal fork.
