### PR TITLE
test: add unit test for BitcoinSocketAddress::get_default_port

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -117,7 +117,7 @@ impl BitcoinSocketAddr {
     /// Returns that network's default port, if present
     ///
     /// Note: it takes an option because it makes the logic inside `parse_port_if_present` easier
-    fn get_default_port(network: Network) -> u16 {
+    pub(crate) fn get_default_port(network: Network) -> u16 {
         match network {
             Network::Signet => 38333,
             Network::Bitcoin => 8333,

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -494,6 +494,18 @@ mod tests {
     }
 
     #[test]
+    fn test_get_default_port() {
+        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Bitcoin), 8333);
+        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Testnet), 18333);
+        assert_eq!(
+            BitcoinSocketAddr::get_default_port(Network::Testnet4),
+            48333
+        );
+        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Signet), 38333);
+        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Regtest), 18444);
+    }
+
+    #[test]
     fn test_parse_address() {
         // IPv6 Tests
         check_address_resolving("[::1]", true, "Valid IPv6 without port");

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -37,6 +37,7 @@ use crate::TransportProtocol;
 use crate::address_man::AddressMan;
 use crate::address_man::AddressState;
 use crate::address_man::LocalAddress;
+use crate::bitcoin_socket_addr::BitcoinSocketAddr;
 use crate::node_context::NodeContext;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::Peer;
@@ -362,13 +363,7 @@ where
     // TODO(@luisschwab): get rid of this once
     // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
     pub(crate) fn get_port(network: Network) -> u16 {
-        match network {
-            Network::Bitcoin => 8333,
-            Network::Signet => 38333,
-            Network::Testnet => 18333,
-            Network::Testnet4 => 48333,
-            Network::Regtest => 18444,
-        }
+        BitcoinSocketAddr::get_default_port(network)
     }
 
     /// Fetch peers from DNS seeds, sending a `NodeNotification` with found ones. Returns


### PR DESCRIPTION
### Description and Notes

Adds a unit test for `BltcoinSocketAddress::get_default_port`, future changes should reuse the existing test and the test will enforce that new implementations will follow the current behavior.

### How to verify the changes you have done?

review and `cargo test -p floresta-wire -- bitcoin_socket_addr::tests::test_get_default_port`