### PR TITLE
fix(wire): keep IBD active when validation catches up to a stale tip

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 use bitcoin::Network;
 use floresta_chain::AssumeUtreexoValue;
 
+use self::node::sync_ctx::DEFAULT_MAX_TIP_AGE;
+
 #[derive(Debug, Clone)]
 /// Configuration for the Utreexo node.
 pub struct UtreexoNodeConfig {
@@ -66,6 +68,11 @@ pub struct UtreexoNodeConfig {
     pub allow_v1_fallback: bool,
     /// Whether to disable DNS seeds. Defaults to false.
     pub disable_dns_seeds: bool,
+    /// Maximum age in seconds that the best-block timestamp may have before
+    /// the node considers the tip stale and refuses to exit IBD. Defaults to
+    /// `DEFAULT_MAX_TIP_AGE` (24 hours). Set to `u32::MAX` to disable the
+    /// check (e.g. in tests with historical block fixtures).
+    pub max_tip_age_secs: u32,
 }
 
 impl Default for UtreexoNodeConfig {
@@ -84,6 +91,7 @@ impl Default for UtreexoNodeConfig {
             filter_start_height: None,
             user_agent: format!("floresta:{}", env!("CARGO_PKG_VERSION")),
             allow_v1_fallback: true,
+            max_tip_age_secs: DEFAULT_MAX_TIP_AGE,
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
@@ -4,6 +4,8 @@
 
 use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bitcoin::p2p::ServiceFlags;
 use floresta_chain::ThreadSafeChain;
@@ -15,6 +17,7 @@ use tokio::time;
 use tokio::time::MissedTickBehavior;
 use tracing::debug;
 use tracing::info;
+use tracing::warn;
 
 use crate::node::ConnectionKind;
 use crate::node::InflightRequests;
@@ -25,6 +28,12 @@ use crate::node_context::LoopControl;
 use crate::node_context::NodeContext;
 use crate::p2p_wire::error::WireError;
 use crate::p2p_wire::peer::PeerMessages;
+
+/// Mirrors Bitcoin Core's [`DEFAULT_MAX_TIP_AGE`]: the maximum age in seconds a
+/// tip may have before the node refuses to leave IBD.
+///
+/// [`DEFAULT_MAX_TIP_AGE`]: https://github.com/bitcoin/bitcoin/blob/master/src/kernel/chainstatemanager_opts.h#L24
+pub(crate) const DEFAULT_MAX_TIP_AGE: u32 = 24 * 60 * 60;
 
 /// [`SyncNode`] is a node that downloads and validates the blockchain.
 /// This node implements:
@@ -235,16 +244,53 @@ where
             .get_validation_index()
             .expect("validation index block should present");
 
-        let best_block = self
+        let (best_block, tip_hash) = self
             .chain
             .get_best_block()
-            .expect("best block should present")
-            .0;
+            .expect("best block is always present");
 
+        // Bitcoin Core's `UpdateIBDStatus` gates the IBD exit on two conditions:
+        // cumulative chain work >= `MinimumChainWork`, and tip age <= `max_tip_age`.
+        // Floresta's ChainStore does not track cumulative chain work today, so
+        // only the age gate is implemented here. The age check is a proxy: a tip
+        // older than max_tip_age_secs is treated as stale regardless of cause
+        // (stuck store, old snapshot, low-activity chain). This matches Core's
+        // steady-state behavior — a genuinely old tip stays in IBD there too.
+        // TODO(@micah): Implement MinimumChainWork checks
         if validation_index == best_block {
-            info!("IBD is finished, switching to normal operation mode");
-            self.chain.update_ibd(IBDState::Done);
-            return LoopControl::Break;
+            // Skip the age check at genesis: the genesis timestamp (~2009) always
+            // looks stale and would trap a genesis-only node in IBD indefinitely.
+            // This is especially important for regtest, where nodes commonly start
+            // at or near genesis.
+            if best_block == 0 {
+                info!("IBD is finished, switching to normal operation mode");
+                self.chain.update_ibd(IBDState::Done);
+                return LoopControl::Break;
+            }
+
+            let tip_time = self
+                .chain
+                .get_block_header(&tip_hash)
+                .expect("tip header is always present")
+                .time;
+            let now: u32 = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after UNIX_EPOCH")
+                .as_secs()
+                .try_into()
+                .unwrap_or(u32::MAX);
+            let tip_age = now.saturating_sub(tip_time);
+
+            if tip_age > self.config.max_tip_age_secs {
+                warn!(
+                    tip_age,
+                    "validation caught up to a stale tip; chain store may be stuck, staying in IBD"
+                );
+            } else {
+                info!("IBD is finished, switching to normal operation mode");
+                self.chain.update_ibd(IBDState::Done);
+                return LoopControl::Break;
+            }
         }
 
         periodic_job!(

--- a/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
@@ -10,10 +10,16 @@ mod tests {
     use crate::p2p_wire::tests::utils::PeerData;
     use crate::p2p_wire::tests::utils::mutated_block_h7;
     use crate::p2p_wire::tests::utils::setup_node;
+    use crate::p2p_wire::tests::utils::setup_node_with_tip_age;
     use crate::p2p_wire::tests::utils::signet_blocks;
     use crate::p2p_wire::tests::utils::signet_headers;
 
     const NUM_BLOCKS: usize = 9;
+    /// `max_tip_age_secs = 0`: every tip timestamp predates "now", so the guard always fires.
+    const TIP_AGE_ALWAYS_STALE: u32 = 0;
+
+    /// `max_tip_age_secs = u32::MAX`: no timestamp can exceed this, so the guard never fires.
+    const TIP_AGE_NEVER_STALE: u32 = u32::MAX;
 
     #[tokio::test]
     async fn test_sync_valid_blocks() {
@@ -47,6 +53,58 @@ mod tests {
         // We were able to find the original block and sync
         assert_eq!(chain.get_validation_index().unwrap(), 9);
         assert_eq!(chain.get_best_block().unwrap().1, headers[9].block_hash());
+        assert!(!chain.is_in_ibd());
+    }
+
+    // When validation catches up to a stale tip the node
+    // must stay in IBD rather than falsely reporting initialblockdownload=false.
+    #[tokio::test]
+    async fn test_ibd_stays_active_on_stale_tip() {
+        let datadir = format!("./tmp-db/{}.sync_node_stale", rand::random::<u32>());
+        let blocks = signet_blocks();
+
+        // TIP_AGE_ALWAYS_STALE: every block timestamp is considered stale.
+        let peer = vec![PeerData::new(Vec::new(), blocks, HashMap::new())];
+        let chain = setup_node_with_tip_age(
+            peer,
+            false,
+            Network::Signet,
+            &datadir,
+            NUM_BLOCKS,
+            TIP_AGE_ALWAYS_STALE,
+        )
+        .await;
+
+        // Confirm validation caught up fully -- only then does is_in_ibd() prove
+        // the stale guard fired rather than the timeout simply expiring mid-sync.
+        assert_eq!(chain.get_validation_index().unwrap(), NUM_BLOCKS as u32);
+        assert_eq!(chain.get_best_block().unwrap().0, NUM_BLOCKS as u32);
+        assert!(chain.is_in_ibd());
+    }
+
+    #[tokio::test]
+    async fn test_ibd_completes_on_fresh_tip() {
+        let datadir = format!("./tmp-db/{}.sync_node_fresh", rand::random::<u32>());
+        let headers = signet_headers();
+        let blocks = signet_blocks();
+
+        // TIP_AGE_NEVER_STALE: no tip is ever considered stale.
+        let peer = vec![PeerData::new(Vec::new(), blocks, HashMap::new())];
+        let chain = setup_node_with_tip_age(
+            peer,
+            false,
+            Network::Signet,
+            &datadir,
+            NUM_BLOCKS,
+            TIP_AGE_NEVER_STALE,
+        )
+        .await;
+
+        assert_eq!(chain.get_validation_index().unwrap(), NUM_BLOCKS as u32);
+        assert_eq!(
+            chain.get_best_block().unwrap().1,
+            headers[NUM_BLOCKS].block_hash()
+        );
         assert!(!chain.is_in_ibd());
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -53,6 +53,9 @@ use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
 use crate::p2p_wire::transport::TransportProtocol;
 
+/// Timeout for node helpers -- long enough to sync signet fixture blocks under CI load.
+const NODE_SYNC_TIMEOUT_SECS: u64 = 100;
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct UtreexoRoots {
     roots: Option<Vec<String>>,
@@ -198,6 +201,8 @@ pub fn get_node_config(
         pow_fraud_proofs,
         datadir: datadir.as_ref().into(),
         user_agent: "node_test".to_string(),
+        // Fixture blocks are historical; disable the stale-tip guard.
+        max_tip_age_secs: u32::MAX,
         ..Default::default()
     }
 }
@@ -292,19 +297,23 @@ pub struct PeerData {
     accs: HashMap<BlockHash, Vec<u8>>,
 }
 
-pub async fn setup_node(
+type SyncTestNode = UtreexoNode<Arc<ChainState<FlatChainStore>>, SyncNode>;
+
+/// Builds a chain and a fully-wired [`UtreexoNode`] ready to run, without starting it.
+///
+/// Both [`setup_node`] and [`setup_node_with_tip_age`] delegate here; they differ only
+/// in how they handle the run timeout.
+fn build_node(
     peers: Vec<PeerData>,
     pow_fraud_proofs: bool,
     network: Network,
     datadir: impl AsRef<Path>,
     num_blocks: usize,
-) -> Arc<ChainState<FlatChainStore>> {
-    let config = FlatChainStoreConfig::new(&datadir);
-
-    let chainstore = FlatChainStore::new(config).unwrap();
+    max_tip_age_secs: u32,
+) -> (Arc<ChainState<FlatChainStore>>, SyncTestNode) {
+    let chainstore = FlatChainStore::new(FlatChainStoreConfig::new(&datadir)).unwrap();
     let mempool = Arc::new(Mutex::new(Mempool::new(1000)));
-    let chain = ChainState::open(chainstore, network, AssumeValidArg::Disabled).unwrap();
-    let chain = Arc::new(chain);
+    let chain = Arc::new(ChainState::open(chainstore, network, AssumeValidArg::Disabled).unwrap());
 
     let mut headers = signet_headers();
     headers.remove(0);
@@ -313,14 +322,15 @@ pub async fn setup_node(
         chain.accept_header(header).unwrap();
     }
 
-    let config = get_node_config(&datadir, network, pow_fraud_proofs);
+    let mut config = get_node_config(&datadir, network, pow_fraud_proofs);
+    config.max_tip_age_secs = max_tip_age_secs;
     let kill_signal = Arc::new(RwLock::new(false));
     let mut node = UtreexoNode::<Arc<ChainState<FlatChainStore>>, SyncNode>::new(
         config,
         chain.clone(),
         mempool,
         None,
-        kill_signal.clone(),
+        kill_signal,
         AddressMan::new(None, &[]),
     )
     .unwrap();
@@ -334,18 +344,16 @@ pub async fn setup_node(
             peer.blocks,
             peer.accs,
             node.node_tx.clone(),
-            sender.clone(),
+            sender,
             receiver,
             peer_id,
         );
 
-        // Add a fixed peer to avoid opening real P2P connections
         if i == 0 {
             node.fixed_peers = vec![peer.address.clone()];
         }
 
         node.peers.insert(peer_id, peer);
-        // Populate the peer services too
         for service in [
             service_flags::UTREEXO.into(),
             ServiceFlags::COMPACT_FILTERS,
@@ -357,17 +365,65 @@ pub async fn setup_node(
                 .push(peer_id);
         }
 
-        // This allows the node to properly assign a message time for the peer
         node.inflight.insert(
             InflightRequests::Connect(peer_id),
             (peer_id, Instant::now()),
         );
     }
 
-    timeout(Duration::from_secs(100), node.run(|_| {}))
-        .await
-        .unwrap();
+    (chain, node)
+}
 
+pub async fn setup_node(
+    peers: Vec<PeerData>,
+    pow_fraud_proofs: bool,
+    network: Network,
+    datadir: impl AsRef<Path>,
+    num_blocks: usize,
+) -> Arc<ChainState<FlatChainStore>> {
+    let (chain, node) = build_node(
+        peers,
+        pow_fraud_proofs,
+        network,
+        datadir,
+        num_blocks,
+        u32::MAX,
+    );
+    timeout(
+        Duration::from_secs(NODE_SYNC_TIMEOUT_SECS),
+        node.run(|_| {}),
+    )
+    .await
+    .unwrap();
+    chain
+}
+
+/// Like [`setup_node`] but with a configurable `max_tip_age_secs`.
+///
+/// Does not panic on timeout. When the stale-tip guard is active the node
+/// completes validation but never exits IBD, so the run lasts until the
+/// timeout ceiling.
+pub async fn setup_node_with_tip_age(
+    peers: Vec<PeerData>,
+    pow_fraud_proofs: bool,
+    network: Network,
+    datadir: impl AsRef<Path>,
+    num_blocks: usize,
+    max_tip_age_secs: u32,
+) -> Arc<ChainState<FlatChainStore>> {
+    let (chain, node) = build_node(
+        peers,
+        pow_fraud_proofs,
+        network,
+        datadir,
+        num_blocks,
+        max_tip_age_secs,
+    );
+    let _ = timeout(
+        Duration::from_secs(NODE_SYNC_TIMEOUT_SECS),
+        node.run(|_| {}),
+    )
+    .await;
     chain
 }
 


### PR DESCRIPTION
## What's happening

When the chain store stops accepting writes (e.g. `FlatChainstoreError::FullIndex` on a filesystem that can't grow the index file), `best_block` height freezes. The validation worker eventually catches up to that frozen height, satisfying
`validation_index == best_block`, and the node exits IBD, reporting `initialblockdownload=false` to every caller of `getblockchaininfo` even though it's stuck far below the real chain tip.

## Fix

Before flipping `IBDState::Done`, check the tip timestamp against the wall clock. If the tip is older than `DEFAULT_MAX_TIP_AGE` (24 hours), stay in IBD and log the tip age at `DEBUG`. The threshold is exposed as `max_tip_age_secs` . When the check fires the node falls through to maintenance so block requests and peer connections keep running.

Bitcoin Core's `UpdateIBDStatus` also gates the IBD exit on cumulative chain work >= `MinimumChainWork`. Floresta's `ChainStore` does not track cumulative chain work today; that gate will be addressed in a follow-up.