### PR TITLE
feat(rpc): Add simple getpeerinfo fields

### DIFF
--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -39,11 +39,23 @@ pub struct PeerInfo {
     /// Human-readable names for the recognized services this peer advertises.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
+    /// Whether this peer requested mempool transaction relay from us.
+    #[serde(rename = "relaytxes")]
+    pub relay_txs: bool,
     /// User agent is a string that represents the client being used by our peer. E.g.
     /// /Satoshi-26.0/ for bitcoin core version 26
     pub user_agent: String,
+    /// Whether this peer connection is inbound.
+    pub inbound: bool,
+    /// Whether we selected this peer as a BIP152 high-bandwidth compact block relay peer.
+    pub bip152_hb_to: bool,
+    /// Whether this peer selected us as a BIP152 high-bandwidth compact block relay peer.
+    pub bip152_hb_from: bool,
     /// This peer's height at the time we've opened a connection with them
     pub initial_height: u32,
+    /// The peer time offset in seconds.
+    #[serde(rename = "timeoffset")]
+    pub time_offset: i64,
     /// The connection type of this peer
     ///
     /// We can connect with peers for different reasons. E.g. we can connect to a peer to
@@ -54,6 +66,8 @@ pub struct PeerInfo {
     ///
     /// Can be either Ready, Connecting or Banned
     pub state: String,
+    /// Special permissions granted to this peer.
+    pub permissions: Vec<String>,
     /// The transport protocol used with peer.
     pub transport_protocol: String,
 }

--- a/crates/floresta-wire/src/p2p_wire/node/conn.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/conn.rs
@@ -238,6 +238,7 @@ where
                 _last_message: Instant::now(),
                 kind,
                 height: 0,
+                time_offset: 0,
                 banscore: 0,
                 // Will be downgraded to V1 if the V2 handshake fails, and we allow fallback
                 transport_protocol: TransportProtocol::V2,

--- a/crates/floresta-wire/src/p2p_wire/node/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/mod.rs
@@ -221,6 +221,9 @@ pub struct LocalPeerView {
     /// The latest height this peer has announced to us
     pub(crate) height: u32,
 
+    /// The peer time offset in seconds, computed from its version message timestamp
+    pub(crate) time_offset: i64,
+
     /// The banscore of this peer
     ///
     /// This is a score kept for each peer, every time this peer misbehaves, we

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -288,6 +288,7 @@ where
             peer_data.services = version.services;
             peer_data.user_agent.clone_from(&version.user_agent);
             peer_data.height = version.blocks;
+            peer_data.time_offset = version.time_offset;
             peer_data.transport_protocol = version.transport_protocol;
 
             // If this peer doesn't have basic services, we disconnect it
@@ -868,10 +869,16 @@ where
             address: peer.address.as_bitcoin_socket_addr().clone(),
             services: format!("{:016x}", peer.services.to_u64()),
             services_names: service_flags_strings(&peer.services),
+            relay_txs: false,
             user_agent: peer.user_agent.clone(),
+            inbound: false,
+            bip152_hb_to: false,
+            bip152_hb_from: false,
             initial_height: peer.height,
+            time_offset: peer.time_offset,
             state: peer.state,
             kind: peer.kind,
+            permissions: Vec::new(),
             transport_protocol: peer.transport_protocol,
         })
     }

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -45,10 +45,18 @@ pub struct PeerInfo {
     pub services: String,
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
+    #[serde(rename = "relaytxes")]
+    pub relay_txs: bool,
     pub user_agent: String,
+    pub inbound: bool,
+    pub bip152_hb_to: bool,
+    pub bip152_hb_from: bool,
     pub initial_height: u32,
+    #[serde(rename = "timeoffset")]
+    pub time_offset: i64,
     pub state: PeerStatus,
     pub kind: ConnectionKind,
+    pub permissions: Vec<String>,
     pub transport_protocol: TransportProtocol,
 }
 

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -7,6 +7,8 @@ use core::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bitcoin::Block;
 use bitcoin::BlockHash;
