### PR TITLE
docs(rpc): added listdescriptors documentation

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -427,8 +427,13 @@ pub enum Methods {
     )]
     Uptime,
 
-    /// Returns a list of all descriptors currently loaded in the wallet
-    #[command(name = "listdescriptors")]
+    #[doc = include_str!("../../../doc/rpc/listdescriptors.md")]
+    #[command(
+        name = "listdescriptors",
+        about = "Returns a list of all descriptors currently loaded in the wallet",
+        long_about = Some(include_str!("../../../doc/rpc/listdescriptors.md")),
+        disable_help_subcommand = true
+    )]
     ListDescriptors,
 
     #[doc = include_str!("../../../doc/rpc/ping.md")]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -152,7 +152,7 @@ pub trait FlorestaRPC {
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
     #[doc = include_str!("../../../doc/rpc/uptime.md")]
     fn uptime(&self) -> Result<u32>;
-    /// Returns a list of all descriptors currently loaded in the wallet
+    #[doc = include_str!("../../../doc/rpc/listdescriptors.md")]
     fn list_descriptors(&self) -> Result<Vec<String>>;
     #[doc = include_str!("../../../doc/rpc/ping.md")]
     fn ping(&self) -> Result<()>;

--- a/doc/rpc/listdescriptors.md
+++ b/doc/rpc/listdescriptors.md
@@ -1,0 +1,29 @@
+# `listdescriptors`
+
+Returns a list of all descriptors currently loaded in the watch-only wallet.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli listdescriptors
+```
+
+### Examples
+
+```bash
+floresta-cli listdescriptors
+```
+
+## Returns
+
+Returns a JSON array of strings:
+- (string) The wallet descriptor (including checksum).
+
+Example:
+```json
+[
+  "wpkh(tpubDDtyive2LqLWKzPZ8LZ9Ebi1JDoLcf1cEpn3Mshp6sxVfCupHZJRPQTozp2EpTF76vJcyQBN7VP7CjUntEJxeADnuTMNTYKoSWNae8soVyv/0/*)#7h6kdtnk"
+]
+```


### PR DESCRIPTION
### Description and Notes

This PR adds complete documentation for the `listdescriptors` JSON-RPC method, which returns a list of all active descriptors currently loaded in the watch-only wallet.

Specifically, this PR:
1. Creates the markdown documentation file `doc/rpc/listdescriptors.md` detailing the usage, returns, and examples of the RPC.
2. Integrates the documentation into `floresta-cli` using `#[doc = include_str!(...)]` on the `ListDescriptors` command variant, allowing it to render correctly in `--help`.
3. Integrates the documentation into `floresta-rpc` on the `list_descriptors` trait method in `rpc.rs`.

- Links to: Ref #799

---

### How to verify the changes

1. **Verify CLI Help Formatting**:
   Verify that Clap renders the newly added documentation correctly in the terminal:
   ```bash
   cargo run --bin floresta-cli -- listdescriptors --help
   ```

2. **Verify RPC Integration & Response**:
   Start the node daemon on a local `regtest` chain:
   ```bash
   cargo run --bin florestad -- --network regtest
   ```
   In a separate terminal or sub tab, load a test descriptor:
   ```bash
   cargo run --bin floresta-cli -- -H http://127.0.0.1:18442 loaddescriptor "wpkh(tpubDDtyive2LqLWKzPZ8LZ9Ebi1JDoLcf1cEpn3Mshp6sxVfCupHZJRPQTozp2EpTF76vJcyQBN7VP7CjUntEJxeADnuTMNTYKoSWNae8soVyv/0/*)#7h6kdtnk"
   ```
   Query the daemon using the CLI to confirm it resolves the RPC and returns the loaded descriptor inside a JSON array:
   ```bash
   cargo run --bin floresta-cli -- -H http://127.0.0.1:18442 listdescriptors
   ```

---

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - **[Ran manually]** `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above