### PR TITLE
chore(deps): update crossbeam-epoch to 0.9.20 and crossbeam-utils to …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"


### PR DESCRIPTION
### Description and Notes

Updates `crossbeam-epoch` to `0.9.20` and `crossbeam-utils` to `0.8.22` to resolve the vulnerability reported by `cargo audit`, fixing the CI failure.

The dependencies were updated using:

```bash
cargo update -p crossbeam-epoch --aggressive
```

which upgrades `crossbeam-epoch` to the latest patched release and updates `crossbeam-utils` accordingly.

For reference:

* Release: https://github.com/crossbeam-rs/crossbeam/releases/tag/crossbeam-epoch-0.9.20
* RustSec advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204.html

This PR contains no functional changes and only updates dependencies to include the upstream security fix.

### How to verify the changes you have done?

* Run `cargo audit` and confirm that `RUSTSEC-2026-0204` is no longer reported.

