### PR TITLE
feat(chain): implement block-based fee estimation

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1370,6 +1370,27 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
             .any(|subscriber| subscriber.wants_spent_utxos())
             .then(|| inputs.clone());
 
+        let avg_fee_rate = {
+            let mut total_fees: u64 = 0;
+            let mut total_weight: u64 = 0;
+            for tx in block.txdata.iter().skip(1) {
+                let total_in: u64 = tx
+                    .input
+                    .iter()
+                    .filter_map(|txin| inputs.get(&txin.previous_output))
+                    .map(|utxo| utxo.txout.value.to_sat())
+                    .sum();
+                let total_out: u64 = tx.output.iter().map(|txout| txout.value.to_sat()).sum();
+
+                total_fees += total_in.saturating_sub(total_out);
+                total_weight += tx.weight().to_wu();
+            }
+            total_fees
+                .checked_div(total_weight)
+                .map(|r| r * 4000)
+                .unwrap_or(0)
+        };
+
         self.validate_block_no_acc(block, height, inputs)?;
         let acc = Consensus::update_acc(&self.acc(), block, height, proof, del_hashes)?;
 
@@ -1390,6 +1411,20 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
 
         // Notify others we have a new block
         self.notify(block, height, inputs_for_notifications.as_ref());
+
+        let mut inner = write_lock!(self);
+        inner.chainstore.save_block_fee_rate(height, avg_fee_rate)?;
+        let rates: Vec<u64> = (height.saturating_sub(60)..=height)
+            .filter_map(|h| inner.chainstore.get_block_fee_rate(h).ok().flatten())
+            .collect();
+        if !rates.is_empty() {
+            inner.fee_estimation = (
+                median(&rates[rates.len().saturating_sub(6)..]),
+                median(&rates[rates.len().saturating_sub(30)..]),
+                median(rates.as_slice()),
+            )
+        }
+
         Ok(height)
     }
 
@@ -1523,7 +1558,19 @@ macro_rules! write_lock {
         $obj.inner.write()
     };
 }
-
+fn median(data: &[u64]) -> f64 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = data.to_vec();
+    sorted.sort();
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 0 {
+        (sorted[mid - 1] + sorted[mid]) as f64 / 2.0
+    } else {
+        sorted[mid] as f64
+    }
+}
 #[cfg(all(test, feature = "flat-chainstore"))]
 mod test {
     use std::format;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -24,11 +24,11 @@ use alloc::fmt::format;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use bitcoin::Amount;
 use core::cell::UnsafeCell;
 use core::cmp::min;
 use core::ops::Add;
 
+use bitcoin::Amount;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Network;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -24,6 +24,7 @@ use alloc::fmt::format;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use bitcoin::Amount;
 use core::cell::UnsafeCell;
 use core::cmp::min;
 use core::ops::Add;
@@ -70,6 +71,8 @@ use crate::pruned_utreexo::IBDState;
 use crate::pruned_utreexo::utxo_data::UtxoData;
 use crate::read_lock;
 use crate::write_lock;
+
+const SATS_PER_KILO_VBYTE: u64 = bitcoin::Weight::WITNESS_SCALE_FACTOR as u64 * 1000;
 
 /// Trait for components that need to receive notifications about new blocks.
 pub trait BlockConsumer: Sync + Send + 'static {
@@ -1002,7 +1005,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         block: &Block,
         height: u32,
         inputs: HashMap<OutPoint, UtxoData>,
-    ) -> Result<(), BlockchainError> {
+    ) -> Result<Vec<(Amount, Amount)>, BlockchainError> {
         read_lock!(self).consensus.check_block(block, height)?;
 
         // Validate block transactions
@@ -1022,8 +1025,21 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             subsidy,
             verify_script,
             flags,
-        )?;
-        Ok(())
+        )
+    }
+    fn compute_avg_fee_rate(tx_values: &[(Amount, Amount)], block: &Block) -> u64 {
+        let mut total_fees: u64 = 0;
+        let mut total_weight: u64 = 0;
+
+        for (tx, &(in_val, out_val)) in block.txdata.iter().skip(1).zip(tx_values.iter()) {
+            total_fees += in_val.to_sat().saturating_sub(out_val.to_sat());
+            total_weight += tx.weight().to_wu();
+        }
+
+        total_fees
+            .checked_div(total_weight)
+            .map(|r| r * SATS_PER_KILO_VBYTE)
+            .unwrap_or(0)
     }
 }
 
