### PR TITLE
refact: BitcoinSocketAddress::default_rpc_port, rename get_default_port to default_p2p_port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "clap",
+ "floresta-common",
  "floresta-rpc",
  "serde_json",
 ]

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true, features = ["help"] }
 serde_json = { workspace = true }
 
 # Local dependencies
+floresta-common = { workspace = true }
 floresta-rpc = { workspace = true, features = ["clap"] }
 
 [lints]

--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -9,6 +9,7 @@ use bitcoin::Network;
 use bitcoin::Txid;
 use clap::Parser;
 use clap::Subcommand;
+use floresta_common::NetworkExt;
 use floresta_rpc::jsonrpc_client::Client;
 use floresta_rpc::rpc::FlorestaRPC;
 use floresta_rpc::rpc_types::AddNodeCommand;
@@ -40,16 +41,7 @@ fn get_host(cmd: &Cli) -> String {
     }
 
     // Otherwise, use the default host based on the network type
-    //
-    // TODO(@luisschwab): use `NetworkExt` to append the correct port
-    // once https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
-    match cmd.network {
-        Network::Bitcoin => "http://127.0.0.1:8332".into(),
-        Network::Signet => "http://127.0.0.1:38332".into(),
-        Network::Testnet => "http://127.0.0.1:18332".into(),
-        Network::Testnet4 => "http://127.0.0.1:48332".into(),
-        Network::Regtest => "http://127.0.0.1:18442".into(),
-    }
+    format!("http://127.0.0.1:{}", cmd.network.default_rpc_port())
 }
 
 // Function to perform the requested RPC call based on CLI arguments

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -18,6 +18,7 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use bitcoin::Network;
 use bitcoin::ScriptBuf;
 use bitcoin::VarInt;
 use bitcoin::consensus::Decodable;
@@ -87,6 +88,27 @@ pub mod service_flags {
     /// `UTREEXO_ARCHIVE`: the node is capable of serving historical
     /// inclusion proofs for all blocks, but not necessarily historical blocks.
     pub const UTREEXO_ARCHIVE: u64 = 1 << 13;
+}
+
+/// Extension trait for [`bitcoin::Network`] providing network-specific defaults.
+// TODO(@luisschwab): get rid of this once
+// https://github.com/rust-bitcoin/rust-bitcoin/pull/6502 makes it into a release.
+// TODO: move to a dedicated network utilities crate if needed.
+pub trait NetworkExt {
+    /// Returns the default RPC port for the given network.
+    fn default_rpc_port(&self) -> u16;
+}
+
+impl NetworkExt for Network {
+    fn default_rpc_port(&self) -> u16 {
+        match self {
+            Self::Bitcoin => 8332,
+            Self::Signet => 38332,
+            Self::Testnet => 18332,
+            Self::Testnet4 => 48332,
+            Self::Regtest => 18442,
+        }
+    }
 }
 
 /// The P2P protocol version Floresta speaks.
@@ -181,10 +203,12 @@ pub mod prelude {
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::Network;
     use bitcoin::ScriptBuf;
     use bitcoin::hashes::Hash;
     use bitcoin::hex::DisplayHex;
 
+    use super::NetworkExt;
     use super::prelude::*;
 
     #[test]
@@ -208,5 +232,14 @@ mod tests {
             String::from("8b01df4e368ea28f8dc0423bcf7a4923e3a12d307c875e47a0cfbf90b5c39161");
 
         assert_eq!(hash.as_byte_array().to_lower_hex_string(), expected);
+    }
+
+    #[test]
+    fn test_default_rpc_port() {
+        assert_eq!(Network::Bitcoin.default_rpc_port(), 8332);
+        assert_eq!(Network::Testnet.default_rpc_port(), 18332);
+        assert_eq!(Network::Testnet4.default_rpc_port(), 48332);
+        assert_eq!(Network::Signet.default_rpc_port(), 38332);
+        assert_eq!(Network::Regtest.default_rpc_port(), 18442);
     }
 }

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -25,6 +25,8 @@ use floresta_chain::FlatChainStore as ChainStore;
 use floresta_chain::FlatChainStoreConfig;
 #[cfg(feature = "zmq-server")]
 use floresta_chain::pruned_utreexo::BlockchainInterface;
+#[cfg(feature = "json-rpc")]
+use floresta_common::NetworkExt;
 use floresta_common::try_and_log;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
