### PR TITLE
fix(wire): Reject truncated BIP324 short-id-0 frames

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/network_message_ext.rs
+++ b/crates/floresta-wire/src/p2p_wire/network_message_ext.rs
@@ -165,7 +165,14 @@ impl NetworkMessageExt for NetworkMessage {
 
         match short_id {
             0u8 => {
-                let mut command_buffer = &buffer[1..13];
+                let Some(mut command_buffer) = buffer.get(1..13) else {
+                    return Err(V2MessageError::Deserialize(encode::Error::Io(
+                        bitcoin::io::Error::new(
+                            bitcoin::io::ErrorKind::UnexpectedEof,
+                            "Missing command for zero short_id message",
+                        ),
+                    )));
+                };
                 let command = CommandString::consensus_decode(&mut command_buffer)
                     .map_err(V2MessageError::Deserialize)?;
                 payload_buffer = &buffer[13..];
@@ -278,5 +285,33 @@ impl NetworkMessageExt for NetworkMessage {
             )?)),
             unknown => Err(V2MessageError::UnknownShortID(unknown)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::p2p::message::NetworkMessage;
+
+    use super::NetworkMessageExt;
+    use super::V2MessageError;
+
+    #[test]
+    fn deserialize_v2_zero_short_id() {
+        assert!(matches!(
+            NetworkMessage::deserialize_v2(&[0u8]),
+            Err(V2MessageError::Deserialize(_))
+        ));
+
+        assert!(matches!(
+            NetworkMessage::deserialize_v2(&[0u8; 12]),
+            Err(V2MessageError::Deserialize(_))
+        ));
+
+        let mut verack = vec![0u8];
+        verack.extend(b"verack\0\0\0\0\0\0");
+        assert_eq!(
+            NetworkMessage::deserialize_v2(&verack).expect("valid verack frame"),
+            NetworkMessage::Verack
+        );
     }
 }


### PR DESCRIPTION
### Description and Notes

`deserialize_v2` parses BIP324 v2 message contents after AEAD decrypt. A short-id of `0` means the next 12 bytes are the command string. Previously, that path indexed `buffer[1..13]` without a length check and a truncated payload could panic the node instead of returning an error.

This PR checks the length before slicing. If fewer than 13 bytes are present, it returns a deserialize error instead of panicking. A malformed frame now drops the offending peer instead of crashing the node. Valid frames decode as before. 

#### Changelog

```
fix(wire): reject truncated BIP324 short-id-0 frames
 - use buffer.get(1..13) instead of unchecked slicing
 - return Io(UnexpectedEof) when the command string is missing
 - add unit test for truncated and valid zero-short-id frames
```

### To verify changes

- `cargo test -p floresta-wire deserialize_v2_zero_short_id`
- `cargo clippy -p floresta-wire --all-targets`

🤖 Assisted-by: Cursor Composer