@@ -1096,6 +1112,7 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
             .try_height()?;
 
         self.validate_block_no_acc(block, height, inputs)
+            .map(|_| ())
     }
 
     fn get_block_locator_for_tip(&self, tip: BlockHash) -> Result<Vec<BlockHash>, BlockchainError> {
@@ -1370,28 +1387,9 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
             .any(|subscriber| subscriber.wants_spent_utxos())
             .then(|| inputs.clone());
 
-        let avg_fee_rate = {
-            let mut total_fees: u64 = 0;
-            let mut total_weight: u64 = 0;
-            for tx in block.txdata.iter().skip(1) {
-                let total_in: u64 = tx
-                    .input
-                    .iter()
-                    .filter_map(|txin| inputs.get(&txin.previous_output))
-                    .map(|utxo| utxo.txout.value.to_sat())
-                    .sum();
-                let total_out: u64 = tx.output.iter().map(|txout| txout.value.to_sat()).sum();
+        let tx_values = self.validate_block_no_acc(block, height, inputs)?;
+        let avg_fee_rate = Self::compute_avg_fee_rate(&tx_values, block);
 
-                total_fees += total_in.saturating_sub(total_out);
-                total_weight += tx.weight().to_wu();
-            }
-            total_fees
-                .checked_div(total_weight)
-                .map(|r| r * 4000)
-                .unwrap_or(0)
-        };
-
-        self.validate_block_no_acc(block, height, inputs)?;
         let acc = Consensus::update_acc(&self.acc(), block, height, proof, del_hashes)?;
 
         self.update_view(height, &block.header, acc)?;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1050,12 +1050,26 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             .collect();
         if !rates.is_empty() {
             inner.fee_estimation = (
-                median(&rates[rates.len().saturating_sub(6)..]),
-                median(&rates[rates.len().saturating_sub(30)..]),
-                median(rates.as_slice()),
+                Self::median(&rates[rates.len().saturating_sub(6)..]),
+                Self::median(&rates[rates.len().saturating_sub(30)..]),
+                Self::median(rates.as_slice()),
             );
         }
         Ok(())
+    }
+
+    fn median(data: &[u64]) -> f64 {
+        if data.is_empty() {
+            return 0.0;
+        }
+        let mut sorted = data.to_vec();
+        sorted.sort();
+        let mid = sorted.len() / 2;
+        if sorted.len() % 2 == 0 {
+            (sorted[mid - 1] + sorted[mid]) as f64 / 2.0
+        } else {
+            sorted[mid] as f64
+        }
     }
 }
 
@@ -1561,19 +1575,7 @@ macro_rules! write_lock {
         $obj.inner.write()
     };
 }
-fn median(data: &[u64]) -> f64 {
-    if data.is_empty() {
-        return 0.0;
-    }
-    let mut sorted = data.to_vec();
-    sorted.sort();
-    let mid = sorted.len() / 2;
-    if sorted.len() % 2 == 0 {
-        (sorted[mid - 1] + sorted[mid]) as f64 / 2.0
-    } else {
-        sorted[mid] as f64
-    }
-}
+
 #[cfg(all(test, feature = "flat-chainstore"))]
 mod test {
     use std::format;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1041,6 +1041,22 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             .map(|r| r * SATS_PER_KILO_VBYTE)
             .unwrap_or(0)
     }
