### PR TITLE
tests(wire): add tests to the node handle

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/tests/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod chain_selector;
+mod node_handle;
 mod sync_node;
 mod utils;

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -5,17 +5,33 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
+    use bitcoin::Amount;
+    use bitcoin::FilterHash;
+    use bitcoin::FilterHeader;
     use bitcoin::Network;
+    use bitcoin::OutPoint;
+    use bitcoin::ScriptBuf;
+    use bitcoin::Sequence;
+    use bitcoin::Transaction;
+    use bitcoin::TxIn;
+    use bitcoin::TxOut;
+    use bitcoin::Txid;
+    use bitcoin::absolute;
+    use bitcoin::hashes::Hash;
     use bitcoin::p2p::ServiceFlags;
+    use bitcoin::p2p::message_filter::CFHeaders;
+    use bitcoin::transaction::Version;
     use floresta_common::service_flags;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::time::Duration;
     use tokio::time::timeout;
 
+    use crate::bitcoin_socket_addr::BitcoinSocketAddr;
     use crate::node::NodeNotification;
     use crate::node::PeerStatus;
     use crate::node_handle::NodeHandle;
     use crate::node_interface::ChainMethods;
+    use crate::node_interface::MempoolMethods;
     use crate::node_interface::NetworkMethods;
     use crate::node_interface::NodeConfigMethods;
     use crate::p2p_wire::tests::utils::PeerData;
