### PR TITLE
docs(rpc): added getrpcinfo documentation

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -417,19 +417,13 @@ pub enum Methods {
     )]
     GetMemoryInfo { mode: Option<String> },
 
-    /// Returns information about the RPC server
-    ///
-    /// Result: {                  (json object)
-    ///   "active_commands" : [    (json array) All active commands
-    ///     {                      (json object) Information about an active command
-    ///       "method" : "str",    (string) The name of the RPC command
-    ///       "duration" : n       (numeric) The running time in microseconds
-    ///     },
-    ///     ...
-    ///   ],
-    ///   "logpath" : "str"        (string) The complete file path to the debug log
-    /// }
-    #[command(name = "getrpcinfo")]
+    #[doc = include_str!("../../../doc/rpc/getrpcinfo.md")]
+    #[command(
+        name = "getrpcinfo",
+        about = "Returns information about the RPC server",
+        long_about = Some(include_str!("../../../doc/rpc/getrpcinfo.md")),
+        disable_help_subcommand = true
+    )]
     GetRpcInfo,
 
     #[doc = include_str!("../../../doc/rpc/uptime.md")]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -148,7 +148,7 @@ pub trait FlorestaRPC {
     ) -> Result<Value>;
     #[doc = include_str!("../../../doc/rpc/getmemoryinfo.md")]
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
-    /// Returns stats about our RPC server
+    #[doc = include_str!("../../../doc/rpc/getrpcinfo.md")]
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
     #[doc = include_str!("../../../doc/rpc/uptime.md")]
     fn uptime(&self) -> Result<u32>;

--- a/doc/rpc/getrpcinfo.md
+++ b/doc/rpc/getrpcinfo.md
@@ -1,0 +1,38 @@
+# getrpcinfo
+
+Returns details about the JSON-RPC server, including active commands and the log file path.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getrpcinfo
+```
+
+### Examples
+
+```bash
+floresta-cli getrpcinfo
+```
+
+## Returns
+
+Returns a JSON object:
+- `active_commands` - (json array) A list of currently active RPC commands:
+  - `method` - (string) The name of the RPC command.
+  - `duration` - (numeric) The running time of the command in microseconds.
+- `logpath` - (string) The complete absolute file path to the debug log.
+
+Example:
+```json
+{
+  "active_commands": [
+    {
+      "method": "getrpcinfo",
+      "duration": 67
+    }
+  ],
+  "logpath": "/home/x0/.floresta/regtest/debug.log"
+}
+```


### PR DESCRIPTION
### Description and Notes

This PR adds complete documentation for the `getrpcinfo` JSON-RPC method, which returns statistics about the active commands and log file path on Floresta.

 this PR entailes:
1. Creates the markdown documentation file `doc/rpc/getrpcinfo.md` detailing the usage, arguments, returns, and examples of the RPC.
2. Integrates the documentation into `floresta-cli` using `#[doc = include_str!(...)]` on the `GetRpcInfo` command variant, allowing it to render correctly in `--help`.
3. Integrates the documentation into `floresta-rpc` on the `get_rpc_info` trait method in `rpc.rs`.

**Side Note (to reviewers):**
- This method has a stable signature that is unaffected by the ongoing RPC traits refactoring in PR #1067.
- Links to: Ref #799

---

### How to verify the changes

1. **Verify CLI Help Formatting**:
   Verify that Clap renders the newly added documentation correctly in the terminal:
   ```bash
   cargo run --bin floresta-cli -- getrpcinfo --help
   ```

2. **Verify RPC Integration & Response**:
   Start the node daemon on a local `regtest` chain:
   ```bash
   cargo run --bin florestad -- --network regtest
   ```
  3. In the same or a sub/separate terminal tab, query the daemon using the CLI to confirm it resolves the RPC and returns statistics successfully:
   ```bash
   cargo run --bin floresta-cli -- -H http://127.0.0.1:18442 getrpcinfo
   ```
---

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - **[Ran manually]** `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above