### PR TITLE
electrum: make block.headers count match the hex chunk

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -293,18 +293,29 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let end_height =
                     (chain_height.saturating_add(1)).min(start_height.saturating_add(count));
 
-                let heights = start_height..end_height;
-                let count = heights.len();
+                // Walk the range contiguously, stopping at the first height that
+                // fails to resolve. `count` must reflect the headers actually
+                // serialized into `hex` (Electrum clients reject a response where
+                // `len(hex) / 160 != count`), and breaking on the first gap keeps
+                // `hex` a contiguous chunk instead of silently splicing out a
+                // header and shifting every one after it.
+                let mut hex = String::new();
+                let mut count: u32 = 0;
 
-                let headers = heights.filter_map(|height| {
-                    let hash = self.chain.get_block_hash(height).ok()?;
-                    let header = self.chain.get_block_header(&hash).ok()?;
-                    Some(serialize_hex(&header))
-                });
+                for height in start_height..end_height {
+                    let Ok(hash) = self.chain.get_block_hash(height) else {
+                        break;
+                    };
+                    let Ok(header) = self.chain.get_block_header(&hash) else {
+                        break;
+                    };
+                    hex.push_str(&serialize_hex(&header));
+                    count += 1;
+                }
 
                 json_rpc_res!(request, {
                     "count": count,
-                    "hex": String::from_iter(headers),
+                    "hex": hex,
                     "max": MAX_COUNT,
                 })
             }


### PR DESCRIPTION
## what's broken

`blockchain.block.headers` can return a response where `count` doesn't match the number of headers in `hex`. Electrum clients assert `len(hex) / 160 == count` and, when it fails, raise `RequestCorrupted('inconsistent chunk hex and count')`, drop the connection, reconnect, and loop — the wallet never reaches tip.

## why

```rust
let heights = start_height..end_height;
let count = heights.len();                    // promised count = range length

let headers = heights.filter_map(|height| {   // any failed lookup silently dropped
    let hash = self.chain.get_block_hash(height).ok()?;
    let header = self.chain.get_block_header(&hash).ok()?;
    Some(serialize_hex(&header))
});
```

`count` is the requested range length, but `hex` comes from a `filter_map` whose `.ok()?` swallows any `get_block_hash` / `get_block_header` failure. If a height in the range fails to resolve, `hex` holds fewer headers than `count` advertises. It's timing-dependent — a height in the range has to fail to resolve, which is most likely while the chain is moving near the tip.

there's a second issue in the same spot: `hex` is a flat concat of fixed-width headers, so a dropped height in the *middle* of the range shifts every header after it. a client that skipped the count check would splice a non-contiguous chunk into its header chain.

## the fix

walk the range contiguously and break on the first height that fails to resolve, counting only what actually gets serialized. `count` now always equals the number of headers in `hex`, and `hex` stays a contiguous run starting at `start_height` (returning a short chunk is fine per the protocol; an inconsistent one isn't).

## test

no regression test here — the existing electrum test harness spins up a live TLS server against a real chain and can't inject a mid-range lookup failure, and the happy path passes under both old and new code (it only diverges when a resolve fails). a deterministic test needs a chain mock that can fail `get_block_hash`/`get_block_header` for a specific height; noting it as a follow-up.

Fixes #1224