### PR TITLE
Improve get_roots test with utreexod node

### DIFF
--- a/tests/floresta-cli/getroots.py
+++ b/tests/floresta-cli/getroots.py
@@ -8,11 +8,22 @@ This functional test cli utility to interact with a Floresta node with `getroots
 
 import pytest
 
+BLOCKS_TO_MINE = 101
+
 
 @pytest.mark.rpc
-def test_get_roots(florestad_node):
+def test_get_roots(node_manager, florestad_utreexod):
     """
     Test the `get_roots` RPC method.
     """
-    vec_hashes = florestad_node.rpc.get_roots()
+    florestad, utreexod = florestad_utreexod
+    vec_hashes = florestad.rpc.get_roots()
     assert len(vec_hashes) == 0
+
+    utreexod.rpc.generate(BLOCKS_TO_MINE)
+    node_manager.wait_for_sync_nodes()
+
+    assert (
+        florestad.rpc.get_roots()
+        == utreexod.rpc.get_utreexo_roots(utreexod.rpc.get_bestblockhash())["roots"]
+    ), "Roots from florestad and utreexod do not match"


### PR DESCRIPTION
### Description and Notes

Improve the `get_roots` integration test by adding an `utreexod` node as a reference implementation.

The test now uses `node_manager` to manage multiple nodes and starts an `utreexod` instance alongside `florestad`. The `utreexod` node mines blocks, while `florestad` syncs the chain and compares its `get_roots` RPC result against `utreexod`'s `get_utreexo_roots`.

This validates that `florestad` correctly computes and exposes Utreexo roots by comparing against a reference implementation instead of only checking the empty state.

Close #798

### How to verify the changes you have done?

Run the integration test:

```bash "
./tests/run.sh ./tests/floresta-cli/getroots.py
```