@@ -23,6 +39,26 @@ mod tests {
     use crate::p2p_wire::tests::utils::signet_blocks;
     use crate::p2p_wire::tests::utils::signet_headers;
     use crate::p2p_wire::transport::TransportProtocol;
+
+    fn sample_transaction() -> Transaction {
+        Transaction {
+            version: Version::ONE,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
 
     #[tokio::test]
     async fn node_handle_get_config_returns_running_node_config() {
@@ -95,6 +131,125 @@ mod tests {
 
         assert_eq!(block, expected_block);
 
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_get_cfilters_headers_returns_mocked_peer_headers() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let stop_hash = signet_headers()[1].block_hash();
+        let cfheaders = CFHeaders {
+            filter_type: 0,
+            stop_hash,
+            previous_filter_header: FilterHeader::all_zeros(),
+            filter_hashes: vec![FilterHash::all_zeros()],
+        };
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new())
+            .with_cfilter_headers(cfheaders.clone());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let response = timeout(
+            Duration::from_secs(5),
+            harness.handle.get_cfilters_headers(1, stop_hash),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(response, cfheaders);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_mempool_methods_use_local_mempool_and_mocked_peer() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let transaction = sample_transaction();
+        let txid = transaction.compute_txid();
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new())
+            .with_transaction(transaction.clone());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let broadcast_txid = timeout(
+            Duration::from_secs(5),
+            harness.handle.broadcast_transaction(transaction.clone()),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+        let fetched_transaction = timeout(
+            Duration::from_secs(5),
+            harness.handle.get_mempool_transaction(txid),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(broadcast_txid, txid);
+        assert_eq!(fetched_transaction, transaction);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_network_methods_return_node_status_and_control_peers() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let add_addr: BitcoinSocketAddr = "127.0.0.1:18444".parse().unwrap();
+        let onetry_addr: BitcoinSocketAddr = "127.0.0.1:18445".parse().unwrap();
+        let connected_addr = harness.handle.get_peer_info().await.unwrap()[0]
+            .address
+            .clone();
+
+        let ping = timeout(Duration::from_secs(5), harness.handle.ping())
+            .await
+            .unwrap()
+            .unwrap();
+        let add = timeout(
+            Duration::from_secs(5),
+            harness.handle.add_peer(add_addr.clone(), false),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let stats = timeout(Duration::from_secs(5), harness.handle.get_addrman_info())
+            .await
+            .unwrap()
+            .unwrap();
+        let remove = timeout(Duration::from_secs(5), harness.handle.remove_peer(add_addr))
+            .await
+            .unwrap()
+            .unwrap();
+        let onetry = timeout(
+            Duration::from_secs(5),
+            harness.handle.onetry_peer(onetry_addr, false),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let disconnect = timeout(
+            Duration::from_secs(5),
+            harness.handle.disconnect_peer(connected_addr),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(ping);
+        assert!(add);
+        assert_eq!(stats.ipv4.total(), stats.ipv4.new + stats.ipv4.tried);
+        assert!(remove);
+        assert!(onetry);
+        assert!(disconnect);
+
+        harness.wait_for_peers(0).await;
         harness.shutdown().await;
     }
 

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -8,10 +8,13 @@ mod tests {
     use bitcoin::Network;
     use bitcoin::p2p::ServiceFlags;
     use floresta_common::service_flags;
+    use tokio::sync::mpsc::unbounded_channel;
     use tokio::time::Duration;
     use tokio::time::timeout;
 
+    use crate::node::NodeNotification;
     use crate::node::PeerStatus;
+    use crate::node_handle::NodeHandle;
     use crate::node_interface::ChainMethods;
     use crate::node_interface::NetworkMethods;
     use crate::node_interface::NodeConfigMethods;
@@ -93,5 +96,20 @@ mod tests {
         assert_eq!(block, expected_block);
 
         harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_returns_error_when_node_receiver_is_dropped() {
+        let (node_sender, node_receiver) = unbounded_channel::<NodeNotification>();
+        drop(node_receiver);
+
+        let handle = NodeHandle::new(node_sender);
+
+        let err = timeout(Duration::from_secs(5), handle.get_config())
+            .await
+            .unwrap()
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "channel closed");
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -2,14 +2,21 @@
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::path::PathBuf;
 
     use bitcoin::Network;
+    use bitcoin::p2p::ServiceFlags;
+    use floresta_common::service_flags;
     use tokio::time::Duration;
     use tokio::time::timeout;
 
+    use crate::node::PeerStatus;
+    use crate::node_interface::NetworkMethods;
     use crate::node_interface::NodeConfigMethods;
+    use crate::p2p_wire::tests::utils::PeerData;
     use crate::p2p_wire::tests::utils::setup_node_handle_test;
+    use crate::p2p_wire::transport::TransportProtocol;
 
     #[tokio::test]
     async fn node_handle_get_config_returns_running_node_config() {
@@ -24,6 +31,39 @@ mod tests {
         assert_eq!(config.network, Network::Signet);
         assert_eq!(config.datadir, PathBuf::from(datadir));
         assert!(!config.pow_fraud_proofs);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_get_peer_info_returns_mocked_peer_data() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let connection_count = timeout(
+            Duration::from_secs(5),
+            harness.handle.get_connection_count(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let peer_info = timeout(Duration::from_secs(5), harness.handle.get_peer_info())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(connection_count, 1);
+        assert_eq!(peer_info.len(), 1);
+
+        let peer = &peer_info[0];
+        assert_eq!(peer.id, 0);
+        assert_eq!(peer.user_agent, "node_test");
+        assert_eq!(peer.state, PeerStatus::Ready);
+        assert_eq!(peer.transport_protocol, TransportProtocol::V2);
+        assert!(peer.services.has(ServiceFlags::NETWORK));
+        assert!(peer.services.has(service_flags::UTREEXO.into()));
 
         harness.shutdown().await;
     }

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bitcoin::Network;
+    use tokio::time::Duration;
+    use tokio::time::timeout;
+
+    use crate::node_interface::NodeConfigMethods;
+    use crate::p2p_wire::tests::utils::setup_node_handle_test;
+
+    #[tokio::test]
+    async fn node_handle_get_config_returns_running_node_config() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let harness = setup_node_handle_test(Vec::new(), false, Network::Signet, &datadir, 0).await;
+
+        let config = timeout(Duration::from_secs(5), harness.handle.get_config())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(config.network, Network::Signet);
+        assert_eq!(config.datadir, PathBuf::from(datadir));
+        assert!(!config.pow_fraud_proofs);
+
+        harness.shutdown().await;
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -112,4 +112,25 @@ mod tests {
 
         assert_eq!(err.to_string(), "channel closed");
     }
+
+    #[tokio::test]
+    async fn node_handle_block_request_stays_pending_when_peer_disconnects() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let headers = signet_headers();
+        let block_hash = headers[1].block_hash();
+        let peer =
+            PeerData::disconnecting_on_block_request(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let request = timeout(
+            Duration::from_millis(500),
+            harness.handle.get_block(block_hash),
+        )
+        .await;
+
+        assert!(request.is_err());
+
+        harness.shutdown().await;
+    }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -12,10 +12,13 @@ mod tests {
     use tokio::time::timeout;
 
     use crate::node::PeerStatus;
+    use crate::node_interface::ChainMethods;
     use crate::node_interface::NetworkMethods;
     use crate::node_interface::NodeConfigMethods;
     use crate::p2p_wire::tests::utils::PeerData;
     use crate::p2p_wire::tests::utils::setup_node_handle_test;
+    use crate::p2p_wire::tests::utils::signet_blocks;
+    use crate::p2p_wire::tests::utils::signet_headers;
     use crate::p2p_wire::transport::TransportProtocol;
 
     #[tokio::test]
@@ -64,6 +67,30 @@ mod tests {
         assert_eq!(peer.transport_protocol, TransportProtocol::V2);
         assert!(peer.services.has(ServiceFlags::NETWORK));
         assert!(peer.services.has(service_flags::UTREEXO.into()));
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_get_block_returns_mocked_peer_block() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let headers = signet_headers();
+        let blocks = signet_blocks();
+        let expected_block = blocks.get(&headers[1].block_hash()).unwrap().clone();
+        let peer = PeerData::new(Vec::new(), blocks, HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let block = timeout(
+            Duration::from_secs(5),
+            harness.handle.get_block(expected_block.block_hash()),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(block, expected_block);
 
         harness.shutdown().await;
     }

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -133,4 +133,24 @@ mod tests {
 
         harness.shutdown().await;
     }
+
+    #[tokio::test]
+    async fn node_handle_block_request_stays_pending_when_peer_ignores_request() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let headers = signet_headers();
+        let block_hash = headers[1].block_hash();
+        let peer = PeerData::ignoring_block_requests(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let request = timeout(
+            Duration::from_millis(500),
+            harness.handle.get_block(block_hash),
+        )
+        .await;
+
+        assert!(request.is_err());
+
+        harness.shutdown().await;
+    }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -5,15 +5,31 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
+    use bitcoin::Amount;
+    use bitcoin::FilterHash;
+    use bitcoin::FilterHeader;
     use bitcoin::Network;
+    use bitcoin::OutPoint;
+    use bitcoin::ScriptBuf;
+    use bitcoin::Sequence;
+    use bitcoin::Transaction;
+    use bitcoin::TxIn;
+    use bitcoin::TxOut;
+    use bitcoin::Txid;
+    use bitcoin::absolute;
+    use bitcoin::hashes::Hash;
+    use bitcoin::p2p::message_filter::CFHeaders;
+    use bitcoin::transaction::Version;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::time::Duration;
     use tokio::time::timeout;
 
+    use crate::bitcoin_socket_addr::BitcoinSocketAddr;
     use crate::node::NodeNotification;
     use crate::node::PeerStatus;
     use crate::node_handle::NodeHandle;
     use crate::node_interface::ChainMethods;
+    use crate::node_interface::MempoolMethods;
     use crate::node_interface::NetworkMethods;
     use crate::node_interface::NodeConfigMethods;
     use crate::p2p_wire::tests::utils::PeerData;
@@ -21,6 +37,26 @@ mod tests {
     use crate::p2p_wire::tests::utils::signet_blocks;
     use crate::p2p_wire::tests::utils::signet_headers;
     use crate::p2p_wire::transport::TransportProtocol;
+
+    fn sample_transaction() -> Transaction {
+        Transaction {
+            version: Version::ONE,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
 
     #[tokio::test]
     async fn node_handle_get_config_returns_running_node_config() {
@@ -102,6 +138,125 @@ mod tests {
 
         assert_eq!(block, expected_block);
 
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_get_cfilters_headers_returns_mocked_peer_headers() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let stop_hash = signet_headers()[1].block_hash();
+        let cfheaders = CFHeaders {
+            filter_type: 0,
+            stop_hash,
+            previous_filter_header: FilterHeader::all_zeros(),
+            filter_hashes: vec![FilterHash::all_zeros()],
+        };
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new())
+            .with_cfilter_headers(cfheaders.clone());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let response = timeout(
+            Duration::from_secs(5),
+            harness.handle.get_cfilters_headers(1, stop_hash),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(response, cfheaders);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_mempool_methods_use_local_mempool_and_mocked_peer() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let transaction = sample_transaction();
+        let txid = transaction.compute_txid();
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new())
+            .with_transaction(transaction.clone());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let broadcast_txid = timeout(
+            Duration::from_secs(5),
+            harness.handle.broadcast_transaction(transaction.clone()),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+        let fetched_transaction = timeout(
+            Duration::from_secs(5),
+            harness.handle.get_mempool_transaction(txid),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(broadcast_txid, txid);
+        assert_eq!(fetched_transaction, transaction);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn node_handle_network_methods_return_node_status_and_control_peers() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let peer = PeerData::new(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let add_addr: BitcoinSocketAddr = "127.0.0.1:18444".parse().unwrap();
+        let onetry_addr: BitcoinSocketAddr = "127.0.0.1:18445".parse().unwrap();
+        let connected_addr = harness.handle.get_peer_info().await.unwrap()[0]
+            .address
+            .clone();
+
+        let ping = timeout(Duration::from_secs(5), harness.handle.ping())
+            .await
+            .unwrap()
+            .unwrap();
+        let add = timeout(
+            Duration::from_secs(5),
+            harness.handle.add_peer(add_addr.clone(), false),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let stats = timeout(Duration::from_secs(5), harness.handle.get_addrman_info())
+            .await
+            .unwrap()
+            .unwrap();
+        let remove = timeout(Duration::from_secs(5), harness.handle.remove_peer(add_addr))
+            .await
+            .unwrap()
+            .unwrap();
+        let onetry = timeout(
+            Duration::from_secs(5),
+            harness.handle.onetry_peer(onetry_addr, false),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let disconnect = timeout(
+            Duration::from_secs(5),
+            harness.handle.disconnect_peer(connected_addr),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(ping);
+        assert!(add);
+        assert_eq!(stats.ipv4.total(), stats.ipv4.new + stats.ipv4.tried);
+        assert!(remove);
+        assert!(onetry);
+        assert!(disconnect);
+
+        harness.wait_for_peers(0).await;
         harness.shutdown().await;
     }
 

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -140,4 +140,24 @@ mod tests {
 
         harness.shutdown().await;
     }
+
+    #[tokio::test]
+    async fn node_handle_block_request_stays_pending_when_peer_ignores_request() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let headers = signet_headers();
+        let block_hash = headers[1].block_hash();
+        let peer = PeerData::ignoring_block_requests(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let request = timeout(
+            Duration::from_millis(500),
+            harness.handle.get_block(block_hash),
+        )
+        .await;
+
+        assert!(request.is_err());
+
+        harness.shutdown().await;
+    }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/node_handle.rs
@@ -6,8 +6,6 @@ mod tests {
     use std::path::PathBuf;
 
     use bitcoin::Network;
-    use bitcoin::p2p::ServiceFlags;
-    use floresta_common::service_flags;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::time::Duration;
     use tokio::time::timeout;
@@ -68,8 +66,17 @@ mod tests {
         assert_eq!(peer.user_agent, "node_test");
         assert_eq!(peer.state, PeerStatus::Ready);
         assert_eq!(peer.transport_protocol, TransportProtocol::V2);
-        assert!(peer.services.has(ServiceFlags::NETWORK));
-        assert!(peer.services.has(service_flags::UTREEXO.into()));
+        assert_eq!(
+            peer.services_names,
+            vec![
+                "NETWORK",
+                "WITNESS",
+                "COMPACT_FILTERS",
+                "UTREEXO",
+                "UTREEXO_ARCHIVE"
+            ]
+        );
+        assert_eq!(peer.services, "0000000000003049");
 
         harness.shutdown().await;
     }
@@ -111,5 +118,26 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string(), "channel closed");
+    }
+
+    #[tokio::test]
+    async fn node_handle_block_request_stays_pending_when_peer_disconnects() {
+        let datadir = format!("./tmp-db/{}.node_handle", rand::random::<u32>());
+        let headers = signet_headers();
+        let block_hash = headers[1].block_hash();
+        let peer =
+            PeerData::disconnecting_on_block_request(Vec::new(), HashMap::new(), HashMap::new());
+        let harness = setup_node_handle_test(vec![peer], false, Network::Signet, &datadir, 0).await;
+        harness.wait_for_peers(1).await;
+
+        let request = timeout(
+            Duration::from_millis(500),
+            harness.handle.get_block(block_hash),
+        )
+        .await;
+
+        assert!(request.is_err());
+
+        harness.shutdown().await;
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -68,9 +68,16 @@ pub struct SimulatedPeer {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    block_request_behavior: BlockRequestBehavior,
     node_tx: UnboundedSender<NodeNotification>,
     node_rx: UnboundedReceiver<NodeRequest>,
     peer_id: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BlockRequestBehavior {
+    Reply,
+    Disconnect,
 }
 
 impl SimulatedPeer {
@@ -124,6 +131,13 @@ impl SimulatedPeer {
                         .unwrap();
                 }
                 NodeRequest::GetBlock(hashes) => {
+                    if matches!(
+                        self.block_request_behavior,
+                        BlockRequestBehavior::Disconnect
+                    ) {
+                        break;
+                    }
+
                     for hash in hashes {
                         let block = self.blocks.get(&hash).unwrap().clone();
 
@@ -163,16 +177,25 @@ impl SimulatedPeer {
     }
 }
 
-pub fn create_peer(
+fn create_peer(
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    block_request_behavior: BlockRequestBehavior,
     node_sender: UnboundedSender<NodeNotification>,
     sender: UnboundedSender<NodeRequest>,
     node_rcv: UnboundedReceiver<NodeRequest>,
     peer_id: u32,
 ) -> LocalPeerView {
-    let mut peer = SimulatedPeer::new(headers, blocks, accs, node_sender, node_rcv, peer_id);
+    let mut peer = SimulatedPeer::new(
+        headers,
+        blocks,
+        accs,
+        block_request_behavior,
+        node_sender,
+        node_rcv,
+        peer_id,
+    );
     task::spawn(async move {
         peer.run().await;
     });
@@ -289,12 +312,41 @@ pub fn mutated_block_h7() -> Block {
     ).unwrap()
 }
 
-#[derive(Clone, Constructor)]
+#[derive(Clone)]
 /// The chain data that our simulated peer will have
 pub struct PeerData {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    block_request_behavior: BlockRequestBehavior,
+}
+
+impl PeerData {
+    pub fn new(
+        headers: Vec<Header>,
+        blocks: HashMap<BlockHash, Block>,
+        accs: HashMap<BlockHash, Vec<u8>>,
+    ) -> Self {
+        Self {
+            headers,
+            blocks,
+            accs,
+            block_request_behavior: BlockRequestBehavior::Reply,
+        }
+    }
+
+    pub fn disconnecting_on_block_request(
+        headers: Vec<Header>,
+        blocks: HashMap<BlockHash, Block>,
+        accs: HashMap<BlockHash, Vec<u8>>,
+    ) -> Self {
+        Self {
+            headers,
+            blocks,
+            accs,
+            block_request_behavior: BlockRequestBehavior::Disconnect,
+        }
+    }
 }
 
 pub struct NodeHandleTestHarness {
@@ -370,7 +422,7 @@ async fn run_node_handle_test_node(
                         node.attach_proof(uproof, peer).unwrap();
                     }
                     PeerMessages::Disconnected(idx) => {
-                        node.handle_disconnection(peer, idx).unwrap();
+                        let _ = node.handle_disconnection(peer, idx);
                     }
                     _ => {}
                 }
@@ -426,6 +478,7 @@ pub async fn setup_node_handle_test(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
             receiver,
@@ -507,6 +560,7 @@ pub async fn setup_node(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
             receiver,

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -77,6 +77,7 @@ pub struct SimulatedPeer {
 #[derive(Debug, Clone, Copy)]
 enum BlockRequestBehavior {
     Reply,
+    Ignore,
     Disconnect,
 }
 
@@ -131,6 +132,10 @@ impl SimulatedPeer {
                         .unwrap();
                 }
                 NodeRequest::GetBlock(hashes) => {
+                    if matches!(self.block_request_behavior, BlockRequestBehavior::Ignore) {
+                        continue;
+                    }
+
                     if matches!(
                         self.block_request_behavior,
                         BlockRequestBehavior::Disconnect
@@ -345,6 +350,19 @@ impl PeerData {
             blocks,
             accs,
             block_request_behavior: BlockRequestBehavior::Disconnect,
+        }
+    }
+
+    pub fn ignoring_block_requests(
+        headers: Vec<Header>,
+        blocks: HashMap<BlockHash, Block>,
+        accs: HashMap<BlockHash, Vec<u8>>,
+    ) -> Self {
+        Self {
+            headers,
+            blocks,
+            accs,
+            block_request_behavior: BlockRequestBehavior::Ignore,
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -9,12 +9,15 @@ use std::time::Instant;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Network;
+use bitcoin::Transaction;
+use bitcoin::Txid;
 use bitcoin::block::Header;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::encode;
 use bitcoin::consensus::encode::deserialize_hex;
 use bitcoin::hex::FromHex;
 use bitcoin::p2p::ServiceFlags;
+use bitcoin::p2p::message_filter::CFHeaders;
 use derive_more::Constructor;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::ChainState;
@@ -63,11 +66,14 @@ pub struct UtreexoRoots {
     numleaves: usize,
 }
 
+#[allow(clippy::too_many_arguments)]
 #[derive(Debug, Constructor)]
 pub struct SimulatedPeer {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    transactions: HashMap<Txid, Transaction>,
+    cfilter_headers: HashMap<BlockHash, CFHeaders>,
     block_request_behavior: BlockRequestBehavior,
     node_tx: UnboundedSender<NodeNotification>,
     node_rx: UnboundedReceiver<NodeRequest>,
@@ -168,6 +174,22 @@ impl SimulatedPeer {
                         .send(NodeNotification::FromPeer(self.peer_id, peer_msg, now))
                         .unwrap();
                 }
+                NodeRequest::MempoolTransaction(txid) => {
+                    let tx = self.transactions.get(&txid).unwrap().clone();
+
+                    let peer_msg = PeerMessages::Transaction(tx);
+                    self.node_tx
+                        .send(NodeNotification::FromPeer(self.peer_id, peer_msg, now))
+                        .unwrap();
+                }
+                NodeRequest::GetCFHeaders { stop_hash, .. } => {
+                    let cfheaders = self.cfilter_headers.get(&stop_hash).unwrap().clone();
+
+                    let peer_msg = PeerMessages::CFHeaders(cfheaders);
+                    self.node_tx
+                        .send(NodeNotification::FromPeer(self.peer_id, peer_msg, now))
+                        .unwrap();
+                }
                 _ => {}
             }
         }
@@ -182,10 +204,13 @@ impl SimulatedPeer {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_peer(
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    transactions: HashMap<Txid, Transaction>,
+    cfilter_headers: HashMap<BlockHash, CFHeaders>,
     block_request_behavior: BlockRequestBehavior,
     node_sender: UnboundedSender<NodeNotification>,
     sender: UnboundedSender<NodeRequest>,
@@ -196,6 +221,8 @@ fn create_peer(
         headers,
         blocks,
         accs,
+        transactions,
+        cfilter_headers,
         block_request_behavior,
         node_sender,
         node_rcv,
@@ -323,6 +350,8 @@ pub struct PeerData {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    transactions: HashMap<Txid, Transaction>,
+    cfilter_headers: HashMap<BlockHash, CFHeaders>,
     block_request_behavior: BlockRequestBehavior,
 }
 
@@ -336,6 +365,8 @@ impl PeerData {
             headers,
             blocks,
             accs,
+            transactions: HashMap::new(),
+            cfilter_headers: HashMap::new(),
             block_request_behavior: BlockRequestBehavior::Reply,
         }
     }
@@ -349,6 +380,8 @@ impl PeerData {
             headers,
             blocks,
             accs,
+            transactions: HashMap::new(),
+            cfilter_headers: HashMap::new(),
             block_request_behavior: BlockRequestBehavior::Disconnect,
         }
     }
@@ -362,8 +395,21 @@ impl PeerData {
             headers,
             blocks,
             accs,
+            transactions: HashMap::new(),
+            cfilter_headers: HashMap::new(),
             block_request_behavior: BlockRequestBehavior::Ignore,
         }
+    }
+
+    pub fn with_transaction(mut self, transaction: Transaction) -> Self {
+        self.transactions
+            .insert(transaction.compute_txid(), transaction);
+        self
+    }
+
+    pub fn with_cfilter_headers(mut self, cfheaders: CFHeaders) -> Self {
+        self.cfilter_headers.insert(cfheaders.stop_hash, cfheaders);
+        self
     }
 }
 
@@ -496,6 +542,8 @@ pub async fn setup_node_handle_test(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.transactions,
+            peer.cfilter_headers,
             peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
@@ -524,6 +572,8 @@ pub async fn setup_node_handle_test(
             (peer_id, Instant::now()),
         );
     }
+
+    node.peer_id_count = node.peers.len() as u32;
 
     let handle = node.get_handle();
     let node_sender = node.node_tx.clone();
@@ -578,6 +628,8 @@ pub async fn setup_node(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.transactions,
+            peer.cfilter_headers,
             peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
@@ -609,6 +661,8 @@ pub async fn setup_node(
             (peer_id, Instant::now()),
         );
     }
+
+    node.peer_id_count = node.peers.len() as u32;
 
     timeout(Duration::from_secs(100), node.run(|_| {}))
         .await

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -36,6 +36,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::task;
 use tokio::task::JoinHandle;
+use tokio::time::sleep;
 use tokio::time::timeout;
 use zstd;
 
@@ -50,6 +51,7 @@ use crate::node::PeerStatus;
 use crate::node::UtreexoNode;
 use crate::node::sync_ctx::SyncNode;
 use crate::node_handle::NodeHandle;
+use crate::node_interface::NetworkMethods;
 use crate::p2p_wire::block_proof::UtreexoProof;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
@@ -303,6 +305,21 @@ pub struct NodeHandleTestHarness {
 }
 
 impl NodeHandleTestHarness {
+    pub async fn wait_for_peers(&self, expected: usize) {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let peers = self.handle.get_peer_info().await.unwrap();
+                if peers.len() == expected {
+                    break;
+                }
+
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
     pub async fn shutdown(self) {
         *self.kill_signal.write().await = true;
         self.node_sender

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -35,6 +35,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::task;
+use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use zstd;
 
@@ -48,6 +49,7 @@ use crate::node::NodeRequest;
 use crate::node::PeerStatus;
 use crate::node::UtreexoNode;
 use crate::node::sync_ctx::SyncNode;
+use crate::node_handle::NodeHandle;
 use crate::p2p_wire::block_proof::UtreexoProof;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
@@ -197,6 +199,7 @@ pub fn get_node_config(
         network,
         pow_fraud_proofs,
         datadir: datadir.as_ref().into(),
+        disable_dns_seeds: true,
         user_agent: "node_test".to_string(),
         ..Default::default()
     }
@@ -290,6 +293,160 @@ pub struct PeerData {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+}
+
+pub struct NodeHandleTestHarness {
+    pub handle: NodeHandle,
+    kill_signal: Arc<RwLock<bool>>,
+    node_sender: UnboundedSender<NodeNotification>,
+    node_task: JoinHandle<()>,
+}
+
+impl NodeHandleTestHarness {
+    pub async fn shutdown(self) {
+        *self.kill_signal.write().await = true;
+        self.node_sender
+            .send(NodeNotification::DnsSeedAddresses(Vec::new()))
+            .unwrap();
+
+        timeout(Duration::from_secs(5), self.node_task)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+}
+
+async fn run_node_handle_test_node(
+    mut node: UtreexoNode<Arc<ChainState<FlatChainStore>>, SyncNode>,
+) {
+    loop {
+        let Some(notification) = node.node_rx.recv().await else {
+            break;
+        };
+
+        if *node.kill_signal.read().await {
+            break;
+        }
+
+        match notification {
+            NodeNotification::FromUser(request, responder) => {
+                node.perform_user_request(request, responder).await;
+            }
+            NodeNotification::DnsSeedAddresses(addresses) => {
+                node.address_man.push_addresses(&addresses);
+            }
+            NodeNotification::FromPeer(peer, message, time) => {
+                node.register_message_time(&message, peer, time);
+
+                let Some(unhandled) = node.handle_peer_msg_common(message, peer).unwrap() else {
+                    continue;
+                };
+
+                match unhandled {
+                    PeerMessages::Ready(version) => {
+                        node.handle_peer_ready(peer, version).unwrap();
+                    }
+                    PeerMessages::Block(block) => {
+                        node.request_block_proof(block, peer).unwrap();
+                    }
+                    PeerMessages::UtreexoProof(uproof) => {
+                        node.attach_proof(uproof, peer).unwrap();
+                    }
+                    PeerMessages::Disconnected(idx) => {
+                        node.handle_disconnection(peer, idx).unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if *node.kill_signal.read().await {
+            break;
+        }
+    }
+
+    node.shutdown();
+}
+
+pub async fn setup_node_handle_test(
+    peers: Vec<PeerData>,
+    pow_fraud_proofs: bool,
+    network: Network,
+    datadir: impl AsRef<Path>,
+    num_blocks: usize,
+) -> NodeHandleTestHarness {
+    let config = FlatChainStoreConfig::new(&datadir);
+
+    let chainstore = FlatChainStore::new(config).unwrap();
+    let mempool = Arc::new(Mutex::new(Mempool::new(1000)));
+    let chain = ChainState::open(chainstore, network, AssumeValidArg::Disabled).unwrap();
+    let chain = Arc::new(chain);
+
+    let mut headers = signet_headers();
+    headers.remove(0);
+    headers.truncate(num_blocks);
+    for header in headers {
+        chain.accept_header(header).unwrap();
+    }
+
+    let config = get_node_config(&datadir, network, pow_fraud_proofs);
+    let kill_signal = Arc::new(RwLock::new(false));
+    let mut node = UtreexoNode::<Arc<ChainState<FlatChainStore>>, SyncNode>::new(
+        config,
+        chain.clone(),
+        mempool,
+        None,
+        kill_signal.clone(),
+        AddressMan::new(None, &[]),
+    )
+    .unwrap();
+
+    for (i, peer) in peers.into_iter().enumerate() {
+        let (sender, receiver) = unbounded_channel();
+        let peer_id = i as u32;
+
+        let peer = create_peer(
+            peer.headers,
+            peer.blocks,
+            peer.accs,
+            node.node_tx.clone(),
+            sender.clone(),
+            receiver,
+            peer_id,
+        );
+
+        if i == 0 {
+            node.fixed_peers = vec![peer.address.clone()];
+        }
+
+        node.peers.insert(peer_id, peer);
+        for service in [
+            service_flags::UTREEXO.into(),
+            ServiceFlags::COMPACT_FILTERS,
+            ServiceFlags::NETWORK,
+        ] {
+            node.peer_by_service
+                .entry(service)
+                .or_default()
+                .push(peer_id);
+        }
+
+        node.inflight.insert(
+            InflightRequests::Connect(peer_id),
+            (peer_id, Instant::now()),
+        );
+    }
+
+    let handle = node.get_handle();
+    let node_sender = node.node_tx.clone();
+    let node_task = task::spawn(run_node_handle_test_node(node));
+
+    NodeHandleTestHarness {
+        handle,
+        kill_signal,
+        node_sender,
+        node_task,
+    }
 }
 
 pub async fn setup_node(

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -66,6 +66,7 @@ pub struct UtreexoRoots {
 // Nightly Clippy false positive in `Constructor`-generated code:
 // https://github.com/rust-lang/rust-clippy/issues/17525
 #[allow(clippy::redundant_field_names)]
+#[allow(clippy::too_many_arguments)]
 #[derive(Debug, Constructor)]
 pub struct SimulatedPeer {
     headers: Vec<Header>,
@@ -80,6 +81,7 @@ pub struct SimulatedPeer {
 #[derive(Debug, Clone, Copy)]
 enum BlockRequestBehavior {
     Reply,
+    Ignore,
     Disconnect,
 }
 
@@ -135,6 +137,10 @@ impl SimulatedPeer {
                         .unwrap();
                 }
                 NodeRequest::GetBlock(hashes) => {
+                    if matches!(self.block_request_behavior, BlockRequestBehavior::Ignore) {
+                        continue;
+                    }
+
                     if matches!(
                         self.block_request_behavior,
                         BlockRequestBehavior::Disconnect
@@ -354,6 +360,19 @@ impl PeerData {
             blocks,
             accs,
             block_request_behavior: BlockRequestBehavior::Disconnect,
+        }
+    }
+
+    pub fn ignoring_block_requests(
+        headers: Vec<Header>,
+        blocks: HashMap<BlockHash, Block>,
+        accs: HashMap<BlockHash, Vec<u8>>,
+    ) -> Self {
+        Self {
+            headers,
+            blocks,
+            accs,
+            block_request_behavior: BlockRequestBehavior::Ignore,
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -35,6 +35,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::task;
+use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use zstd;
 
@@ -48,6 +49,7 @@ use crate::node::NodeRequest;
 use crate::node::PeerStatus;
 use crate::node::UtreexoNode;
 use crate::node::sync_ctx::SyncNode;
+use crate::node_handle::NodeHandle;
 use crate::p2p_wire::block_proof::UtreexoProof;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
@@ -202,6 +204,7 @@ pub fn get_node_config(
         network,
         pow_fraud_proofs,
         datadir: datadir.as_ref().into(),
+        disable_dns_seeds: true,
         user_agent: "node_test".to_string(),
         ..Default::default()
     }
@@ -298,6 +301,160 @@ pub struct PeerData {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+}
+
+pub struct NodeHandleTestHarness {
+    pub handle: NodeHandle,
+    kill_signal: Arc<RwLock<bool>>,
+    node_sender: UnboundedSender<NodeNotification>,
+    node_task: JoinHandle<()>,
+}
+
+impl NodeHandleTestHarness {
+    pub async fn shutdown(self) {
+        *self.kill_signal.write().await = true;
+        self.node_sender
+            .send(NodeNotification::DnsSeedAddresses(Vec::new()))
+            .unwrap();
+
+        timeout(Duration::from_secs(5), self.node_task)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+}
+
+async fn run_node_handle_test_node(
+    mut node: UtreexoNode<Arc<ChainState<FlatChainStore>>, SyncNode>,
+) {
+    loop {
+        let Some(notification) = node.node_rx.recv().await else {
+            break;
+        };
+
+        if *node.kill_signal.read().await {
+            break;
+        }
+
+        match notification {
+            NodeNotification::FromUser(request, responder) => {
+                node.perform_user_request(request, responder).await;
+            }
+            NodeNotification::DnsSeedAddresses(addresses) => {
+                node.address_man.push_addresses(&addresses);
+            }
+            NodeNotification::FromPeer(peer, message, time) => {
+                node.register_message_time(&message, peer, time);
+
+                let Some(unhandled) = node.handle_peer_msg_common(message, peer).unwrap() else {
+                    continue;
+                };
+
+                match unhandled {
+                    PeerMessages::Ready(version) => {
+                        node.handle_peer_ready(peer, version).unwrap();
+                    }
+                    PeerMessages::Block(block) => {
+                        node.request_block_proof(block, peer).unwrap();
+                    }
+                    PeerMessages::UtreexoProof(uproof) => {
+                        node.attach_proof(uproof, peer).unwrap();
+                    }
+                    PeerMessages::Disconnected(idx) => {
+                        node.handle_disconnection(peer, idx).unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if *node.kill_signal.read().await {
+            break;
+        }
+    }
+
+    node.shutdown();
+}
+
+pub async fn setup_node_handle_test(
+    peers: Vec<PeerData>,
+    pow_fraud_proofs: bool,
+    network: Network,
+    datadir: impl AsRef<Path>,
+    num_blocks: usize,
+) -> NodeHandleTestHarness {
+    let config = FlatChainStoreConfig::new(&datadir);
+
+    let chainstore = FlatChainStore::new(config).unwrap();
+    let mempool = Arc::new(Mutex::new(Mempool::new(1000)));
+    let chain = ChainState::open(chainstore, network, AssumeValidArg::Disabled).unwrap();
+    let chain = Arc::new(chain);
+
+    let mut headers = signet_headers();
+    headers.remove(0);
+    headers.truncate(num_blocks);
+    for header in headers {
+        chain.accept_header(header).unwrap();
+    }
+
+    let config = get_node_config(&datadir, network, pow_fraud_proofs);
+    let kill_signal = Arc::new(RwLock::new(false));
+    let mut node = UtreexoNode::<Arc<ChainState<FlatChainStore>>, SyncNode>::new(
+        config,
+        chain.clone(),
+        mempool,
+        None,
+        kill_signal.clone(),
+        AddressMan::new(None, &[]),
+    )
+    .unwrap();
+
+    for (i, peer) in peers.into_iter().enumerate() {
+        let (sender, receiver) = unbounded_channel();
+        let peer_id = i as u32;
+
+        let peer = create_peer(
+            peer.headers,
+            peer.blocks,
+            peer.accs,
+            node.node_tx.clone(),
+            sender.clone(),
+            receiver,
+            peer_id,
+        );
+
+        if i == 0 {
+            node.fixed_peers = vec![peer.address.clone()];
+        }
+
+        node.peers.insert(peer_id, peer);
+        for service in [
+            service_flags::UTREEXO.into(),
+            ServiceFlags::COMPACT_FILTERS,
+            ServiceFlags::NETWORK,
+        ] {
+            node.peer_by_service
+                .entry(service)
+                .or_default()
+                .push(peer_id);
+        }
+
+        node.inflight.insert(
+            InflightRequests::Connect(peer_id),
+            (peer_id, Instant::now()),
+        );
+    }
+
+    let handle = node.get_handle();
+    let node_sender = node.node_tx.clone();
+    let node_task = task::spawn(run_node_handle_test_node(node));
+
+    NodeHandleTestHarness {
+        handle,
+        kill_signal,
+        node_sender,
+        node_task,
+    }
 }
 
 pub async fn setup_node(

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -36,6 +36,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::task;
 use tokio::task::JoinHandle;
+use tokio::time::sleep;
 use tokio::time::timeout;
 use zstd;
 
@@ -50,6 +51,7 @@ use crate::node::PeerStatus;
 use crate::node::UtreexoNode;
 use crate::node::sync_ctx::SyncNode;
 use crate::node_handle::NodeHandle;
+use crate::node_interface::NetworkMethods;
 use crate::p2p_wire::block_proof::UtreexoProof;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
@@ -311,6 +313,21 @@ pub struct NodeHandleTestHarness {
 }
 
 impl NodeHandleTestHarness {
+    pub async fn wait_for_peers(&self, expected: usize) {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let peers = self.handle.get_peer_info().await.unwrap();
+                if peers.len() == expected {
+                    break;
+                }
+
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
     pub async fn shutdown(self) {
         *self.kill_signal.write().await = true;
         self.node_sender

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -9,12 +9,15 @@ use std::time::Instant;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Network;
+use bitcoin::Transaction;
+use bitcoin::Txid;
 use bitcoin::block::Header;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::encode;
 use bitcoin::consensus::encode::deserialize_hex;
 use bitcoin::hex::FromHex;
 use bitcoin::p2p::ServiceFlags;
+use bitcoin::p2p::message_filter::CFHeaders;
 use derive_more::Constructor;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::ChainState;
@@ -72,6 +75,8 @@ pub struct SimulatedPeer {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    transactions: HashMap<Txid, Transaction>,
+    cfilter_headers: HashMap<BlockHash, CFHeaders>,
     block_request_behavior: BlockRequestBehavior,
     node_tx: UnboundedSender<NodeNotification>,
     node_rx: UnboundedReceiver<NodeRequest>,
@@ -173,6 +178,22 @@ impl SimulatedPeer {
                         .send(NodeNotification::FromPeer(self.peer_id, peer_msg, now))
                         .unwrap();
                 }
+                NodeRequest::MempoolTransaction(txid) => {
+                    let tx = self.transactions.get(&txid).unwrap().clone();
+
+                    let peer_msg = PeerMessages::Transaction(tx);
+                    self.node_tx
+                        .send(NodeNotification::FromPeer(self.peer_id, peer_msg, now))
+                        .unwrap();
+                }
+                NodeRequest::GetCFHeaders { stop_hash, .. } => {
+                    let cfheaders = self.cfilter_headers.get(&stop_hash).unwrap().clone();
+
+                    let peer_msg = PeerMessages::CFHeaders(cfheaders);
+                    self.node_tx
+                        .send(NodeNotification::FromPeer(self.peer_id, peer_msg, now))
+                        .unwrap();
+                }
                 _ => {}
             }
         }
@@ -192,6 +213,8 @@ fn create_peer(
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    transactions: HashMap<Txid, Transaction>,
+    cfilter_headers: HashMap<BlockHash, CFHeaders>,
     block_request_behavior: BlockRequestBehavior,
     node_sender: UnboundedSender<NodeNotification>,
     sender: UnboundedSender<NodeRequest>,
@@ -202,6 +225,8 @@ fn create_peer(
         headers,
         blocks,
         accs,
+        transactions,
+        cfilter_headers,
         block_request_behavior,
         node_sender,
         node_rcv,
@@ -333,6 +358,8 @@ pub struct PeerData {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    transactions: HashMap<Txid, Transaction>,
+    cfilter_headers: HashMap<BlockHash, CFHeaders>,
     block_request_behavior: BlockRequestBehavior,
 }
 
@@ -346,6 +373,8 @@ impl PeerData {
             headers,
             blocks,
             accs,
+            transactions: HashMap::new(),
+            cfilter_headers: HashMap::new(),
             block_request_behavior: BlockRequestBehavior::Reply,
         }
     }
@@ -359,6 +388,8 @@ impl PeerData {
             headers,
             blocks,
             accs,
+            transactions: HashMap::new(),
+            cfilter_headers: HashMap::new(),
             block_request_behavior: BlockRequestBehavior::Disconnect,
         }
     }
@@ -372,8 +403,21 @@ impl PeerData {
             headers,
             blocks,
             accs,
+            transactions: HashMap::new(),
+            cfilter_headers: HashMap::new(),
             block_request_behavior: BlockRequestBehavior::Ignore,
         }
+    }
+
+    pub fn with_transaction(mut self, transaction: Transaction) -> Self {
+        self.transactions
+            .insert(transaction.compute_txid(), transaction);
+        self
+    }
+
+    pub fn with_cfilter_headers(mut self, cfheaders: CFHeaders) -> Self {
+        self.cfilter_headers.insert(cfheaders.stop_hash, cfheaders);
+        self
     }
 }
 
@@ -506,6 +550,8 @@ pub async fn setup_node_handle_test(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.transactions,
+            peer.cfilter_headers,
             peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
@@ -534,6 +580,8 @@ pub async fn setup_node_handle_test(
             (peer_id, Instant::now()),
         );
     }
+
+    node.peer_id_count = node.peers.len() as u32;
 
     let handle = node.get_handle();
     let node_sender = node.node_tx.clone();
@@ -588,6 +636,8 @@ pub async fn setup_node(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.transactions,
+            peer.cfilter_headers,
             peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
@@ -619,6 +669,8 @@ pub async fn setup_node(
             (peer_id, Instant::now()),
         );
     }
+
+    node.peer_id_count = node.peers.len() as u32;
 
     timeout(Duration::from_secs(100), node.run(|_| {}))
         .await

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -71,9 +71,16 @@ pub struct SimulatedPeer {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    block_request_behavior: BlockRequestBehavior,
     node_tx: UnboundedSender<NodeNotification>,
     node_rx: UnboundedReceiver<NodeRequest>,
     peer_id: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BlockRequestBehavior {
+    Reply,
+    Disconnect,
 }
 
 impl SimulatedPeer {
@@ -128,6 +135,13 @@ impl SimulatedPeer {
                         .unwrap();
                 }
                 NodeRequest::GetBlock(hashes) => {
+                    if matches!(
+                        self.block_request_behavior,
+                        BlockRequestBehavior::Disconnect
+                    ) {
+                        break;
+                    }
+
                     for hash in hashes {
                         let block = self.blocks.get(&hash).unwrap().clone();
 
@@ -167,16 +181,26 @@ impl SimulatedPeer {
     }
 }
 
-pub fn create_peer(
+#[allow(clippy::too_many_arguments)]
+fn create_peer(
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    block_request_behavior: BlockRequestBehavior,
     node_sender: UnboundedSender<NodeNotification>,
     sender: UnboundedSender<NodeRequest>,
     node_rcv: UnboundedReceiver<NodeRequest>,
     peer_id: u32,
 ) -> LocalPeerView {
-    let mut peer = SimulatedPeer::new(headers, blocks, accs, node_sender, node_rcv, peer_id);
+    let mut peer = SimulatedPeer::new(
+        headers,
+        blocks,
+        accs,
+        block_request_behavior,
+        node_sender,
+        node_rcv,
+        peer_id,
+    );
     task::spawn(async move {
         peer.run().await;
     });
@@ -297,12 +321,41 @@ pub fn mutated_block_h7() -> Block {
 // Nightly Clippy false positive in `Constructor`-generated code:
 // https://github.com/rust-lang/rust-clippy/issues/17525
 #[allow(clippy::redundant_field_names)]
-#[derive(Clone, Constructor)]
+#[derive(Clone)]
 /// The chain data that our simulated peer will have
 pub struct PeerData {
     headers: Vec<Header>,
     blocks: HashMap<BlockHash, Block>,
     accs: HashMap<BlockHash, Vec<u8>>,
+    block_request_behavior: BlockRequestBehavior,
+}
+
+impl PeerData {
+    pub fn new(
+        headers: Vec<Header>,
+        blocks: HashMap<BlockHash, Block>,
+        accs: HashMap<BlockHash, Vec<u8>>,
+    ) -> Self {
+        Self {
+            headers,
+            blocks,
+            accs,
+            block_request_behavior: BlockRequestBehavior::Reply,
+        }
+    }
+
+    pub fn disconnecting_on_block_request(
+        headers: Vec<Header>,
+        blocks: HashMap<BlockHash, Block>,
+        accs: HashMap<BlockHash, Vec<u8>>,
+    ) -> Self {
+        Self {
+            headers,
+            blocks,
+            accs,
+            block_request_behavior: BlockRequestBehavior::Disconnect,
+        }
+    }
 }
 
 pub struct NodeHandleTestHarness {
@@ -378,7 +431,7 @@ async fn run_node_handle_test_node(
                         node.attach_proof(uproof, peer).unwrap();
                     }
                     PeerMessages::Disconnected(idx) => {
-                        node.handle_disconnection(peer, idx).unwrap();
+                        let _ = node.handle_disconnection(peer, idx);
                     }
                     _ => {}
                 }
@@ -434,6 +487,7 @@ pub async fn setup_node_handle_test(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
             receiver,
@@ -515,6 +569,7 @@ pub async fn setup_node(
             peer.headers,
             peer.blocks,
             peer.accs,
+            peer.block_request_behavior,
             node.node_tx.clone(),
             sender.clone(),
             receiver,


### PR DESCRIPTION
### Description and Notes

Closes #1179

This PR adds tests to the `NodeInterface` and `NodeHandle` implementations. I've followed the same setup we use for `sync_node` and `chain_selector`, where we create mock peers that have hard-coded data and returns them. All methods are covered, including some failure cases.

**Important**: Those tests are kinda slow if you run them in `debug` mode, so if try to run them and they feel slow, considering running `cargo test --release`.

### Changelog

```
 - Improved our tests utils harnesses to help with those tests
 - Tested all methods exposed by `NodeInterface`
 - Adde some tests for failure cases, like having the receiver dropped or peer timing out requests
```