### PR TITLE
chore(consensus): use same param defaults as Core

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -375,10 +375,10 @@ impl From<Network> for ChainParams {
                 params: Params::new(network),
                 network,
                 genesis,
-                pow_target_timespan: 14 * 24 * 60 * 60, // two weeks
+                pow_target_timespan: 24 * 60 * 60, // one day
                 subsidy_halving_interval: SubsidyHalvingInterval::Regtest,
                 coinbase_maturity: 100,
-                csv_activation_height: 0,
+                csv_activation_height: 1,
                 segwit_activation_height: 0,
                 exceptions,
                 enforce_bip94: false,


### PR DESCRIPTION
### Description and Notes

Our `ChainParams` values for `Regtest` are deviating from Bitcoin Core in two cases:

- `csv_activation_height` should be 1, not 0 (https://github.com/bitcoin/bitcoin/blob/v31.0/src/kernel/chainparams.cpp#L572).
- `pow_target_timespan` should be one day, not two weeks (https://github.com/bitcoin/bitcoin/blob/v31.0/src/kernel/chainparams.cpp#L576).

### How to verify the changes you have done?

Click the two links above.