+
+    fn update_fee_estimation(&self, height: u32, avg_fee_rate: u64) -> Result<(), BlockchainError> {
+        let mut inner = write_lock!(self);
+        inner.chainstore.save_block_fee_rate(height, avg_fee_rate)?;
+        let rates: Vec<u64> = (height.saturating_sub(60)..=height)
+            .filter_map(|h| inner.chainstore.get_block_fee_rate(h).ok().flatten())
+            .collect();
+        if !rates.is_empty() {
+            inner.fee_estimation = (
+                median(&rates[rates.len().saturating_sub(6)..]),
+                median(&rates[rates.len().saturating_sub(30)..]),
+                median(rates.as_slice()),
+            );
+        }
+        Ok(())
+    }
 }
 
 impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedState> {
@@ -1410,18 +1426,7 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
         // Notify others we have a new block
         self.notify(block, height, inputs_for_notifications.as_ref());
 
-        let mut inner = write_lock!(self);
-        inner.chainstore.save_block_fee_rate(height, avg_fee_rate)?;
-        let rates: Vec<u64> = (height.saturating_sub(60)..=height)
-            .filter_map(|h| inner.chainstore.get_block_fee_rate(h).ok().flatten())
-            .collect();
-        if !rates.is_empty() {
-            inner.fee_estimation = (
-                median(&rates[rates.len().saturating_sub(6)..]),
-                median(&rates[rates.len().saturating_sub(30)..]),
-                median(rates.as_slice()),
-            )
-        }
+        self.update_fee_estimation(height, avg_fee_rate)?;
 
         Ok(height)
     }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -72,7 +72,7 @@ use crate::pruned_utreexo::utxo_data::UtxoData;
 use crate::read_lock;
 use crate::write_lock;
 
