### PR TITLE
docs(rpc): wired gettxout documentation

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -352,10 +352,13 @@ pub enum Methods {
     )]
     GetConnectionCount,
 
-    /// Returns the value associated with a UTXO, if it's still not spent.
-    /// This function only works properly if we have the compact block filters
-    /// feature enabled
-    #[command(name = "gettxout")]
+    #[doc = include_str!("../../../doc/rpc/gettxout.md")]
+    #[command(
+        name = "gettxout",
+        about = "Returns details about an unspent transaction output.",
+        long_about = Some(include_str!("../../../doc/rpc/gettxout.md")),
+        disable_help_subcommand = true
+    )]
     GetTxOut { txid: Txid, vout: u32 },
 
     #[doc = include_str!("../../../doc/rpc/stop.md")]

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -114,11 +114,7 @@ pub trait FlorestaRPC {
     /// is returned as a hexadecimal string. If the verbosity flag is 1, the block is returned
     /// as a json object.
     fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes>;
-    /// Return a cached transaction output
-    ///
-    /// This method returns a cached transaction output. If the output is not in the cache,
-    /// or is spent, an empty object is returned. If you want to find a utxo that's not in
-    /// the cache, you can use the findtxout method.
+    #[doc = include_str!("../../../doc/rpc/gettxout.md")]
     fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut>;
     #[doc = include_str!("../../../doc/rpc/stop.md")]
     fn stop(&self) -> Result<String>;


### PR DESCRIPTION
### Description and Notes

This PR wires the existing documentation for the `gettxout` JSON-RPC method into the CLI and RPC client libraries so it displays correctly in `--help`. 

- Links to: Ref #799

Specifically, this PR:
1. Integrates the documentation into `floresta-cli` using `#[doc = include_str!(...)]` on the `GetTxOut` command variant, allowing it to render correctly in `--help`.
2. Integrates the documentation into `floresta-rpc` on the `get_tx_out` trait method in `rpc.rs`.

---

### How to verify the changes

1. **Verify CLI Help Formatting**:
   Verify that Clap renders the newly added documentation correctly in the terminal:
   ```bash
   cargo run --bin floresta-cli -- gettxout --help
   
Additionally, you can verify that the workspace compiles with zero warnings under all features:   
 ```bash
cargo clippy --workspace --all-targets --all-features -- -D warnings