### PR TITLE
docs: add findtxout RPC documentation

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -392,7 +392,13 @@ pub enum Methods {
         node_id: Option<usize>,
     },
 
-    #[command(name = "findtxout")]
+    #[doc = include_str!("../../../doc/rpc/findtxout.md")]
+    #[command(
+        name = "findtxout",
+        about = "Finds a specific unspent transaction output in the chain",
+        long_about = Some(include_str!("../../../doc/rpc/findtxout.md")),
+        disable_help_subcommand = true
+    )]
     FindTxOut {
         txid: Txid,
         vout: u32,

--- a/doc/rpc/findtxout.md
+++ b/doc/rpc/findtxout.md
@@ -42,13 +42,13 @@ lookup much faster.
 
 ### Ok Response
 
-If the output is found, an object describing it is returned:
+If the output is found, an object describing it is returned. This is a variant of the
+[`gettxout`](gettxout.md) response, currently returning just:
 
 - `value` - (numeric) The output value in satoshis.
 - `script_pubkey` - (string) The output scriptPubKey, hex encoded.
 
-If the output can't be found (it doesn't exist or has already been spent), an empty object `{}`
-is returned.
+In the future `findtxout` will return the same response shape as `gettxout` directly.
 
 ### Error Enum `JsonRpcError`
 
@@ -62,6 +62,8 @@ to use this method.
 
 ## Notes
 
+- If the output can't be found (it doesn't exist or has already been spent), an empty object `{}`
+is returned.
 - You must enable block filters by setting the `blockfilters=1` option, otherwise this method
 returns `NoBlockFilters`.
 - Passing a good `height_hint` matters a lot for performance, since without it the scan starts

--- a/doc/rpc/findtxout.md
+++ b/doc/rpc/findtxout.md
@@ -1,0 +1,69 @@
+# `findtxout`
+
+Finds a specific unspent transaction output (UTXO) in the chain.
+
+This is a Floresta flavored RPC and is not part of the Bitcoin Core RPC spec. Unlike
+`gettxout`, which only looks at outputs already cached by the wallet, `findtxout` uses
+block filters to scan the chain for an output that the wallet doesn't know about yet. If
+the output is found it is cached, so subsequent calls to `gettxout` will return it too.
+
+## Usage
+
+### Synopsis
+
+```
+floresta-cli findtxout <txid> <vout> <script> [<height_hint>]
+```
+
+### Examples
+
+```bash
+# Look for output 0 of a transaction, providing its scriptPubKey hex
+floresta-cli findtxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 0014c664139327b98043febeab6434eba89bb196d1af
+
+# Same lookup, but start scanning from block height 800000 to speed things up
+floresta-cli findtxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 0014c664139327b98043febeab6434eba89bb196d1af 800000
+```
+
+## Arguments
+
+`txid` - (string, required) The transaction id that created the output.
+
+`vout` - (numeric, required) The index of the output within that transaction.
+
+`script` - (string, required) The scriptPubKey of the output, hex encoded. This is what gets
+matched against the block filters, so it must be correct for the output to be found.
+
+`height_hint` - (numeric, optional, default=0) The block height to start scanning from. Providing
+a height close to where the output was created avoids scanning the whole chain and makes the
+lookup much faster.
+
+## Returns
+
+### Ok Response
+
+If the output is found, an object describing it is returned:
+
+- `value` - (numeric) The output value in satoshis.
+- `script_pubkey` - (string) The output scriptPubKey, hex encoded.
+
+If the output can't be found (it doesn't exist or has already been spent), an empty object `{}`
+is returned.
+
+### Error Enum `JsonRpcError`
+
+- `InInitialBlockDownload` - The node is still doing its initial block download, so there are no
+filters to scan yet.
+- `NoBlockFilters` - Block filters are not enabled. You must start the node with `blockfilters=1`
+to use this method.
+- `Filters` - Something went wrong while matching against the block filters.
+- `Node` - A node level error happened while fetching a candidate block.
+- `BlockNotFound` - A matched block could not be located in the chain.
+
+## Notes
+
+- You must enable block filters by setting the `blockfilters=1` option, otherwise this method
+returns `NoBlockFilters`.
+- Passing a good `height_hint` matters a lot for performance, since without it the scan starts
+from the beginning of the chain.
+- Related methods: `gettxout`, which returns an output only if it is already in the wallet cache.


### PR DESCRIPTION
### Description and Notes

Part of #799. `findtxout` was the last RPC endpoint still missing from the docs, so this adds `doc/rpc/findtxout.md` following the existing template used by the other RPC docs.

While writing it I noticed the `FindTxOut` variant in `floresta-cli` didn't wire its doc into `clap` like the other commands do, so `findtxout --help` only showed the bare arg list. I added the `#[doc = include_str!(...)]` plus the `about`/`long_about` attributes to match the pattern the neighbouring commands already use, so the new doc now surfaces in `--help` too.

The content is based on the actual implementation in `crates/floresta-node/src/json_rpc/blockchain.rs` and the CLI signature in `bin/floresta-cli/src/main.rs`: the four arguments (txid, vout, script, optional height_hint), the empty-object result when the utxo isn't found, the relevant `JsonRpcError` variants, and the `blockfilters=1` requirement.

### How to verify the changes you have done?

```
cargo build -p floresta-cli
./target/debug/floresta-cli findtxout --help
```

The help output now renders the full documentation instead of just the argument list.

### Contributor Checklist

- [x] I've followed the contribution guidelines
- [x] I've verified one of the following:
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
