### PR TITLE
fix: replace yanked spin 0.10.0 with 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rustreexo = { version = "=0.6.0" }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = { version = "=1.0.150" }
 sha2 = { version = "=0.10.9", default-features = false }
-spin = { version = "=0.10.0", default-features = false, features = ["spin_mutex", "rwlock"] }
+spin = { version = "=0.10.1", default-features = false, features = ["spin_mutex", "rwlock"] }
 tempfile = { version = "=3.27.0" }
 tokio = { version = "=1.52.3", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["ring", "tls12"] }


### PR DESCRIPTION
### Description and Notes

spin 0.10.0 was yanked from crates.io. 0.10.1 is API-identical — only metadata was updated.
https://github.com/getfloresta/Floresta/issues/1208

### How to verify the changes you have done?
rm Cargo.lock && cargo check   # was broken, now passes
cargo test --workspace          # no regressions

### Contributor Checklist


- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

rm Cargo.lock && cargo check   # was broken, now passes
cargo test --workspace          # no regressions