@@ -135,6 +137,7 @@ pub struct Peer<T: AsyncWrite + Unpin + Send + Sync> {
     mempool: Arc<Mutex<dyn MempoolBase>>,
     blocks_only: bool,
     services: ServiceFlags,
+    time_offset: i64,
     user_agent: String,
     messages: u64,
     start_time: Instant,
@@ -653,6 +656,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                             blocks: self.current_best_block.unsigned_abs(),
                             address_id: self.address.id,
                             services: self.services,
+                            time_offset: self.time_offset,
                             kind: self.kind,
                             transport_protocol: self.transport_protocol,
                         }),
@@ -729,6 +733,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             last_addrv2: Instant::now() - ADDRV2_MESSAGE_INTERVAL,
             node_tx,
             services: ServiceFlags::NONE,
+            time_offset: 0,
             messages: 0,
             start_time: Instant::now(),
             user_agent: "".into(),
@@ -755,6 +760,11 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
     }
 
     async fn handle_version(&mut self, version: VersionMessage) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should not be before UNIX epoch")
+            .as_secs() as i64;
+        self.time_offset = version.timestamp.saturating_sub(now);
         self.user_agent = version.user_agent;
         self.blocks_only = !version.relay;
         self.current_best_block = version.start_height;
@@ -854,6 +864,7 @@ pub struct Version {
     pub id: u32,
     pub address_id: usize,
     pub services: ServiceFlags,
+    pub time_offset: i64,
     pub kind: ConnectionKind,
     pub transport_protocol: TransportProtocol,
 }
