### PR TITLE
fix(rpc): addnode now returns the actual error instead of always reporting success

### DIFF
--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -63,12 +63,15 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         let address =
             BitcoinSocketAddr::parse_address(&address, Some(self.network), SystemResolver)?;
 
-        let _ = match command.as_str() {
+        let result = match command.as_str() {
             "add" => self.node.add_peer(address, v2transport).await,
             "remove" => self.node.remove_peer(address).await,
             "onetry" => self.node.onetry_peer(address, v2transport).await,
             _ => return Err(JsonRpcError::InvalidAddnodeCommand),
-        };
+        }
+        .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+        result.map_err(|e| JsonRpcError::Node(e.to_string()))?;
 
         Ok(json!(null))
     }

--- a/crates/floresta-wire/src/p2p_wire/node/user_req.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/user_req.rs
@@ -100,11 +100,11 @@ where
                 let node_response = match self.handle_addnode_add_peer(addr.clone(), v2transport) {
                     Ok(_) => {
                         info!("Added peer {addr}");
-                        NodeResponse::Add(true)
+                        NodeResponse::Add(Ok(()))
                     }
                     Err(err) => {
                         warn!("{err:?}");
-                        NodeResponse::Add(false)
+                        NodeResponse::Add(Err(err))
                     }
                 };
 
@@ -116,11 +116,11 @@ where
                 let node_response = match self.handle_addnode_remove_peer(addr.clone()) {
                     Ok(_) => {
                         info!("Removed peer {addr}");
-                        NodeResponse::Remove(true)
+                        NodeResponse::Remove(Ok(()))
                     }
                     Err(err) => {
                         warn!("{err:?}");
-                        NodeResponse::Remove(false)
+                        NodeResponse::Remove(Err(err))
                     }
                 };
 
@@ -133,11 +133,11 @@ where
                 {
                     Ok(_) => {
                         info!("Connected to peer {addr}");
-                        NodeResponse::Onetry(true)
+                        NodeResponse::Onetry(Ok(()))
                     }
                     Err(err) => {
                         warn!("{err:?}");
-                        NodeResponse::Onetry(false)
+                        NodeResponse::Onetry(Err(err))
                     }
                 };
 

--- a/crates/floresta-wire/src/p2p_wire/node_handle.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_handle.rs
@@ -36,6 +36,7 @@ use crate::node_interface::MempoolMethods;
 use crate::node_interface::NetworkMethods;
 use crate::node_interface::NodeConfigMethods;
 use crate::node_interface::PeerInfo;
