### PR TITLE
bump hashbrown 0.17.0 -> 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ name = "floresta-common"
 version = "0.5.0"
 dependencies = [
  "bitcoin",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "sha2",
  "spin",
  "tracing",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1719,7 +1719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1908,7 +1908,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ hex = { version = "=0.4.3" }
 kv = { version = "=0.24.0" }
 miniscript = { version = "=13.0.0", default-features = false }
 rand = { version = "=0.10.1" }
-rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "pem"] }
+rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "pem"] } # note: >0.14.7 requires Rust 1.86.0
 rustreexo = { version = "=0.6.0" }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = { version = "=1.0.150" }

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true # Floresta/README.md
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
-hashbrown = { version = "=0.17.0" }
+hashbrown = { version = "=0.17.1" }
 sha2 = { workspace = true }
 spin = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
Overwrite #1202.

Updates the dependencies from the original Dependabot PR while preserving compatibility with the project's current MSRV (Rust 1.85.0). The updates for `criterion`, `tonic`, `tonic-prost`, and `rcgen` were intentionally omitted because they require a newer Rust version.

Updating `bitcoin` to `0.32.9` causes issues when deserializing P2P messages, preventing the node from synchronizing with other peers.

Bumps the all group with 6 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [hashbrown](https://github.com/rust-lang/hashbrown) | `0.17.0` | `0.17.1` |




Updates `hashbrown` from 0.17.0 to 0.17.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/rust-lang/hashbrown/releases">hashbrown's releases</a>.</em></p>
<blockquote>
<h2>v0.17.1</h2>
<h3>Added</h3>
<ul>
<li>Added <code>HashMap::rustc_try_insert</code> (<a href="https://redirect.github.com/rust-lang/hashbrown/issues/722">#722</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rust-lang/hashbrown/blob/main/CHANGELOG.md">hashbrown's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/rust-lang/hashbrown/compare/v0.17.0...v0.17.1">0.17.1</a> - 2026-04-20</h2>
<h3>Added</h3>
<ul>
<li>Added <code>HashMap::rustc_try_insert</code> (<a href="https://redirect.github.com/rust-lang/hashbrown/issues/722">#722</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-lang/hashbrown/commit/c62a63a61b7caf2de8f9ecb7b06a66b0ab6bdf3d"><code>c62a63a</code></a> chore: release v0.17.1</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/420e83ba586255328ed3279479e7388ab32a1b79"><code>420e83b</code></a> Merge pull request <a href="https://redirect.github.com/rust-lang/hashbrown/issues/722">#722</a> from cuviper/rustc_try_insert</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/51cecbdbf459737db65c6906db9c00d49fbf07ef"><code>51cecbd</code></a> Move the <code>RustcOccupiedError</code> note as requested in review</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/16d0f371630f29c3972dcc9cfac31c8dee3c7231"><code>16d0f37</code></a> Add <code>HashMap::rustc_try_insert</code></li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/18a04c52f30bbb491bc24c63975cc55c605a61fc"><code>18a04c5</code></a> Merge pull request <a href="https://redirect.github.com/rust-lang/hashbrown/issues/721">#721</a> from clarfonthey/branch-rename</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/ee8a0ee1276991e0f4dcaf4d9ed52ae3616663b6"><code>ee8a0ee</code></a> Rename master to main in release-plz workflow</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/147df6521d48a6d4a816b62962d5d387610c1d34"><code>147df65</code></a> Merge pull request <a href="https://redirect.github.com/rust-lang/hashbrown/issues/720">#720</a> from xtqqczze/authors</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/64a0acbbba976e7ae2f9bf54a13e0cf6b2d65c58"><code>64a0acb</code></a> Remove package.authors field from Cargo metadata</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/867db72c99f0d4397bdd2c70b3eb2643c19e20d7"><code>867db72</code></a> Merge pull request <a href="https://redirect.github.com/rust-lang/hashbrown/issues/716">#716</a> from atouchet/rdm</li>
<li><a href="https://github.com/rust-lang/hashbrown/commit/57b760ba0cb05ccd3ad6f538671dd8afa2c861fb"><code>57b760b</code></a> Update Readme</li>
<li>Additional commits viewable in <a href="https://github.com/rust-lang/hashbrown/compare/v0.17.0...v0.17.1">compare view</a></li>
</ul>
</details>
<br />