-const SATS_PER_KILO_VBYTE: u64 = bitcoin::Weight::WITNESS_SCALE_FACTOR as u64 * 1000;
+const SATS_PER_KILO_VBYTE: u64 = bitcoin::Weight::WITNESS_SCALE_FACTOR * 1000;
 
 /// Trait for components that need to receive notifications about new blocks.
 pub trait BlockConsumer: Sync + Send + 'static {

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -79,6 +79,9 @@ pub trait ChainStore {
     /// this store. Implementations should not include the size of any enclosing
     /// directory or unrelated data.
     fn size_on_disk(&self) -> Result<u64, Self::Error>;
+
+    fn save_block_fee_rate(&mut self, height: u32, fee_rate: u64) -> Result<(), Self::Error>;
+    fn get_block_fee_rate(&mut self, height: u32) -> Result<Option<u64>, Self::Error>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -80,7 +80,9 @@ pub trait ChainStore {
     /// directory or unrelated data.
     fn size_on_disk(&self) -> Result<u64, Self::Error>;
 
+    /// Persist the average fee rate for a block at the given height.
     fn save_block_fee_rate(&mut self, height: u32, fee_rate: u64) -> Result<(), Self::Error>;
+    /// Retrieve the stored average fee rate for a block at the given height, if any.
     fn get_block_fee_rate(&mut self, height: u32) -> Result<Option<u64>, Self::Error>;
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -173,7 +173,7 @@ impl Consensus {
         subsidy: Amount,
         verify_script: bool,
         flags: c_uint,
-    ) -> Result<(), BlockchainError> {
+    ) -> Result<Vec<(Amount, Amount)>, BlockchainError> {
         // Blocks must contain at least one transaction (i.e., the coinbase)
         if transactions.is_empty() {
             Err(BlockValidationErrors::EmptyBlock)?;
@@ -181,6 +181,9 @@ impl Consensus {
 
         // Total block fees that the miner can claim in the coinbase
         let mut fee = Amount::ZERO;
+
+        // Store in_value and out_value as Vector for return
+        let mut tx_fee_values = Vec::new();
 
         for (n, transaction) in transactions.iter().enumerate() {
             if n == 0 {
@@ -195,7 +198,7 @@ impl Consensus {
             // Actually verify the transaction
             let (in_value, out_value) =
                 Self::verify_transaction(transaction, &mut utxos, height, verify_script, flags)?;
-
+            tx_fee_values.push((in_value, out_value));
             // Fee is the difference between inputs and outputs. In the above function call we have
             // verified that `out_value <= in_value` (no underflow risk).
             fee = fee
@@ -214,7 +217,7 @@ impl Consensus {
             Err(BlockValidationErrors::BadCoinbaseOutValue)?;
         }
 
-        Ok(())
+        Ok(tx_fee_values)
     }
 
     /// Performs all transaction checks that are independent of the spent outputs and produces

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -628,6 +628,9 @@ pub struct FlatChainStore {
 
     /// A LRU cache for the last n blocks we've touched
     cache: Mutex<LruCache<BlockHash, DiskBlockHeader>>,
+
+    // Binary for saving fee rate
+    fee_rate_file: File,
 }
 
 impl FlatChainStore {
@@ -660,6 +663,7 @@ impl FlatChainStore {
         let metadata_path = datadir.join("metadata.bin");
         let fork_headers_path = datadir.join("fork_headers.bin");
         let accumulator_file_path = datadir.join("accumulators.bin");
+        let fee_rate_file_path = datadir.join("fee_rates.bin");
 
         let index_map_file_size = index_size * size_of::<u32>();
         let index_map = unsafe { Self::init_file(&index_path, index_map_file_size, file_mode)? };
@@ -709,9 +713,17 @@ impl FlatChainStore {
             .truncate(false)
             .open(accumulator_file_path)?;
 
+        let fee_rate_file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(fee_rate_file_path)?;
+
         Ok(Self {
             headers,
             accumulator_file,
+            fee_rate_file,
             metadata,
             block_index: BlockIndex::new(index_map, index_size),
             fork_headers,
@@ -762,6 +774,7 @@ impl FlatChainStore {
         let headers_file_path = datadir.join("headers.bin");
         let fork_file_path = datadir.join("fork_headers.bin");
         let accumulator_file_path = datadir.join("accumulators.bin");
+        let fee_rate_file_path = datadir.join("fee_rates.bin");
 
         let index_file_size = metadata.index_capacity * size_of::<u32>();
         let headers_file_size = metadata.headers_file_size * size_of::<HashedDiskHeader>();
@@ -781,9 +794,17 @@ impl FlatChainStore {
             .truncate(false)
             .open(accumulator_file_path)?;
 
+        let fee_rate_file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(fee_rate_file_path)?;
+
         Ok(Self {
             headers,
             accumulator_file,
+            fee_rate_file,
             metadata: metadata_file,
             block_index: BlockIndex::new(index_map, metadata.index_capacity),
             fork_headers,
@@ -1300,6 +1321,25 @@ impl ChainStore for FlatChainStore {
         let index = Index::new(height)?;
 
         unsafe { self.add_index_entry(hash, index) }
+    }
+
+    fn save_block_fee_rate(&mut self, height: u32, fee_rate: u64) -> Result<(), Self::Error> {
+        let pos = height as u64 * 8;
+        self.fee_rate_file.seek(SeekFrom::Start(pos))?;
+        self.fee_rate_file.write_all(&fee_rate.to_le_bytes())?;
+        Ok(())
+    }
+
+    fn get_block_fee_rate(&mut self, height: u32) -> Result<Option<u64>, Self::Error> {
+        let pos = height as u64 * 8;
+        let file_len = self.fee_rate_file.metadata()?.len();
+        if pos + 8 > file_len {
+            return Ok(None);
+        }
+        let mut buf = [0u8; 8];
+        self.fee_rate_file.seek(SeekFrom::Start(pos))?;
+        self.fee_rate_file.read_exact(&mut buf)?;
+        Ok(Some(u64::from_le_bytes(buf)))
     }
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1871,6 +1871,38 @@ mod tests {
     }
 
     #[test]
+    fn test_fee_rate_save_and_get() {
+        let mut store = get_test_chainstore(None).unwrap();
+
+        // save and get
+        store.save_block_fee_rate(0, 12345).unwrap();
+        store.save_block_fee_rate(1, 67890).unwrap();
+        store.save_block_fee_rate(100, u64::MAX).unwrap();
+
+        assert_eq!(store.get_block_fee_rate(0).unwrap(), Some(12345));
+        assert_eq!(store.get_block_fee_rate(1).unwrap(), Some(67890));
+        assert_eq!(store.get_block_fee_rate(100).unwrap(), Some(u64::MAX));
+    }
+
+    #[test]
+    fn test_fee_rate_missing_block_returns_none() {
+        let mut store = get_test_chainstore(None).unwrap();
+
+        // not saved
+        assert_eq!(store.get_block_fee_rate(2).unwrap(), None);
+        assert_eq!(store.get_block_fee_rate(99999).unwrap(), None);
+    }
+
+    #[test]
+    fn test_fee_rate_overwrite() {
+        let mut store = get_test_chainstore(None).unwrap();
+
+        store.save_block_fee_rate(5, 111).unwrap();
+        store.save_block_fee_rate(5, 222).unwrap();
+        assert_eq!(store.get_block_fee_rate(5).unwrap(), Some(222));
+    }
+
+    #[test]
     fn accept_first_signet_headers() {
         // Accepts the first 2016 signet headers
         let file = include_bytes!("../../testdata/signet_headers.zst");

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -134,6 +134,10 @@ type CacheType = LruCache<BlockHash, DiskBlockHeader>;
 /// 64 (MAX_ROOTS) * 32 bytes (ROOT_SIZE) + 8 bytes (LEAF_COUNT) = 2056 bytes
 pub const MAX_ACCUMULATOR_SIZE: usize = 2056;
 
+/// Fee rate pruning window: keep at most the last 1008 blocks (~1week)
+const FEE_RATE_WINDOW: u32 = 1008;
+const FEE_RATE_FILE_SIZE: u64 = FEE_RATE_WINDOW as u64 * size_of::<u64>() as u64; //8064 bytes
+
 #[derive(Clone)]
 /// Configuration for our flat chain store. See each field for more information
 pub struct FlatChainStoreConfig {
@@ -720,6 +724,8 @@ impl FlatChainStore {
             .truncate(false)
             .open(fee_rate_file_path)?;
 
+        fee_rate_file.set_len(FEE_RATE_FILE_SIZE)?;
+
         Ok(Self {
             headers,
             accumulator_file,
@@ -800,6 +806,8 @@ impl FlatChainStore {
             .create(true)
             .truncate(false)
             .open(fee_rate_file_path)?;
+
+        fee_rate_file.set_len(FEE_RATE_FILE_SIZE)?;
 
         Ok(Self {
             headers,
@@ -1324,14 +1332,21 @@ impl ChainStore for FlatChainStore {
     }
 
     fn save_block_fee_rate(&mut self, height: u32, fee_rate: u64) -> Result<(), Self::Error> {
-        let pos = height as u64 * size_of::<u64>() as u64;
+        let pos = (height as u64 % FEE_RATE_WINDOW as u64) * size_of::<u64>() as u64;
         self.fee_rate_file.seek(SeekFrom::Start(pos))?;
         self.fee_rate_file.write_all(&fee_rate.to_le_bytes())?;
         Ok(())
     }
 
     fn get_block_fee_rate(&mut self, height: u32) -> Result<Option<u64>, Self::Error> {
-        let pos = height as u64 * size_of::<u64>() as u64;
+        let tip_height = unsafe { self.get_metadata()?.depth.saturating_sub(1) };
+
+        // Fee rate pruned return None: outside the ~1 week window, or future block
+        if tip_height.saturating_sub(height) >= FEE_RATE_WINDOW || tip_height < height {
+            return Ok(None);
+        }
+
+        let pos = (height as u64 % FEE_RATE_WINDOW as u64) * size_of::<u64>() as u64;
         let file_len = self.fee_rate_file.metadata()?.len();
         if pos + size_of::<u64>() as u64 > file_len {
             return Ok(None);
@@ -1873,6 +1888,14 @@ mod tests {
     #[test]
     fn test_fee_rate_save_and_get() {
         let mut store = get_test_chainstore(None).unwrap();
+        store
+            .save_height(&BestChain {
+                depth: 1000,
+                best_block: BlockHash::all_zeros(),
+                validation_index: BlockHash::all_zeros(),
+                alternative_tips: vec![],
+            })
+            .unwrap();
 
         // save and get
         store.save_block_fee_rate(0, 12345).unwrap();
@@ -1882,6 +1905,39 @@ mod tests {
         assert_eq!(store.get_block_fee_rate(0).unwrap(), Some(12345));
         assert_eq!(store.get_block_fee_rate(1).unwrap(), Some(67890));
         assert_eq!(store.get_block_fee_rate(100).unwrap(), Some(u64::MAX));
+    }
+
+    #[test]
+    fn test_fee_rate_prune_window() {
+        const W: u32 = super::FEE_RATE_WINDOW;
+
+        let mut store = get_test_chainstore(None).unwrap();
+
+        // tip = W * 2
+        let tip = W * 2;
+        store
+            .save_height(&BestChain {
+                depth: tip + 1, // tip_height = depth - 1 = W * 2
+                best_block: BlockHash::all_zeros(),
+                validation_index: BlockHash::all_zeros(),
+                alternative_tips: vec![],
+            })
+            .unwrap();
+
+        // Case 1: within window → Some
+        let h1 = W + 500; // tip - h1 = W - 500 < W
+        store.save_block_fee_rate(h1, 100).unwrap();
+        assert_eq!(store.get_block_fee_rate(h1).unwrap(), Some(100));
+
+        // Case 2: at window boundary → None (tip - h2 = W >= W)
+        let h2 = W;
+        store.save_block_fee_rate(h2, 200).unwrap();
+        assert_eq!(store.get_block_fee_rate(h2).unwrap(), None);
+
+        // Case 3: future block → None
+        let h3 = tip + 1;
+        store.save_block_fee_rate(h3, 300).unwrap();
+        assert_eq!(store.get_block_fee_rate(h3).unwrap(), None);
     }
 
     #[test]
@@ -1896,6 +1952,14 @@ mod tests {
     #[test]
     fn test_fee_rate_overwrite() {
         let mut store = get_test_chainstore(None).unwrap();
+        store
+            .save_height(&BestChain {
+                depth: 1000,
+                best_block: BlockHash::all_zeros(),
+                validation_index: BlockHash::all_zeros(),
+                alternative_tips: vec![],
+            })
+            .unwrap();
 
         store.save_block_fee_rate(5, 111).unwrap();
         store.save_block_fee_rate(5, 222).unwrap();

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1324,19 +1324,19 @@ impl ChainStore for FlatChainStore {
     }
 
     fn save_block_fee_rate(&mut self, height: u32, fee_rate: u64) -> Result<(), Self::Error> {
-        let pos = height as u64 * 8;
+        let pos = height as u64 * size_of::<u64>() as u64;
         self.fee_rate_file.seek(SeekFrom::Start(pos))?;
         self.fee_rate_file.write_all(&fee_rate.to_le_bytes())?;
         Ok(())
     }
 
     fn get_block_fee_rate(&mut self, height: u32) -> Result<Option<u64>, Self::Error> {
-        let pos = height as u64 * 8;
+        let pos = height as u64 * size_of::<u64>() as u64;
         let file_len = self.fee_rate_file.metadata()?.len();
-        if pos + 8 > file_len {
+        if pos + size_of::<u64>() as u64 > file_len {
             return Ok(None);
         }
-        let mut buf = [0u8; 8];
+        let mut buf = [0u8; size_of::<u64>()];
         self.fee_rate_file.seek(SeekFrom::Start(pos))?;
         self.fee_rate_file.read_exact(&mut buf)?;
         Ok(Some(u64::from_le_bytes(buf)))

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -629,7 +629,7 @@ pub struct FlatChainStore {
     /// A LRU cache for the last n blocks we've touched
     cache: Mutex<LruCache<BlockHash, DiskBlockHeader>>,
 
-    // Binary for saving fee rate
+    /// Per-block fee rate store, one little-endian u64 per height (offset = height * 8)
     fee_rate_file: File,
 }
 

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -308,7 +308,20 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     "max": MAX_COUNT,
                 })
             }
-            "blockchain.estimatefee" => json_rpc_res!(request, 0.0001),
+            "blockchain.estimatefee" => {
+                use std::convert::TryFrom;
+                let target = request
+                    .params
+                    .first()
+                    .and_then(|v| v.as_u64())
+                    .and_then(|t| usize::try_from(t).ok())
+                    .unwrap_or(1);
+                let fee_sat = self
+                    .chain
+                    .estimate_fee(target)
+                    .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
+                json_rpc_res!(request, (fee_sat / 100_000_000.0))
+            }
             "blockchain.headers.subscribe" => {
                 let (height, hash) = self
                     .chain
@@ -1314,7 +1327,7 @@ mod test {
 
         let batch_response = send_request(batch_req, port).await.unwrap();
 
-        assert_eq!(batch_response[0]["result"], 0.0001);
+        assert_eq!(batch_response[0]["result"], 0.00000001);
         assert_eq!(batch_response[1]["result"], 0.00001);
     }
 

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -28,6 +28,9 @@ use floresta_watch_only::CachedTransaction;
 use floresta_watch_only::kv_database::KvDatabase;
 use floresta_wire::node_handle::NodeHandle;
 use floresta_wire::node_interface::ChainMethods;
+
+/// Number of satoshis in one bitcoin
+const SATS_PER_BTC: f64 = 100_000_000.0;
 use floresta_wire::node_interface::MempoolMethods;
 use serde_json::Value;
 use serde_json::json;
@@ -320,7 +323,7 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                     .chain
                     .estimate_fee(target)
                     .map_err(|e| super::error::Error::Blockchain(Box::new(e)))?;
-                json_rpc_res!(request, (fee_sat / 100_000_000.0))
+                json_rpc_res!(request, (fee_sat / SATS_PER_BTC))
             }
             "blockchain.headers.subscribe" => {
                 let (height, hash) = self


### PR DESCRIPTION

### Description and Notes

Implements block-based fee estimation for `blockchain.estimatefee`,
replacing the hardcoded `0.0001 BTC/kB`. Closes #1141.

**Architecture:**
- `ChainStore` trait gains `save_block_fee_rate` / `get_block_fee_rate`
- `FlatChainStore` persists fee rates in a fixed-record file (`fee_rates.bin`)
- `connect_block` computes each block's average fee rate (sat/kvB) from
  UTXO inputs and transaction outputs before they are consumed
- `ChainStateInner.fee_estimation` cache is updated with rolling medians:
  6 blocks → target=1, 30 blocks → target=10, 60 blocks → target=20
- Electrum `blockchain.estimatefee` now calls `estimate_fee()` and
  converts sat/kvB → BTC/kB


### How to verify the changes you have done?

<!--If applicable, this section will help reviewers to understand your changes, and how to assert it's working as intended. You may also add steps that helps to reproduce some results, like commands that you've used during your development. -->

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
- [x] signing commit


*Note: this patch was created with assistance guide & review from an deepseek v4 pro LLM