### PR TITLE
feat: getchaintips as it is

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -130,6 +130,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_deployment_info(blockhash)?)?
         }
         Methods::GetAddrManInfo => serde_json::to_string_pretty(&client.get_addrman_info()?)?,
+        Methods::GetChainTips => serde_json::to_string_pretty(&client.get_chain_tips()?)?,
     })
 }
 
@@ -464,4 +465,13 @@ pub enum Methods {
         disable_help_subcommand = true
     )]
     GetAddrManInfo,
+
+    #[doc = include_str!("../../../doc/rpc/getchaintips.md")]
+    #[command(
+        name = "getchaintips",
+        about = "Return information about all known tips in the block tree",
+        long_about = Some(include_str!("../../../doc/rpc/getchaintips.md")),
+        disable_help_subcommand = true
+    )]
+    GetChainTips,
 }

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -306,6 +306,7 @@ mod tests {
     use crate::BlockConsumer;
     use crate::BlockchainError;
     use crate::UtxoData;
+    use crate::pruned_utreexo::ChainTipInfo;
     use crate::pruned_utreexo::IBDState;
 
     #[derive(Debug)]
@@ -432,7 +433,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn get_chain_tips(&self) -> Result<Vec<BlockHash>, Self::Error> {
+        fn get_chain_tips(&self) -> Result<Vec<ChainTipInfo>, Self::Error> {
             unimplemented!()
         }
 

--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -27,6 +27,7 @@ pub mod pruned_utreexo;
 pub(crate) use floresta_common::prelude;
 pub use pruned_utreexo::BlockchainInterface;
 pub use pruned_utreexo::ChainBackend;
+pub use pruned_utreexo::ChainTipInfo;
 pub use pruned_utreexo::Notification;
 pub use pruned_utreexo::ThreadSafeChain;
 pub use pruned_utreexo::chain_state::*;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -25,6 +25,7 @@ use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
+use core::cmp::Reverse;
 use core::cmp::min;
 use core::ops::Add;
 
@@ -52,6 +53,7 @@ use tracing::info;
 use tracing::warn;
 
 use super::BlockchainInterface;
+use super::ChainTipInfo;
 use super::UpdatableChainstate;
 use super::chain_state_builder::BlockchainBuilderError;
 use super::chain_state_builder::ChainStateBuilder;
@@ -1063,12 +1065,49 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         Consensus::update_acc(&acc, block, height, proof, del_hashes)
     }
 
-    fn get_chain_tips(&self) -> Result<Vec<BlockHash>, Self::Error> {
-        let inner = read_lock!(self);
-        let mut tips = Vec::new();
+    fn get_chain_tips(&self) -> Result<Vec<ChainTipInfo>, Self::Error> {
+        let (best_height, best_hash, alt_tips) = {
+            let inner = read_lock!(self);
+            (
+                inner.best_block.depth,
+                inner.best_block.best_block,
+                inner.best_block.alternative_tips.clone(),
+            )
+        };
 
-        tips.push(inner.best_block.best_block);
-        tips.extend(inner.best_block.alternative_tips.iter());
+        let mut tips = Vec::with_capacity(1 + alt_tips.len());
+
+        // The active tip is always the first element, with branch_length 0.
+        tips.push(ChainTipInfo {
+            height: best_height,
+            hash: best_hash,
+            branch_length: 0,
+        });
+
+        for tip_hash in &alt_tips {
+            let tip_height = self
+                .get_disk_block_header(tip_hash)?
+                .height()
+                .ok_or(BlockchainError::BlockNotPresent)?;
+
+            let fork_point = self.find_fork_point(&self.get_block_header(tip_hash)?)?;
+            let fork_height = self
+                .get_disk_block_header(&fork_point.block_hash())?
+                .height()
+                .ok_or(BlockchainError::BlockNotPresent)?;
+
+            let tip = ChainTipInfo {
+                height: tip_height,
+                hash: *tip_hash,
+                branch_length: tip_height - fork_height,
+            };
+
+            // Insert sorted by height descending among the alternative tips (indices 1..).
+            let pos = tips[1..]
+                .binary_search_by_key(&Reverse(tip_height), |t| Reverse(t.height))
+                .unwrap_or_else(|i| i);
+            tips.insert(1 + pos, tip);
+        }
 
         Ok(tips)
     }
@@ -1904,6 +1943,8 @@ mod test {
         // Only one tip so far (the main chain)
         let tips = chain.get_chain_tips().unwrap();
         assert_eq!(tips.len(), 1);
+        assert_eq!(tips[0].height, 10);
+        assert_eq!(tips[0].branch_length, 0);
 
         // Accept only 4 fork headers (less work than main chain: 4 < 5 blocks after fork point)
         for block in &long_chain[..4] {
@@ -1917,10 +1958,14 @@ mod test {
         // First tip is always the best block (main chain tip at height 10)
         let (best_height, best_hash) = chain.get_best_block().unwrap();
         assert_eq!(best_height, 10);
-        assert_eq!(tips[0], best_hash);
+        assert_eq!(tips[0].hash, best_hash);
+        assert_eq!(tips[0].height, 10);
+        assert_eq!(tips[0].branch_length, 0);
 
-        // Second tip is the fork tip (4th fork block)
-        assert_eq!(tips[1], long_chain[3].block_hash());
+        // Second tip is the fork tip (4th fork block, height 9, branching at height 5)
+        assert_eq!(tips[1].hash, long_chain[3].block_hash());
+        assert_eq!(tips[1].height, 9);
+        assert_eq!(tips[1].branch_length, 4);
     }
 
     #[test]

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -41,6 +41,24 @@ use crate::BlockchainError;
 use crate::prelude::*;
 use crate::pruned_utreexo::utxo_data::UtxoData;
 
+/// Information about a single chain tip, as returned by
+/// [`BlockchainInterface::get_chain_tips`].
+///
+/// The active tip is always the first element in the returned vector.
+/// Alternative (fork) tips follow, sorted by height descending.
+#[derive(Debug, Clone)]
+pub struct ChainTipInfo {
+    /// Height of this tip.
+    pub height: u32,
+
+    /// Block hash of this tip.
+    pub hash: BlockHash,
+
+    /// Number of blocks between this tip and the fork point with the main
+    /// chain. Always 0 for the active tip.
+    pub branch_length: u32,
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 /// Our current IBD state, meaning which startup phase are we, if any.
 ///
@@ -128,8 +146,11 @@ pub trait BlockchainInterface {
         del_hashes: Vec<sha256::Hash>,
     ) -> Result<Stump, Self::Error>;
 
-    /// Returns all known chain tips, including the best one and forks
-    fn get_chain_tips(&self) -> Result<Vec<BlockHash>, Self::Error>;
+    /// Returns all known chain tips, including the best one and forks.
+    ///
+    /// The active tip is always the first element. Alternative tips follow,
+    /// sorted by height descending.
+    fn get_chain_tips(&self) -> Result<Vec<ChainTipInfo>, Self::Error>;
 
     /// Validates a block according to Bitcoin's rules, without modifying our chain
     fn validate_block(
@@ -373,7 +394,7 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
         T::update_acc(self, acc, block, height, proof, del_hashes)
     }
 
-    fn get_chain_tips(&self) -> Result<Vec<BlockHash>, Self::Error> {
+    fn get_chain_tips(&self) -> Result<Vec<ChainTipInfo>, Self::Error> {
         T::get_chain_tips(self)
     }
 

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -34,6 +34,7 @@ use rustreexo::stump::Stump;
 use tracing::info;
 
 use super::BlockchainInterface;
+use super::ChainTipInfo;
 use super::UpdatableChainstate;
 use super::chainparams::ChainParams;
 use super::consensus::Consensus;
@@ -407,7 +408,7 @@ impl BlockchainInterface for PartialChainState {
         unimplemented!("PartialChainState::get_block_header")
     }
 
-    fn get_chain_tips(&self) -> Result<Vec<BlockHash>, Self::Error> {
+    fn get_chain_tips(&self) -> Result<Vec<ChainTipInfo>, Self::Error> {
         unimplemented!("PartialChainState::get_chain_tips")
     }
 

--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -20,11 +20,14 @@ use bitcoin::hashes::Hash;
 use bitcoin::hex::DisplayHex;
 use corepc_types::ScriptPubKey;
 use corepc_types::v29::GetTxOut;
+use corepc_types::v30::ChainTips;
+use corepc_types::v30::ChainTipsStatus;
 use corepc_types::v30::DeploymentInfo;
 use corepc_types::v30::GetBlockHeaderVerbose;
 use corepc_types::v30::GetBlockVerboseOne;
 use corepc_types::v30::GetBlockchainInfo;
 use corepc_types::v30::GetDeploymentInfo;
+use corepc_types::v31::GetChainTips;
 use floresta_chain::buried_deployments_for;
 use floresta_chain::extensions::HeaderExt;
 use floresta_chain::extensions::WorkExt;
@@ -356,7 +359,32 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
     // getblockstats
     // getchainstates
+
     // getchaintips
+    pub(super) fn get_chain_tips(&self) -> Result<GetChainTips, JsonRpcError> {
+        let tips = self
+            .chain
+            .get_chain_tips()
+            .map_err(|_| JsonRpcError::Chain)?;
+
+        let result = tips
+            .into_iter()
+            .enumerate()
+            .map(|(i, tip)| ChainTips {
+                height: tip.height.into(),
+                hash: tip.hash.to_string(),
+                branch_length: tip.branch_length.into(),
+                status: if i == 0 {
+                    ChainTipsStatus::Active
+                } else {
+                    ChainTipsStatus::ValidHeaders
+                },
+            })
+            .collect();
+
+        Ok(GetChainTips(result))
+    }
+
     // getchaintxstats
 
     // getdeploymentinfo

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -245,6 +245,11 @@ async fn handle_json_rpc_request(
                 .get_block_count()
                 .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG));
         }
+        "getchaintips" => {
+            return state
+                .get_chain_tips()
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG));
+        }
         "getconnectioncount" => {
             return state
                 .get_connection_count()

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -8,6 +8,7 @@ use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
 use corepc_types::v30::GetAddrManInfo;
 use corepc_types::v30::GetBlockchainInfo;
+use corepc_types::v30::GetChainTips;
 use corepc_types::v30::GetDeploymentInfo;
 use serde_json::Number;
 use serde_json::Value;
@@ -154,6 +155,9 @@ pub trait FlorestaRPC {
     fn ping(&self) -> Result<()>;
     /// Returns address manager statistics broken down by network.
     fn get_addrman_info(&self) -> Result<GetAddrManInfo>;
+    /// Return information about all known tips in the block tree, including the
+    /// main chain as well as orphaned branches.
+    fn get_chain_tips(&self) -> Result<GetChainTips>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -383,5 +387,9 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_addrman_info(&self) -> Result<GetAddrManInfo> {
         self.call("getaddrmaninfo", &[])
+    }
+
+    fn get_chain_tips(&self) -> Result<GetChainTips> {
+        self.call("getchaintips", &[])
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -742,13 +742,13 @@ where
                 );
 
                 self.context.state = ChainSelectorState::Done;
-                self.chain.mark_chain_as_assumed(acc, tips[0]).unwrap();
+                self.chain.mark_chain_as_assumed(acc, tips[0].hash).unwrap();
                 self.chain.update_ibd(IBDState::Done);
             }
             // if we have more than one tip, we need to check if our best chain has an invalid block
             tips.remove(0); // no need to check our best one
             for tip in tips {
-                self.is_our_chain_invalid(tip).await?;
+                self.is_our_chain_invalid(tip.hash).await?;
             }
 
             return Ok(());

--- a/doc/rpc/getchaintips.md
+++ b/doc/rpc/getchaintips.md
@@ -1,0 +1,48 @@
+# `getchaintips`
+
+Return information about all known tips in the block tree, including the main chain as well as orphaned branches.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli getchaintips
+```
+
+### Examples
+
+```bash
+# List all chain tips
+floresta-cli getchaintips
+```
+
+## Returns
+
+### Ok Response
+
+Returns a JSON array of objects, each describing one chain tip:
+
+- `height` - (numeric) The height of the chain tip.
+
+- `hash` - (string) The block hash of the tip.
+
+- `branchlen` - (numeric) The number of blocks between the tip and the fork point with the main chain. Zero for the active chain tip.
+
+- `status` - (string) The status of the chain tip. One of:
+  - `"active"` — This is the tip of the active best chain, which is certainly valid.
+  - `"valid-headers"` — The headers for this branch are valid, but the full blocks have not been validated. In Floresta, this is the only status used for fork tips (see Notes).
+
+### Error Enum
+
+- `JsonRpcError::Chain` — If there is an error accessing chain state data.
+- `JsonRpcError::BlockNotFound` — If a tip's block header could not be found while computing branch length.
+
+## Notes
+
+- **Incompatibility with Bitcoin Core**: Floresta's `getchaintips` uses the same JSON response shape as Bitcoin Core, but the `status` field is limited to two values: `"active"` and `"valid-headers"`. The following Bitcoin Core statuses are never returned by Floresta:
+  - `"valid-fork"` — Floresta never fully validates fork blocks (only the active chain's blocks are validated), so this status cannot be determined.
+  - `"headers-only"` — Floresta does not track this status option because headers only is yet the default behavior.
+  - `"invalid"` — Floresta does not persist metadata about branches containing invalid blocks yet.
+- `branchlen` is computed by walking back through fork tip headers until reaching a block that belongs to the main chain.
+- **Fork tip retention**: Floresta prunes alternative tips that fall too far behind or have too little work compared to the active chain. As a result, `getchaintips` may return fewer fork tips than Bitcoin Core, which retains all known tips in its block index.

--- a/tests/floresta-cli/getchaintips.py
+++ b/tests/floresta-cli/getchaintips.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+floresta_cli_getchaintips.py
+
+Functional tests for `getchaintips`. Verifies the RPC returns correct chain tip
+information for both a single-tip chain and after a chain reorganization that
+produces multiple tips.
+
+The genesis and single-tip tests share a single set of class-scoped nodes.
+The reorg test uses its own function-scoped two-node network so that reorg
+synchronisation is reliable (matching the proven pattern in reorg_chain.py).
+"""
+
+import pytest
+from test_framework.constants import GENESIS_BLOCK_HASH
+
+# pylint: disable=redefined-outer-name
+
+MINE_BLOCKS = 10
+
+
+def assert_active_tip(tip, expected_height, expected_hash):
+    """Assert a tip entry has active status with the expected height and hash."""
+    assert tip["status"] == "active"
+    assert tip["branchlen"] == 0
+    assert tip["height"] == expected_height
+    assert tip["hash"] == expected_hash
+
+
+@pytest.fixture(scope="class")
+def setup_nodes(
+    shared_setup_logging,
+    shared_florestad_bitcoind_utreexod_with_chain,
+):
+    """Set up logging and the three-node network synced to MINE_BLOCKS blocks."""
+    return shared_setup_logging, shared_florestad_bitcoind_utreexod_with_chain(
+        MINE_BLOCKS
+    )
+
+
+@pytest.mark.rpc
+class TestGetChainTips:
+    """Tests for the getchaintips RPC command."""
+
+    def test_at_genesis(self, shared_florestad_node):
+        """
+        At genesis (no blocks mined), getchaintips should return a single
+        active tip at height 0 with the genesis block hash.
+        """
+        tips = shared_florestad_node.rpc.get_chain_tips()
+
+        assert isinstance(tips, list)
+        assert len(tips) == 1
+        assert_active_tip(tips[0], 0, GENESIS_BLOCK_HASH)
+
+    def test_single_tip(self, setup_nodes):
+        """
+        After mining blocks on a single chain (no forks), getchaintips should
+        return exactly one tip with status "active" and branchlen 0.
+        """
+        _log, (florestad, _bitcoind, _utreexod) = setup_nodes
+
+        tips = florestad.rpc.get_chain_tips()
+
+        assert isinstance(tips, list)
+        assert len(tips) == 1
+        assert_active_tip(
+            tips[0],
+            florestad.rpc.get_block_count(),
+            florestad.rpc.get_bestblockhash(),
+        )
+
+
+@pytest.mark.rpc
+def test_getchaintips_after_reorg(setup_logging, florestad_utreexod, node_manager):
+    """
+    Trigger a chain reorganization and verify that getchaintips reports
+    multiple tips: the active tip and at least one fork tip with
+    status "valid-headers" and branchlen > 0.
+    """
+    log = setup_logging
+    florestad, utreexod = florestad_utreexod
+
+    # Mine initial blocks and wait for sync
+    utreexod.rpc.generate(MINE_BLOCKS)
+    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
+
+    old_best = florestad.rpc.get_bestblockhash()
+
+    # Invalidate a block to create a fork point
+    count_invalid = 5
+    height_invalid = utreexod.rpc.get_block_count() - count_invalid
+    log.info(f"Invalidating block at height {height_invalid}")
+    utreexod.rpc.invalidate_block(utreexod.rpc.get_blockhash(height_invalid))
+
+    # Mine a longer alternative chain to trigger reorg
+    new_blocks = count_invalid + 5
+    log.info(f"Mining {new_blocks} blocks on the alternative chain")
+    utreexod.rpc.generate(new_blocks)
+    node_manager.wait_for_sync_nodes(is_finished_ibd=False)
+
+    # The best block should have changed
+    assert florestad.rpc.get_bestblockhash() != old_best
+
+    tips = florestad.rpc.get_chain_tips()
+    assert isinstance(tips, list)
+    assert len(tips) >= 2
+
+    # Exactly one tip should be active
+    active_tips = [t for t in tips if t["status"] == "active"]
+    assert len(active_tips) == 1
+    assert_active_tip(
+        active_tips[0],
+        active_tips[0]["height"],
+        florestad.rpc.get_bestblockhash(),
+    )
+    assert active_tips[0]["hash"] == utreexod.rpc.get_bestblockhash()
+
+    # At least one fork tip should exist with valid-headers status
+    fork_tips = [t for t in tips if t["status"] == "valid-headers"]
+    assert len(fork_tips) >= 1
+
+    for fork_tip in fork_tips:
+        assert fork_tip["branchlen"] > 0
+        assert fork_tip["height"] > 0

--- a/tests/test_framework/constants.py
+++ b/tests/test_framework/constants.py
@@ -50,6 +50,7 @@ NO_PARAM_METHODS = [
     "getbestblockhash",
     "getblockchaininfo",
     "getblockcount",
+    "getchaintips",
     "getroots",
     "getrpcinfo",
     "uptime",

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -423,6 +423,12 @@ class BaseRPC(ABC):
         """
         return self.perform_request("getaddrmaninfo")
 
+    def get_chain_tips(self) -> list:
+        """
+        Get information about all known tips in the block tree
+        """
+        return self.perform_request("getchaintips")
+
     def get_raw_transaction(self, txid: str, verbose: int | None = None):
         """
         Returns the raw transaction data for a given transaction ID.


### PR DESCRIPTION
### Description and Notes

This pr just exposes the current information that we have about our internal tips to the rpc layer.

This unblocks some monitoring tools to run on top even if the data is not precise and incapable of comparisons against bitcoin core... By the other side, this bring us another point of useful data extraction and already set tests and wiring thatll help when we start working on making the internal chain view (block status definition) to be core compliant.

### How to verify the changes you have done?

Read the docs and the tests, every incompatibility with core should be documented so we have precise points to work on.