### PR TITLE
feat(rpc) add Core-style getpeerinfo service fields

### DIFF
--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -34,8 +34,11 @@ pub struct PeerInfo {
     pub id: u32,
     /// The network address for this peer.
     pub address: String,
-    /// A string with the services this peer advertises. E.g. NODE_NETWORK, UTREEXO, WITNESS...
+    /// Hex-encoded bitfield with the services this peer advertises.
     pub services: String,
+    /// Human-readable names for the recognized services this peer advertises.
+    #[serde(rename = "servicesnames")]
+    pub services_names: Vec<String>,
     /// User agent is a string that represents the client being used by our peer. E.g.
     /// /Satoshi-26.0/ for bitcoin core version 26
     pub user_agent: String,

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -10,6 +10,7 @@ use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::message_blockdata::Inventory;
 use floresta_chain::ChainBackend;
 use floresta_common::service_flags;
+use floresta_common::service_flags_strings;
 use floresta_common::try_and_log;
 use rand::distr::Distribution;
 use rand::distr::weighted::WeightedIndex;
@@ -865,7 +866,8 @@ where
         Some(PeerInfo {
             id: *peer_id,
             address: peer.address.as_bitcoin_socket_addr().clone(),
-            services: peer.services,
+            services: format!("{:016x}", peer.services.to_u64()),
+            services_names: service_flags_strings(&peer.services),
             user_agent: peer.user_agent.clone(),
             initial_height: peer.height,
             state: peer.state,

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -21,7 +21,6 @@ use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
 use bitcoin::Txid;
-use bitcoin::p2p::ServiceFlags;
 use bitcoin::p2p::message_filter::CFHeaders;
 use floresta_domain::mempool::MempoolError;
 use serde::Serialize;
@@ -43,8 +42,9 @@ pub struct PeerInfo {
     pub id: u32,
     #[serde(serialize_with = "serialize_addr")]
     pub address: BitcoinSocketAddr,
-    #[serde(serialize_with = "serialize_service_flags")]
-    pub services: ServiceFlags,
+    pub services: String,
+    #[serde(rename = "servicesnames")]
+    pub services_names: Vec<String>,
     pub user_agent: String,
     pub initial_height: u32,
     pub state: PeerStatus,
@@ -177,11 +177,4 @@ where
     S: serde::Serializer,
 {
     serializer.serialize_str(&local_addr.to_string())
-}
-
-fn serialize_service_flags<S>(flags: &ServiceFlags, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&flags.to_string())
 }

--- a/doc/rpc/getpeerinfo.md
+++ b/doc/rpc/getpeerinfo.md
@@ -29,7 +29,8 @@ Returns a JSON array of objects, each representing a connected peer with the fol
 
 - `id` - (numeric) This peer's unique identifier in the node's peer manager. This is useful for commands like `disconnectnode` which can target a peer by its ID.
 - `address` - (string) The network address and port for this peer (e.g., "192.168.1.5:8333"). This helps identify where the connection is established.
-- `services` - (string) A string listing the services this peer advertises (e.g., NODE_NETWORK, UTREEXO, WITNESS). This indicates what capabilities the peer supports and what data we can request from them.
+- `services` - (string) A 16-character hexadecimal bitfield with the services this peer advertises (e.g., "0000000000000c09"). This indicates what capabilities the peer supports and what data we can request from them.
+- `servicesnames` - (array of strings) Human-readable names for the recognized services this peer advertises (e.g., "NETWORK", "WITNESS", "P2P_V2"). Unknown service bits are still represented in `services`.
 - `user_agent` - (string) The User Agent string representing the client software and version being used by the peer (e.g., `/Satoshi-26.0/`). Useful for identifying the software distribution on the network.
 - `initial_height` - (numeric) The block height this peer reported when the connection was first established. This may differ from the current chain tip if the peer has not announced new blocks since connecting.
 - `kind` - (string) The connection type of this peer. Possible values are "feeler" (short-lived connections to test address validity), "regular" (standard persistent P2P connection), "extra", or "manual".

--- a/tests/floresta-cli/getpeerinfo.py
+++ b/tests/floresta-cli/getpeerinfo.py
@@ -7,10 +7,11 @@ This functional test cli utility to interact with a Floresta node with `getpeeri
 """
 
 import pytest
+from test_framework.util import assert_bitcoind_service_fields
 
 
 @pytest.mark.rpc
-def test_peer_info(florestad_node):
+def test_peer_info(florestad_node, bitcoind_node, node_manager):
     """
     Test `getpeerinfo` with a fresh node and its initial state.
     """
@@ -19,3 +20,12 @@ def test_peer_info(florestad_node):
 
     assert isinstance(result, list)
     assert len(result) == 0
+
+    node_manager.connect_nodes(florestad_node, bitcoind_node)
+
+    result = florestad_node.rpc.get_peerinfo()
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+    peer_info = result[0]
+    assert_bitcoind_service_fields(peer_info)

--- a/tests/florestad/node_info.py
+++ b/tests/florestad/node_info.py
@@ -6,6 +6,7 @@ Tests for node information exchanged between Floresta and other peers.
 
 import re
 import pytest
+from test_framework.util import assert_bitcoind_service_fields
 
 
 @pytest.mark.rpc
@@ -16,20 +17,19 @@ def test_node_info(florestad_bitcoind):
     """
     florestad, bitcoind = florestad_bitcoind
 
-    peer_info = bitcoind.rpc.get_peerinfo()
+    peers_seen_by_bitcoind = bitcoind.rpc.get_peerinfo()
 
-    assert len(peer_info) == 1
-    assert peer_info[0]["services"] == "0000000000001808"  # WITNESS | P2P_V2 | UTREEXO
-    assert peer_info[0]["version"] == 70016
-    assert re.match(r"\/Floresta:\d+\.\d+\.\d+.*\/", peer_info[0]["subver"])
-    assert peer_info[0]["inbound"] is True
+    assert len(peers_seen_by_bitcoind) == 1
+    floresta_peer = peers_seen_by_bitcoind[0]
+    assert floresta_peer["services"] == "0000000000001808"  # WITNESS | P2P_V2 | UTREEXO
+    assert floresta_peer["version"] == 70016
+    assert re.match(r"\/Floresta:\d+\.\d+\.\d+.*\/", floresta_peer["subver"])
+    assert floresta_peer["inbound"] is True
 
-    peer_info = florestad.rpc.get_peerinfo()
-    assert peer_info[0]["address"] == bitcoind.p2p_url
-    assert peer_info[0]["kind"] == "manual"
-    assert (
-        peer_info[0]["services"]
-        == "ServiceFlags(NETWORK|WITNESS|NETWORK_LIMITED|P2P_V2)"
-    )
-    assert peer_info[0]["transport_protocol"] == "V2"
-    assert re.match(r"\/Satoshi:\d*\.\d*\.\d*\/", peer_info[0]["user_agent"])
+    peers_seen_by_floresta = florestad.rpc.get_peerinfo()
+    bitcoind_peer = peers_seen_by_floresta[0]
+    assert bitcoind_peer["address"] == bitcoind.p2p_url
+    assert bitcoind_peer["kind"] == "manual"
+    assert_bitcoind_service_fields(bitcoind_peer)
+    assert bitcoind_peer["transport_protocol"] == "V2"
+    assert re.match(r"\/Satoshi:\d*\.\d*\.\d*\/", bitcoind_peer["user_agent"])

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -15,6 +15,26 @@ from test_framework.crypto.pkcs8 import (
     create_pkcs8_self_signed_certificate,
 )
 
+SERVICE_FLAGS_BY_NAME = {
+    "NETWORK": 1 << 0,
+    "GETUTXO": 1 << 1,
+    "BLOOM": 1 << 2,
+    "WITNESS": 1 << 3,
+    "COMPACT_FILTERS": 1 << 6,
+    "NETWORK_LIMITED": 1 << 10,
+    "P2P_V2": 1 << 11,
+    "UTREEXO": 1 << 12,
+    "UTREEXO_ARCHIVE": 1 << 13,
+}
+
+BITCOIND_TEST_FRAMEWORK_SERVICES = "0000000000000c09"
+BITCOIND_TEST_FRAMEWORK_SERVICESNAMES = {
+    "NETWORK",
+    "WITNESS",
+    "NETWORK_LIMITED",
+    "P2P_V2",
+}
+
 
 class Utility:
     """
@@ -135,6 +155,35 @@ def wait_until(predicate, timeout=30, interval=0.5, error_msg="Condition not met
         time.sleep(interval)
 
     raise TimeoutError(f"{error_msg} after {timeout} seconds")
+
+
+def assert_service_fields_consistent(peer_info):
+    """
+    Assert that getpeerinfo's services and servicesnames describe the same flags.
+    """
+    services = peer_info["services"]
+    assert isinstance(services, str)
+    assert len(services) == 16
+    services_bits = int(services, 16)
+
+    services_names = peer_info["servicesnames"]
+    assert isinstance(services_names, list)
+    assert all(isinstance(name, str) for name in services_names)
+
+    services_names = set(services_names)
+    assert services_names <= set(SERVICE_FLAGS_BY_NAME)
+
+    for name, flag in SERVICE_FLAGS_BY_NAME.items():
+        assert bool(services_bits & flag) == (name in services_names), name
+
+
+def assert_bitcoind_service_fields(peer_info):
+    """
+    Assert getpeerinfo service fields for the Bitcoin Core test framework node.
+    """
+    assert_service_fields_consistent(peer_info)
+    assert peer_info["services"] == BITCOIND_TEST_FRAMEWORK_SERVICES
+    assert set(peer_info["servicesnames"]) == BITCOIND_TEST_FRAMEWORK_SERVICESNAMES
 
 
 def compare_fields(candidate, reference, ignore_fields=None, float_tol=1e-8):


### PR DESCRIPTION
### Description and Notes

Adds Bitcoin Core-style service fields to `getpeerinfo`.

This PR:
- formats `services` as a 16-character hex bitfield;
- adds `servicesnames` for recognized service flags;
- reuses the existing `service_flags_strings` helper;
- keeps server serialization and client deserialization aligned;
- updates the `getpeerinfo` RPC documentation.

This addresses the `services` / `servicesnames` portion of #622.

This intentionally does not rename other `getpeerinfo` fields such as `address`, `user_agent`, `initial_height`, `kind`, or `transport_protocol`. Those can be handled in follow-up PRs for full Bitcoin Core schema parity.

Note: this overlaps with #1161 in `getpeerinfo` tests/docs, but the changes are independent. If #1161 lands first, this branch can be rebased and the small conflict resolved there.

### How to verify the changes you have done?

Confirmed CI passed on my fork: https://github.com/octaviolucca/Floresta/pull/2

Locally ran the targeted checks below, after preparing the functional test environment:

```bash
cargo fmt --all -- --check
cargo check -p floresta-wire -p floresta-rpc
cargo test -p floresta-wire -p floresta-rpc --lib
cargo +nightly clippy -p floresta-wire -p floresta-rpc --all-targets -- -D warnings
just test-functional-run "tests/floresta-cli/getpeerinfo.py tests/florestad/node_info.py"
```
Also manually checked `getpeerinfo` against a running Floresta node with connected peers.