### PR TITLE
feat(node): made flat_chain_store capacities configurable

### DIFF
--- a/bin/florestad/src/cli.rs
+++ b/bin/florestad/src/cli.rs
@@ -4,12 +4,11 @@ use std::path::PathBuf;
 
 use bitcoin::BlockHash;
 use bitcoin::Network;
-#[cfg(unix)]
 use clap::CommandFactory;
 use clap::Parser;
 use floresta_node::AssumeValidArg;
 
-#[derive(Parser)]
+#[derive(Parser, Clone, Debug)]
 #[command(
     author = "Davidson Souza",
     version = env!("GIT_DESCRIBE"),
@@ -190,6 +189,18 @@ pub struct Cli {
     /// This will run in the background and wont't affect node's operation. However,
     /// to disable backfilling, run floresta using this flag.
     pub no_backfill: bool,
+
+    #[arg(long, value_name = "SIZE")]
+    /// The maximum number of block indexes we can store in our database (default: 10,000,000)
+    pub block_index_size: Option<usize>,
+
+    #[arg(long, value_name = "SIZE")]
+    /// The maximum number of block headers in the main chain we can store (default: 10,000,000)
+    pub headers_file_size: Option<usize>,
+
+    #[arg(long, value_name = "SIZE")]
+    /// The maximum number of alternative fork headers we can track (default: 10,000)
+    pub fork_file_size: Option<usize>,
 }
 
 impl Cli {
@@ -198,15 +209,48 @@ impl Cli {
     /// Checks:
     ///   - If `--pid-file` is passed, `--daemon` must also be passed.
     pub fn validate(&self) {
+        if let Err(err) = self.check_validity() {
+            err.exit();
+        }
+    }
+
+    fn check_validity(&self) -> Result<(), clap::Error> {
         #[cfg(unix)]
         if self.pid_file.is_some() && !self.daemon {
-            Self::command()
-                .error(
-                    clap::error::ErrorKind::MissingRequiredArgument,
-                    "--pid-file requires that --daemon be set",
-                )
-                .exit();
+            return Err(Self::command().error(
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "--pid-file requires that --daemon be set",
+            ));
         }
+
+        if let Some(size) = self.block_index_size {
+            if size < 1000 {
+                return Err(Self::command().error(
+                    clap::error::ErrorKind::ValueValidation,
+                    "--block-index-size must be at least 1,000",
+                ));
+            }
+        }
+
+        if let Some(size) = self.headers_file_size {
+            if size < 1000 {
+                return Err(Self::command().error(
+                    clap::error::ErrorKind::ValueValidation,
+                    "--headers-file-size must be at least 1,000",
+                ));
+            }
+        }
+
+        if let Some(size) = self.fork_file_size {
+            if size < 10 {
+                return Err(Self::command().error(
+                    clap::error::ErrorKind::ValueValidation,
+                    "--fork-file-size must be at least 10",
+                ));
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -218,5 +262,95 @@ fn parse_assume_valid(s: &str) -> Result<AssumeValidArg, String> {
             .parse::<BlockHash>()
             .map(AssumeValidArg::UserInput)
             .map_err(|e| format!("expected 0 or a block hash, got '{other}': {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_validation_bounds() {
+        // Base case with valid bounds
+        let base_cli = Cli {
+            disable_dns_seeds: false,
+            config_file: None,
+            network: Network::Bitcoin,
+            debug: false,
+            log_to_file: false,
+            data_dir: None,
+            no_cfilters: false,
+            proxy: None,
+            wallet_xpub: None,
+            wallet_descriptor: None,
+            assume_valid: AssumeValidArg::Hardcoded,
+            zmq_address: None,
+            connect: vec![],
+            rpc_address: None,
+            filters_start_height: None,
+            no_assume_utreexo: false,
+            electrum_address: None,
+            enable_electrum_tls: false,
+            electrum_address_tls: None,
+            generate_cert: false,
+            tls_key_path: None,
+            tls_cert_path: None,
+            allow_v1_fallback: false,
+            #[cfg(unix)]
+            daemon: false,
+            #[cfg(unix)]
+            pid_file: None,
+            no_backfill: false,
+            block_index_size: Some(1000),
+            headers_file_size: Some(1000),
+            fork_file_size: Some(10),
+        };
+
+        // Assert valid base case passes
+        assert!(base_cli.check_validity().is_ok());
+
+        // Test invalid block_index_size (under 1000)
+        let mut cli = base_cli.clone();
+        cli.block_index_size = Some(999);
+        let res = cli.check_validity();
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+
+        // Test invalid headers_file_size (under 1000)
+        let mut cli = base_cli.clone();
+        cli.headers_file_size = Some(999);
+        let res = cli.check_validity();
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+
+        // Test invalid fork_file_size (under 10)
+        let mut cli = base_cli.clone();
+        cli.fork_file_size = Some(9);
+        let res = cli.check_validity();
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+
+        // Test valid boundary values
+        let mut cli = base_cli.clone();
+        cli.block_index_size = Some(1000);
+        cli.headers_file_size = Some(1000);
+        cli.fork_file_size = Some(10);
+        assert!(cli.check_validity().is_ok());
+
+        // Test valid values far above bounds
+        let mut cli = base_cli.clone();
+        cli.block_index_size = Some(10000000);
+        cli.headers_file_size = Some(10000000);
+        cli.fork_file_size = Some(10000);
+        assert!(cli.check_validity().is_ok());
     }
 }

--- a/bin/florestad/src/main.rs
+++ b/bin/florestad/src/main.rs
@@ -94,6 +94,9 @@ fn main() {
         tls_key_path: params.tls_key_path,
         allow_v1_fallback: params.allow_v1_fallback,
         backfill: !params.no_backfill,
+        block_index_size: params.block_index_size,
+        headers_file_size: params.headers_file_size,
+        fork_file_size: params.fork_file_size,
     };
 
     #[cfg(unix)]

--- a/crates/floresta-node/src/config_file.rs
+++ b/crates/floresta-node/src/config_file.rs
@@ -15,8 +15,17 @@ pub struct Wallet {
 }
 
 #[derive(Default, Debug, Deserialize)]
+pub struct ChainStore {
+    pub block_index_size: Option<usize>,
+    pub headers_file_size: Option<usize>,
+    pub fork_file_size: Option<usize>,
+}
+
+#[derive(Default, Debug, Deserialize)]
 pub struct ConfigFile {
+    #[serde(default)]
     pub wallet: Wallet,
+    pub chain_store: Option<ChainStore>,
 }
 
 impl ConfigFile {
@@ -24,5 +33,63 @@ impl ConfigFile {
         let config_file = fs::read_to_string(path.as_ref())?;
 
         Ok(toml::from_str(&config_file)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toml_deserialization() {
+        // Test parsing of a complete, valid config
+        let toml_str = r#"
+            [wallet]
+            xpubs = ["xpub1", "xpub2"]
+            descriptors = ["desc1"]
+            addresses = ["addr1"]
+
+            [chain_store]
+            block_index_size = 10000000
+            headers_file_size = 10000000
+            fork_file_size = 10000
+        "#;
+        let config: ConfigFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.wallet.xpubs.unwrap(),
+            vec!["xpub1".to_string(), "xpub2".to_string()]
+        );
+        let chain_store = config.chain_store.unwrap();
+        assert_eq!(chain_store.block_index_size, Some(10000000));
+        assert_eq!(chain_store.headers_file_size, Some(10000000));
+        assert_eq!(chain_store.fork_file_size, Some(10000));
+
+        // Test optional fields and default parsing (missing fields/sections)
+        let toml_str_partial = r#"
+            [chain_store]
+            block_index_size = 5000
+        "#;
+        let config_partial: ConfigFile = toml::from_str(toml_str_partial).unwrap();
+        assert!(config_partial.wallet.xpubs.is_none());
+        let chain_store_partial = config_partial.chain_store.unwrap();
+        assert_eq!(chain_store_partial.block_index_size, Some(5000));
+        assert_eq!(chain_store_partial.headers_file_size, None);
+        assert_eq!(chain_store_partial.fork_file_size, None);
+
+        // Test invalid data type for usize fields (should fail deserialization)
+        let toml_invalid_type = r#"
+            [chain_store]
+            block_index_size = "not-a-number"
+        "#;
+        let res: Result<ConfigFile, _> = toml::from_str(toml_invalid_type);
+        assert!(res.is_err());
+
+        // Test negative number for usize fields (should fail deserialization)
+        let toml_negative = r#"
+            [chain_store]
+            block_index_size = -5
+        "#;
+        let res_neg: Result<ConfigFile, _> = toml::from_str(toml_negative);
+        assert!(res_neg.is_err());
     }
 }

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -223,6 +223,15 @@ pub struct Config {
     /// and won't affect the node's operation. You may notice that this will take a lot of CPU
     /// and bandwidth to run.
     pub backfill: bool,
+
+    /// Maximum number of block indexes we can store in our flat database
+    pub block_index_size: Option<usize>,
+
+    /// Maximum number of block headers we can store in our flat database
+    pub headers_file_size: Option<usize>,
+
+    /// Maximum number of alternative fork headers we can track
+    pub fork_file_size: Option<usize>,
 }
 
 impl Config {
@@ -257,6 +266,9 @@ impl Config {
             tls_cert_path: None,
             allow_v1_fallback: false,
             backfill: false,
+            block_index_size: None,
+            headers_file_size: None,
+            fork_file_size: None,
         }
     }
 }
@@ -369,11 +381,32 @@ impl Florestad {
         info!("Loading watch-only wallet");
         let wallet = self.setup_wallet()?;
 
+        let config_file = self.get_config_file();
+        let (block_index_size, headers_file_size, fork_file_size) = match config_file.chain_store {
+            Some(ref chain_store) => (
+                self.config
+                    .block_index_size
+                    .or(chain_store.block_index_size),
+                self.config
+                    .headers_file_size
+                    .or(chain_store.headers_file_size),
+                self.config.fork_file_size.or(chain_store.fork_file_size),
+            ),
+            None => (
+                self.config.block_index_size,
+                self.config.headers_file_size,
+                self.config.fork_file_size,
+            ),
+        };
+
         info!("Loading blockchain database");
         let blockchain_state = Arc::new(Self::load_chain_state(
             datadir,
             self.config.network,
             self.config.assume_valid,
+            block_index_size,
+            headers_file_size,
+            fork_file_size,
         )?);
 
         #[cfg(feature = "compact-filters")]
@@ -708,8 +741,14 @@ impl Florestad {
         datadir: impl AsRef<Path>,
         network: Network,
         assume_valid: AssumeValidArg,
+        block_index_size: Option<usize>,
+        headers_file_size: Option<usize>,
+        fork_file_size: Option<usize>,
     ) -> Result<ChainState<ChainStore>, FlorestadError> {
-        let chain_store_config = FlatChainStoreConfig::new(datadir.as_ref().join("chaindata"));
+        let mut chain_store_config = FlatChainStoreConfig::new(datadir.as_ref().join("chaindata"));
+        chain_store_config.block_index_size = block_index_size;
+        chain_store_config.headers_file_size = headers_file_size;
+        chain_store_config.fork_file_size = fork_file_size;
 
         let chain_store = ChainStore::new(chain_store_config)
             .map_err(|e| FlorestadError::CouldNotLoadFlatChainStore(e.into()))?;


### PR DESCRIPTION
### Description and Notes

This PR makes the `FlatChainStore` database pre-allocated file capacities (`headers.bin`, `blocks_index.bin`, and `fork_headers.bin`) configurable via command-line flags and the TOML configuration file, with runtime safety boundaries.

Specifically:
1. **CLI Flags**: Exposes `--block-index-size`, `--headers-file-size`, and `--fork-file-size` in `florestad` with boundary validation (rejects invalid sizes below safe limits).
2. **TOML Configuration**: Exposes a `[chain_store]` section in `config.toml` for configuring database capacities (`block_index_size`, `headers_file_size`, `fork_file_size`) with `#[serde(default)]` support.
3. **Plumbing & Precedence**: Merges configuration options in `florestad` (CLI flags take precedence over `config.toml` parameters, which fall back to `FlatChainStore` defaults).

- Fixes / Ref: #1003

---

### How to verify the changes

1. **CLI Validation Check**:
   ```bash
   cargo run --bin florestad -- --headers-file-size 500
   # Result: Rejects immediately with: error: --headers-file-size must be at least 1,000
   ```

2. **TOML Configuration Loading**:
   Create a `config.toml` with `[chain_store]` settings and launch `florestad --config-file config.toml`.

3. **Linter & Formatting Checks**:
   ```bash
   cargo fmt --all --check
   cargo clippy --workspace --all-targets --all-features -- -D warnings
   ```

---

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] I've linked any related issue(s) in the sections above