@@ -470,7 +472,7 @@ impl Florestad {
                 self.config
                     .json_rpc_address
                     .as_ref()
-                    .map(|x| Self::resolve_hostname(x, 8332))
+                    .map(|x| Self::resolve_hostname(x, self.config.network.default_rpc_port()))
                     .transpose()?,
                 datadir.join("debug.log"),
                 self.config.user_agent.clone(),

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -36,6 +36,7 @@ use corepc_types::v30::GetRawTransactionVerbose;
 use corepc_types::v31::RawTransactionInput;
 use corepc_types::v31::RawTransactionOutput;
 use floresta_chain::ThreadSafeChain;
+use floresta_common::NetworkExt;
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
 use floresta_compact_filters::network_filters::NetworkFilters;
 use floresta_watch_only::AddressCache;
@@ -656,18 +657,6 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         })
     }
 
-    // TODO(@luisschwab): get rid of this once
-    // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
-    fn get_port(net: &Network) -> u16 {
-        match net {
-            Network::Bitcoin => 8332,
-            Network::Signet => 38332,
-            Network::Testnet => 18332,
-            Network::Testnet4 => 48332,
-            Network::Regtest => 18442,
-        }
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         chain: Blockchain,
@@ -682,7 +671,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         proxy: Option<SocketAddr>,
     ) {
         let address = address.unwrap_or_else(|| {
-            format!("127.0.0.1:{}", Self::get_port(&network))
+            format!("127.0.0.1:{}", network.default_rpc_port())
                 .parse()
                 .expect("hardcoded address is valid")
         });

--- a/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
+++ b/crates/floresta-wire/src/p2p_wire/bitcoin_socket_addr.rs
@@ -114,10 +114,10 @@ impl DnsResolver for SystemResolver {
 }
 
 impl BitcoinSocketAddr {
-    /// Returns that network's default port, if present
-    ///
-    /// Note: it takes an option because it makes the logic inside `parse_port_if_present` easier
-    pub(crate) fn get_default_port(network: Network) -> u16 {
+    // TODO(@luisschwab): get rid of this once
+    // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
+    /// Returns the default P2P port for the given network.
+    pub fn default_p2p_port(network: Network) -> u16 {
         match network {
             Network::Signet => 38333,
             Network::Bitcoin => 8333,
@@ -145,7 +145,7 @@ impl BitcoinSocketAddr {
             .map(str::parse)
             .transpose()
             .map_err(|_| InvalidAddressError::InvalidPort)?
-            .or_else(|| network.map(Self::get_default_port))
+            .or_else(|| network.map(Self::default_p2p_port))
             .ok_or(InvalidAddressError::MissingPort)
     }
 
@@ -186,7 +186,7 @@ impl BitcoinSocketAddr {
             IpAddr::V6(ipv6) => AddrV2::Ipv6(ipv6),
         };
 
-        let port = Self::get_default_port(network);
+        let port = Self::default_p2p_port(network);
 
         Self { address, port }
     }
@@ -494,15 +494,15 @@ mod tests {
     }
 
     #[test]
-    fn test_get_default_port() {
-        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Bitcoin), 8333);
-        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Testnet), 18333);
+    fn test_default_p2p_port() {
+        assert_eq!(BitcoinSocketAddr::default_p2p_port(Network::Bitcoin), 8333);
+        assert_eq!(BitcoinSocketAddr::default_p2p_port(Network::Testnet), 18333);
         assert_eq!(
-            BitcoinSocketAddr::get_default_port(Network::Testnet4),
+            BitcoinSocketAddr::default_p2p_port(Network::Testnet4),
             48333
         );
-        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Signet), 38333);
-        assert_eq!(BitcoinSocketAddr::get_default_port(Network::Regtest), 18444);
+        assert_eq!(BitcoinSocketAddr::default_p2p_port(Network::Signet), 38333);
+        assert_eq!(BitcoinSocketAddr::default_p2p_port(Network::Regtest), 18444);
     }
 
     #[test]

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -360,12 +360,6 @@ where
 
     // === BOOTSTRAPPING ===
 
-    // TODO(@luisschwab): get rid of this once
-    // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
-    pub(crate) fn get_port(network: Network) -> u16 {
-        BitcoinSocketAddr::get_default_port(network)
-    }
-
     /// Fetch peers from DNS seeds, sending a `NodeNotification` with found ones. Returns
     /// immediately after spawning a background blocking task that performs the work.
     pub(crate) fn get_peers_from_dns(&self) -> Result<(), WireError> {
@@ -379,7 +373,7 @@ where
         });
 
         tokio::task::spawn_blocking(move || {
-            let default_port = Self::get_port(network);
+            let default_port = BitcoinSocketAddr::default_p2p_port(network);
             let dns_seeds = floresta_chain::get_chain_dns_seeds(network);
 
             let mut addresses = Vec::new();


### PR DESCRIPTION
### Description and Notes

This pr add a `default_rpc_port` to BitcoinSocketAddress and rename the previous get_default_port to default_p2p_port.

Floresta-cli would need to depend on floresta-wire to directly use BitcoinSocketAddress methods so i just updated the TODO.

### How to verify the changes you have done?

the new method adds a new unit test and dont change any previous values
