### PR TITLE
Add heavy marker for tests and implement option

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           tests/run.sh
 
+      - name: Run expensive functional tests tasks
+        run: |
+          tests/run.sh -n 1 --run-expensive ./tests/expensive
+
       - name: Log tests on failure
         if: failure()
         run: |

--- a/justfile
+++ b/justfile
@@ -57,6 +57,10 @@ test-functional-prepare arg="":
 test-functional-run arg="":
     bash tests/run.sh {{ arg }}
 
+# Execute tests/run.sh -n 1 --run-expensive ./tests/expensive
+test-expensive-functional-run:
+    bash tests/run.sh -n 1 --run-expensive ./tests/expensive
+
 # Format and lint functional tests
 test-functional-uv-fmt:
     @just check-command uv test-functional-uv-fmt "https://docs.astral.sh/uv/getting-started/installation/"
@@ -67,6 +71,7 @@ test-functional-uv-fmt:
 test-functional:
     @just test-functional-prepare
     @just test-functional-run
+    @just test-expensive-functional-run
 
 # Run the benchmarks
 bench:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ markers = [
     "florestad: marks tests specific to the Florestad daemon",
     "rpc: marks tests focused on RPC calls",
     "p2p: marks tests related to peer-to-peer interactions",
+    "expensive: marks heavy-weight tests that only run when --run-expensive is passed",
 ]
 
 minversion = "9.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,29 @@ from test_framework.node import Node, NodeType
 from test_framework.util import Utility
 
 
+def pytest_addoption(parser):
+    """Register custom pytest command-line options used by this test suite."""
+    parser.addoption(
+        "--run-expensive",
+        action="store_true",
+        default=False,
+        help="Run tests marked with the expensive marker",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip expensive-marked tests unless the dedicated opt-in flag is enabled."""
+    if config.getoption("--run-expensive"):
+        return
+
+    skip_expensive = pytest.mark.skip(
+        reason="need --run-expensive to run expensive tests"
+    )
+    for item in items:
+        if "expensive" in item.keywords:
+            item.add_marker(skip_expensive)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def validate_and_check_environment():
     """Validate environment and check for required binaries before running tests."""

--- a/tests/expensive/p2p_resilience.py
+++ b/tests/expensive/p2p_resilience.py
@@ -74,7 +74,7 @@ class TestP2pResilience:
     p2p_conn_v1 = None
     p2p_conn_v2 = None
 
-    @pytest.mark.p2p
+    @pytest.mark.expensive
     def test_oversized_messages_disconnection(
         self, setup_logging, node_manager, florestad_node
     ):
@@ -154,7 +154,7 @@ class TestP2pResilience:
             self.p2p_conn_v2.send_without_ping(msg)
             self.check_disconnection(self.p2p_conn_v2)
 
-    @pytest.mark.p2p
+    @pytest.mark.expensive
     def test_spam_rate_limiting(self, setup_logging, node_manager, florestad_node):
         """
         Test message spam protection and rate limit enforcement.


### PR DESCRIPTION
### Description and Notes

Introduce a `heavy` marker for functional tests.

This marker is used for heavy-specific tests, such as IBD and P2P resilience tests. These tests are usually more expensive and take significantly longer to execute, so they are separated from the regular functional test suite.

By default, heavy tests are skipped and can be executed explicitly when needed.

To run only the regular functional tests:

```bash
./tests/run.sh
```

To run functional tests including security tests:

```bash
./tests/run.sh --run-heavy
```

### How to verify the changes you have done?

1. Run:

   ```bash
   ./tests/run.sh
   ```

   Verify that security tests are not executed.

2. Run:

   ```bash
   ./tests/run.sh --run-heavy
   ```

   Verify that heavy tests are executed along with the regular functional tests.