@@ -974,6 +985,7 @@ mod tests {
             mempool: Arc::new(Mutex::new(Mempool::new(1000))),
             node_tx,
             services: ServiceFlags::NONE,
+            time_offset: 0,
             messages: 0,
             shutdown: false,
             last_ping: Some(Instant::now()),

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -82,6 +82,7 @@ impl SimulatedPeer {
                 | service_flags::UTREEXO_ARCHIVE.into()
                 | ServiceFlags::WITNESS
                 | ServiceFlags::COMPACT_FILTERS,
+            time_offset: 0,
             kind: ConnectionKind::Regular(service_flags::UTREEXO.into()),
             transport_protocol: TransportProtocol::V2,
         };
@@ -179,6 +180,7 @@ pub fn create_peer(
         services: service_flags::UTREEXO.into(),
         user_agent: "/utreexo:0.1.0/".to_string(),
         height: 0,
+        time_offset: 0,
         state: PeerStatus::Ready,
         channel: sender,
         kind: ConnectionKind::Regular(service_flags::UTREEXO.into()),

--- a/doc/rpc/getpeerinfo.md
+++ b/doc/rpc/getpeerinfo.md
@@ -31,10 +31,16 @@ Returns a JSON array of objects, each representing a connected peer with the fol
 - `address` - (string) The network address and port for this peer (e.g., "192.168.1.5:8333"). This helps identify where the connection is established.
 - `services` - (string) A 16-character hexadecimal bitfield with the services this peer advertises (e.g., "0000000000000c09"). This indicates what capabilities the peer supports and what data we can request from them.
 - `servicesnames` - (array of strings) Human-readable names for the recognized services this peer advertises (e.g., "NETWORK", "WITNESS", "P2P_V2"). Unknown service bits are still represented in `services`.
+- `relaytxes` - (boolean) Whether mempool transaction relay is enabled with this peer. Always `false` in Floresta, since Floresta does not implement mempool transaction relay.
 - `user_agent` - (string) The User Agent string representing the client software and version being used by the peer (e.g., `/Satoshi-26.0/`). Useful for identifying the software distribution on the network.
+- `inbound` - (boolean) Whether this peer connection is inbound. Always `false` in Floresta, since Floresta does not accept inbound P2P connections.
+- `bip152_hb_to` - (boolean) Whether we selected this peer as a BIP152 high-bandwidth compact block relay peer. Always `false` in Floresta, since this relay mode is not implemented.
+- `bip152_hb_from` - (boolean) Whether this peer selected us as a BIP152 high-bandwidth compact block relay peer. Always `false` in Floresta, since this relay mode is not implemented.
 - `initial_height` - (numeric) The block height this peer reported when the connection was first established. This may differ from the current chain tip if the peer has not announced new blocks since connecting.
+- `timeoffset` - (numeric) The peer time offset in seconds, computed from the peer's version message timestamp.
 - `kind` - (string) The connection type of this peer. Possible values are "feeler" (short-lived connections to test address validity), "regular" (standard persistent P2P connection), "extra", or "manual".
 - `state` - (string) The current state of this peer. Can be "Ready" (fully handshaked and active), "Awaiting" (still establishing connection), or "Banned" (connection rejected/dropped).
+- `permissions` - (array of strings) Special permissions granted to this peer. Always empty in Floresta, since Floresta does not implement Bitcoin Core's peer permission system.
 - `transport_protocol` - (string) The transport protocol used to communicate with the peer (e.g., "V1" or "V2").
 
 ### Error Enum

--- a/tests/floresta-cli/getpeerinfo.py
+++ b/tests/floresta-cli/getpeerinfo.py
@@ -29,3 +29,10 @@ def test_peer_info(florestad_node, bitcoind_node, node_manager):
 
     peer_info = result[0]
     assert_bitcoind_service_fields(peer_info)
+    assert peer_info["relaytxes"] is False
+    assert peer_info["inbound"] is False
+    assert peer_info["bip152_hb_to"] is False
+    assert peer_info["bip152_hb_from"] is False
+    assert isinstance(peer_info["timeoffset"], int)
+    assert abs(peer_info["timeoffset"]) < 60
+    assert peer_info["permissions"] == []


### PR DESCRIPTION
### Description and Notes

Adds a small set of Bitcoin Core-compatible `getpeerinfo` fields that Floresta can expose from its current handshake state.

This PR:
- adds `relaytxes`, `inbound`, `bip152_hb_to`, `bip152_hb_from`, `timeoffset`, and `permissions`;
- returns explicit neutral values for fields tied to functionality Floresta does not currently implement;
- keeps the server and client `PeerInfo` schemas aligned;
- updates the `getpeerinfo` RPC documentation;
- extends the CLI functional test.

`timeoffset` is computed as `peer_time - our_time` during the version handshake. Thanks @Micah-Shallom for pointing this out in review.

The hardcoded values are intentional:
- `relaytxes` is `false` because Floresta does not implement mempool transaction relay;
- `inbound` is `false` because Floresta does not accept inbound P2P connections;
- `bip152_hb_to` and `bip152_hb_from` are `false` because BIP152 high-bandwidth compact block relay is not implemented;
- `permissions` is `[]` because Floresta does not implement Bitcoin Core's peer permission system.

This addresses part of #622.

`addr_relay_enabled` is intentionally left out because Floresta does not currently track address-relay state per peer. That field can be handled later if/when the node tracks it explicitly.

Note: this overlaps with #1161 in `getpeerinfo` response shape/docs, but the changes are independent. If #1161 lands first, this branch can be rebased and the small conflicts resolved there.

### How to verify the changes you have done?

Locally ran:

```bash
cargo +nightly fmt --all -- --check
uv run black --check tests/floresta-cli/getpeerinfo.py
cargo check -p floresta-wire -p floresta-rpc
cargo build -p florestad
cargo test -p floresta-wire -p floresta-rpc --lib
cargo +nightly clippy -p floresta-wire -p floresta-rpc --all-targets -- -D warnings
just test-functional-prepare
bash tests/run.sh tests/floresta-cli/getpeerinfo.py
```

Also tested CI on my fork: https://github.com/octaviolucca/Floresta/pull/3

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Confirmed CI passed on my fork: https://github.com/octaviolucca/Floresta/pull/3
- [x] I've linked any related issue(s) in the sections above
