### PR TITLE
Group all dependabot updates in the same PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
           time: "00:00"
       cooldown:
           default-days: 60
+      groups:
+          all:
+            patterns: ["*"]
 
     - package-ecosystem: "github-actions"
       directory: "/"
@@ -18,6 +21,9 @@ updates:
           time: "00:00"
       cooldown:
           default-days: 60
+      groups:
+          all:
+            patterns: ["*"]
 
     - package-ecosystem: "nix"
       directory: "/"
@@ -26,6 +32,9 @@ updates:
           time: "00:00"
       cooldown:
           default-days: 60
+      groups:
+          all:
+            patterns: ["*"]
 
     - package-ecosystem: "uv"
       directory: "/"
@@ -34,3 +43,6 @@ updates:
           time: "00:00"
       cooldown:
           default-days: 60
+      groups:
+          all:
+            patterns: ["*"]


### PR DESCRIPTION
This PR groups all dependabot updates across all ecosystems in the same PR, since we only use dependabot as a notification and manually bump everything.