### PR TITLE
fuzz: add harness for p2p v2 network messages

### DIFF
--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -32,6 +32,8 @@ pub use p2p_wire::block_proof;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::error;
 #[cfg(not(target_arch = "wasm32"))]
+pub use p2p_wire::network_message_ext;
+#[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::node;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::node_context;

--- a/crates/floresta-wire/src/p2p_wire/network_message_ext.rs
+++ b/crates/floresta-wire/src/p2p_wire/network_message_ext.rs
@@ -118,14 +118,13 @@ impl NetworkMessageExt for NetworkMessage {
                     .consensus_encode(&mut buffer)
                     .expect("Encoding to Vec<u8> never fails");
             }
-            Self::Unknown {
-                command,
-                payload: _,
-            } => {
+            Self::Unknown { command, payload } => {
                 buffer.push(0u8);
                 command
                     .consensus_encode(&mut buffer)
                     .expect("Encoding to Vec<u8> never fails");
+                buffer.extend(payload);
+                return buffer;
             }
         }
 
@@ -173,6 +172,19 @@ impl NetworkMessageExt for NetworkMessage {
                         ),
                     )));
                 };
+                let command_end = command_buffer
+                    .iter()
+                    .position(|byte| *byte == 0)
+                    .unwrap_or(command_buffer.len());
+                let command_is_valid = command_buffer[..command_end]
+                    .iter()
+                    .all(|byte| (0x20..=0x7e).contains(byte))
+                    && command_buffer[command_end..].iter().all(|byte| *byte == 0);
+                if !command_is_valid {
+                    return Err(V2MessageError::Deserialize(encode::Error::ParseFailed(
+                        "Invalid command string",
+                    )));
+                }
                 let command = CommandString::consensus_decode(&mut command_buffer)
                     .map_err(V2MessageError::Deserialize)?;
                 payload_buffer = &buffer[13..];
@@ -290,6 +302,7 @@ impl NetworkMessageExt for NetworkMessage {
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::p2p::message::CommandString;
     use bitcoin::p2p::message::NetworkMessage;
 
     use super::NetworkMessageExt;
@@ -313,5 +326,28 @@ mod tests {
             NetworkMessage::deserialize_v2(&verack).expect("valid verack frame"),
             NetworkMessage::Verack
         );
+    }
+
+    #[test]
+    fn unknown_v2_message_roundtrip() {
+        let message = NetworkMessage::Unknown {
+            command: CommandString::try_from_static("uproof").expect("valid command"),
+            payload: vec![0xf8, 0x08],
+        };
+
+        let encoded = message.serialize_v2();
+        let decoded =
+            NetworkMessage::deserialize_v2(&encoded).expect("serialized message must decode");
+
+        assert_eq!(decoded, message);
+    }
+
+    #[test]
+    fn deserialize_v2_rejects_invalid_command() {
+        let invalid_command = [
+            0, 0x7e, 0xa9, 0xa9, 0xa9, 0xa9, 0x1c, 0xa9, 0xa9, 0xa9, 0xa9, 0xa9, 0,
+        ];
+
+        assert!(NetworkMessage::deserialize_v2(&invalid_command).is_err());
     }
 }

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -13,8 +13,12 @@ Available fuzz targets:
 - `addrman`
 - `best_chain_decode`
 - `best_chain_roundtrip`
+- `bitcoin_socket_addr`
 - `disk_block_header_decode`
 - `disk_block_header_roundtrip`
-- `local_address_str`
-- `utreexo_proof_des`
 - `flat_chainstore_header_insertion`
+- `local_address_str`
+- `onion_address_rtt`
+- `onion_address_str_parse`
+- `p2p_v2_message`
+- `utreexo_proof_des`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -97,5 +97,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "p2p_v2_message"
+path = "fuzz_targets/p2p_v2_message.rs"
+test = false
+doc = false
+bench = false
+
 [lints]
 workspace = true

--- a/fuzz/fuzz_targets/p2p_v2_message.rs
+++ b/fuzz/fuzz_targets/p2p_v2_message.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use bitcoin::p2p::message::NetworkMessage;
+use bitcoin::p2p::message_blockdata::Inventory;
+use floresta_wire::network_message_ext::NetworkMessageExt;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(message) = NetworkMessage::deserialize_v2(data) else {
+        return;
+    };
+
+    // `getuproof` is an outbound-only extension and has no corresponding decode path.
+    if matches!(
+        &message,
+        NetworkMessage::Unknown { command, .. } if command.as_ref() == "getuproof"
+    ) {
+        return;
+    }
+
+    // TODO: rust-bitcoin 0.32.8 does not consume the hash following an `Error`
+    // inventory type when decoding. Fixed upstream in rust-bitcoin@72e97c6;
+    // remove this workaround after upgrading.
+    if matches!(
+        &message,
+        NetworkMessage::Inv(inventory)
+            | NetworkMessage::GetData(inventory)
+            | NetworkMessage::NotFound(inventory)
+            if inventory.iter().any(|item| matches!(item, Inventory::Error))
+    ) {
+        return;
+    }
+
+    let encoded = message.serialize_v2();
+    let decoded =
+        NetworkMessage::deserialize_v2(&encoded).expect("serialized v2 message must decode");
+    assert_eq!(decoded, message, "v2 message roundtrip mismatch");
+});


### PR DESCRIPTION
It adds a fuzz target `p2p_v2_message` that:

1. Attempts to decode arbitrary input as a BIP324 `NetworkMessage`.
2. Serializes successfully decoded messages.
3. Decodes the serialized result again.
4. Verifies that the message survives the roundtrip unchanged.

While working on the target, two issues in `NetworkMessageExt` were uncovered and fixed:

  - Unknown-message payloads were serialized through `Vec<u8>::consensus_encode`, which added an incorrect CompactSize length prefix. They are now
  appended directly as raw BIP324 payload bytes.
  - Long-form message commands were accepted without validating their ASCII encoding and zero padding. Malformed commands could produce an invalid
  `CommandString` and later panic during serialization. These commands are now rejected during deserialization.

This PR also:

  - Re-exports `network_message_ext` from `floresta-wire` so external crates can use `NetworkMessageExt`.
  - Adds regression tests for unknown-message roundtrips and malformed commands.