+use crate::p2p_wire::error::WireError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// A request that can be made to the node.
@@ -133,16 +134,16 @@ pub enum NodeResponse {
     GetConnectionCount(usize),
 
     /// A response indicating whether a peer was successfully added.
-    Add(bool),
+    Add(Result<(), WireError>),
 
     /// A response indicating whether a peer was successfully removed.
-    Remove(bool),
+    Remove(Result<(), WireError>),
 
     // A response indicating whether a peer was successfully disconnected from.
     Disconnect(bool),
 
     /// A response indicating whether a peer was successfully connected once.
-    Onetry(bool),
+    Onetry(Result<(), WireError>),
 
     /// A response indicating whether the ping was successful.
     Ping(bool),
@@ -255,7 +256,7 @@ impl NetworkMethods for NodeHandle {
         &self,
         addr: BitcoinSocketAddr,
         v2transport: bool,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<Result<(), WireError>, Self::Error> {
         let val = self
             .send_request(UserRequest::Add((addr, v2transport)))
             .await?;
@@ -263,7 +264,10 @@ impl NetworkMethods for NodeHandle {
         extract_variant!(Add, val);
     }
 
-    async fn remove_peer(&self, addr: BitcoinSocketAddr) -> Result<bool, Self::Error> {
+    async fn remove_peer(
+        &self,
+        addr: BitcoinSocketAddr,
+    ) -> Result<Result<(), WireError>, Self::Error> {
         let val = self.send_request(UserRequest::Remove(addr)).await?;
         extract_variant!(Remove, val);
     }
@@ -278,7 +282,7 @@ impl NetworkMethods for NodeHandle {
         &self,
         addr: BitcoinSocketAddr,
         v2transport: bool,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<Result<(), WireError>, Self::Error> {
         let val = self
             .send_request(UserRequest::Onetry((addr, v2transport)))
             .await?;

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -31,6 +31,7 @@ use super::node::PeerStatus;
 use super::transport::TransportProtocol;
 use crate::address_man::ConnectionStats;
 use crate::bitcoin_socket_addr::BitcoinSocketAddr;
+use crate::p2p_wire::error::WireError;
 
 #[derive(Debug, Clone, Serialize)]
 /// A struct representing a peer connected to the node.
@@ -102,21 +103,21 @@ pub trait NetworkMethods {
     type Error: core::error::Error;
 
     /// Connects to a specified address and port.
-    /// This function will return a boolean indicating whether the connection was successful. It
-    /// may be called multiple times, and may use hostnames or IP addresses.
+    /// Returns `Ok(Ok(()))` if the peer was added, or `Ok(Err(WireError))` describing why it
+    /// wasn't (e.g. already added). May be called multiple times, and may use hostnames or IPs.
     fn add_peer(
         &self,
         addr: BitcoinSocketAddr,
         v2transport: bool,
-    ) -> impl Future<Output = Result<bool, Self::Error>>;
+    ) -> impl Future<Output = Result<Result<(), WireError>, Self::Error>>;
 
     /// Removes a peer from the node's peer list.
-    /// This function will return a boolean indicating whether the peer was successfully removed.
-    /// It may be called multiple times, and may use hostnames or IP addresses.
+    /// Returns `Ok(Ok(()))` if the peer was removed, or `Ok(Err(WireError))` describing why it
+    /// wasn't (e.g. not found). May be called multiple times, and may use hostnames or IPs.
     fn remove_peer(
         &self,
         addr: BitcoinSocketAddr,
-    ) -> impl Future<Output = Result<bool, Self::Error>>;
+    ) -> impl Future<Output = Result<Result<(), WireError>, Self::Error>>;
 
     /// Immediately disconnect from a peer.
     ///
@@ -129,13 +130,13 @@ pub trait NetworkMethods {
     /// Attempts to connect to a peer once.
     ///
     /// This function will try to connect to the peer once, but will not add it to the node's
-    /// peer list. It will return a boolean indicating whether the connection was successful.
-    /// It may be called multiple times, and may use hostnames or IP addresses.
+    /// peer list. Returns `Ok(Ok(()))` on success, or `Ok(Err(WireError))` describing why the
+    /// attempt failed. May be called multiple times, and may use hostnames or IP addresses.
     fn onetry_peer(
         &self,
         addr: BitcoinSocketAddr,
         v2transport: bool,
-    ) -> impl Future<Output = Result<bool, Self::Error>>;
+    ) -> impl Future<Output = Result<Result<(), WireError>, Self::Error>>;
 
     /// Gets information about all connected peers.
     ///

--- a/tests/floresta-cli/addnode.py
+++ b/tests/floresta-cli/addnode.py
@@ -5,6 +5,7 @@
 import pytest
 
 from test_framework.node import NodeType
+from test_framework.rpc.exceptions import JSONRPCError
 
 
 @pytest.mark.rpc
@@ -101,10 +102,11 @@ class AddNodeTest:
         self.verify_peer_connection_state(is_connected=True)
 
         self.log.info(
-            "===== Verify Floresta does not add the same persistent peer twice"
+            "===== Verify Floresta rejects re-adding the same persistent peer"
         )
-        self.floresta_addnode_with_command("add")
-        # This function expects 1 peer connected to florestad
+        with pytest.raises(JSONRPCError):
+            self.floresta_addnode_with_command("add")
+        # Nothing should have changed: still only 1 peer connected
         self.verify_peer_connection_state(is_connected=True)
 
         self.floresta_addnode_with_command("onetry")
@@ -131,3 +133,17 @@ class AddNodeTest:
 
         self.node_manager.run_node(self.bitcoind)
         self.verify_peer_connection_state(is_connected=False)
+
+
+@pytest.mark.rpc
+def test_add_node_remove_unknown_peer_fails(
+    setup_logging, node_manager, florestad_node, add_node_with_extra_args
+):
+    """`addnode remove` on a peer that was never added should return an error,
+    not silently report success."""
+    log = setup_logging
+    bitcoind = add_node_with_extra_args(NodeType.BITCOIND, ["-v2transport=0"])
+
+    log.info("===== 'remove' on a peer that was never added should fail")
+    with pytest.raises(JSONRPCError):
+        node_manager.connect_nodes(florestad_node, bitcoind, "remove", False)

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -186,17 +186,15 @@ class BaseRPC(ABC):
         self.log.debug(self.log_msg(logmsg))
 
         resp = self.noraise_request(method, params)
-
-        if resp["status_code"] != 200:
-            self.log.error(
-                f"RPC request failed with status code {resp['status_code']}: {resp['body']}"
-            )
-            raise HTTPError
-
         result = resp["body"]
+
         # Error could be None or a str
         # If in the future this change,
         # cast the resulted error to str
+        #
+        # The server may return a non-200 HTTP status alongside a JSON-RPC error
+        # body (see `http_code()` on the Rust side), so check for a JSON-RPC error
+        # in the body before falling back to a generic HTTP-level failure.
         if "error" in result and result["error"] is not None:
             raise JSONRPCError(
                 data=result["error"] if isinstance(result["error"], str) else None,
@@ -204,6 +202,12 @@ class BaseRPC(ABC):
                 code=result["error"]["code"],
                 message=result["error"]["message"],
             )
+
+        if resp["status_code"] != 200:
+            self.log.error(
+                f"RPC request failed with status code {resp['status_code']}: {resp['body']}"
+            )
+            raise HTTPError
 
         self.log.debug(self.log_msg(result["result"]))
         return result["result"]


### PR DESCRIPTION
## Description

`addnode` (`add`/`remove`/`onetry`) always returned `null` (success), even
when the peer operation actually failed. The node knew the real outcome
(`add_peer`/`remove_peer`/`onetry_peer` returned a `bool`), but the RPC
handler discarded it.

This PR makes `addnode` check the result and return an error on failure.
Per maintainer feedback on the issue, it propagates the actual underlying
`WireError` (e.g. "Peer already exists") rather than a generic per-command
error.

## Changes

- `node_interface.rs` / `node_handle.rs` / `user_req.rs`: `add_peer`,
  `remove_peer`, `onetry_peer` now return `Result<(), WireError>` instead
  of `bool`, preserving the real failure reason. (`disconnect_peer`
  untouched already correct.)
- `json_rpc/network.rs`: `add_node` now returns an error instead of
  always `Ok(null)`.
- `tests/floresta-cli/addnode.py`: updated to expect an error on
  re-adding an already-connected peer; added a test for `remove` on an
  unknown peer.
- `tests/test_framework/rpc/base.py`: fixed a pre-existing test-client bug
  found while testing this it raised a generic `HTTPError` before
  checking the JSON-RPC error body, silently blocking error-path testing
  for any RPC method with a non-200 status, not just `addnode`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p floresta-wire -p floresta-node`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [ ] `tests/floresta-cli/addnode.py` functional test hit an
      unresolved local WSL environment issue; flagging for CI/maintainer
      to confirm in a clean environment.
      
    

Fixes #1239.
