### PR TITLE
fix(wire): don't panic when a peer is unresponsive during fork resolution

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -615,6 +615,23 @@ where
         candidate_accs.retain(|acc| !invalid_accs.contains(&acc.1));
         //we should have only one candidate left
         if candidate_accs.len() != 1 {
+            // No single trusted candidate remains (e.g. we might be eclipsed). If the user
+            // configured an assumeutreexo checkpoint, fall back to it instead of bailing out,
+            // mirroring the fallback in `empty_headers_message`.
+            if let Some(assume_utreexo) = self.common.config.assume_utreexo.as_ref() {
+                info!(
+                    "Could not find a single trusted accumulator candidate; falling back to \
+                     assumeutreexo checkpoint at height={} tip={}",
+                    assume_utreexo.height, assume_utreexo.block_hash
+                );
+                let acc = Stump {
+                    leaves: assume_utreexo.leaves,
+                    roots: assume_utreexo.roots.clone(),
+                };
+                self.chain
+                    .mark_chain_as_assumed(acc.clone(), assume_utreexo.block_hash)?;
+                return Ok(acc);
+            }
             return Err(WireError::PeerTimeout);
         }
 

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -589,10 +589,18 @@ where
                 }
                 PeerCheck::UnresponsivePeer(dead_peer) => {
                     self.disconnect_and_ban(dead_peer)?;
+                    if dead_peer == peer1 {
+                        invalid_accs.insert(peer[0].1.clone());
+                    } else {
+                        invalid_accs.insert(peer[1].1.clone());
+                    }
                 }
                 PeerCheck::BothUnresponsivePeers => {
                     self.disconnect_and_ban(peer1)?;
                     self.disconnect_and_ban(peer2)?;
+
+                    invalid_accs.insert(peer[0].1.clone());
+                    invalid_accs.insert(peer[1].1.clone());
                 }
                 PeerCheck::BothLying => {
                     self.disconnect_and_ban(peer1)?;
@@ -606,7 +614,9 @@ where
         //filter out the invalid accs
         candidate_accs.retain(|acc| !invalid_accs.contains(&acc.1));
         //we should have only one candidate left
-        assert_eq!(candidate_accs.len(), 1);
+        if candidate_accs.len() != 1 {
+            return Err(WireError::PeerTimeout);
+        }
 
         Self::parse_acc(&candidate_accs.pop().unwrap().1)
     }


### PR DESCRIPTION
### Description and Notes

An unresponsive peer during PoW fraud-proof fork resolution left its stale candidate accumulator in `candidate_accs`, since only lying peers (`OneLying`/`BothLying`) were added to `invalid_accs` — the `UnresponsivePeer`/`BothUnresponsivePeers` arms disconnected/banned the peer but never marked its accumulator invalid. This made `assert_eq!(candidate_accs.len(), 1)` panic on an ordinary 60s peer timeout instead of returning a `WireError`.

This PR makes the `UnresponsivePeer`/`BothUnresponsivePeers` arms insert their accumulator(s) into `invalid_accs` the same way the lying-peer arms already do, and replaces the `assert_eq!` with a proper `WireError::PeerTimeout` return for the case the invariant still doesn't hold.

Fixes #1240

### How to verify the changes you have done?

`cargo test -p floresta-wire` — all 46 tests pass, including the existing `chain_selector` tests (`two_peers_one_lying`, `ten_peers_one_honest`).

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] Ran `cargo check -p floresta-wire` and `cargo test -p floresta-wire` — clean, 0 warnings, all tests pass
- [x] Linked related issue: Fixes #1240
