### PR TITLE
feat(consensus): enforce BIP68 relative lock-time during block validation

### DIFF
--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -7,10 +7,12 @@ use core::fmt::Formatter;
 
 use bitcoin::Block;
 use bitcoin::BlockHash;
+use bitcoin::Transaction;
 use bitcoin::Work;
 use bitcoin::block::Header;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::hashes::Hash;
+use bitcoin::transaction::Version;
 use floresta_common::bhash;
 use floresta_common::prelude::Box;
 use floresta_common::prelude::String;
@@ -37,6 +39,25 @@ impl Bip30UnspendableExt for Block {
             91812 => self.block_hash() == bhash_91812,
             _ => false,
         }
+    }
+}
+
+/// Provides additional methods for working with [`Transaction`] objects,
+pub trait TransactionExt {
+    /// Returns whether this transaction's version enforces BIP68 relative lock-time semantics.
+    ///
+    /// BIP68 only applies to version >= 2 transactions.
+    fn is_enforce_bip68(&self) -> bool;
+}
+
+impl TransactionExt for Transaction {
+    fn is_enforce_bip68(&self) -> bool {
+        // Bitcoin Core treats nVersion as a uint32_t (bitcoin/bitcoin#29325), but rust-bitcoin's
+        // `Version` still wraps an i32, so a signed comparison here would misclassify versions
+        // whose top bit is set (they'd read as negative and wrongly skip the BIP68 check).
+        // Cast to u32 on both sides to compare using the actual consensus semantics.
+        // TODO(jaoleal): remove this cast when https://github.com/rust-bitcoin/rust-bitcoin/pull/4040 lands in a release.
+        self.version.0 as u32 >= Version::TWO.0 as u32
     }
 }
 
@@ -315,6 +336,7 @@ mod tests {
     use bitcoin::OutPoint;
     use bitcoin::Transaction;
     use bitcoin::Txid;
+    use bitcoin::absolute::LockTime;
     use bitcoin::block::Header;
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::hashes::sha256::Hash as Sha256Hash;
@@ -404,6 +426,13 @@ mod tests {
             }
 
             Ok(hash)
+        }
+
+        fn get_mtp_by_height(&self, height: u32) -> Result<u32, Self::Error> {
+            let hash = self.get_block_hash(height)?;
+            let header = self.get_block_header(&hash)?;
+
+            header.median_time_past_with(|current| self.get_block_header(&current.prev_blockhash))
         }
 
         fn get_block_height(&self, hash: &BlockHash) -> Result<Option<u32>, Self::Error> {
@@ -1006,5 +1035,30 @@ mod tests {
             work.to_string_hex(),
             "0000000300000001000000000000000200000000000000030000000000000004"
         );
+    }
+
+    fn tx_with_version(version: Version) -> Transaction {
+        Transaction {
+            version,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_is_enforce_bip68() {
+        assert!(!tx_with_version(Version::ONE).is_enforce_bip68());
+        assert!(tx_with_version(Version::TWO).is_enforce_bip68());
+        assert!(tx_with_version(Version::non_standard(3)).is_enforce_bip68());
+    }
+
+    #[test]
+    fn test_is_enforce_bip68_unsigned_comparison() {
+        // A version whose top bit is set reads as negative in rust-bitcoin's i32-backed
+        // `Version`, but Bitcoin Core treats nVersion as a uint32_t, so this must still
+        // enforce BIP68 (see the TODO on `TransactionExt::is_enforce_bip68`).
+        let high_bit_version = Version::non_standard(-1);
+        assert!(tx_with_version(high_bit_version).is_enforce_bip68());
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1071,6 +1071,11 @@ impl<PersistedState: ChainStore> BlockchainInterface for ChainState<PersistedSta
         Ok(read_lock!(self).chainstore.size_on_disk()?)
     }
 
+    fn get_mtp_by_height(&self, height: u32) -> Result<u32, Self::Error> {
+        let header = *self.get_header_by_height(height)?;
+        self.median_time_past(header)
+    }
+
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error> {
         let fork_point = self.find_fork_point(&self.get_block_header(&block)?)?;
         Ok(fork_point.block_hash())

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -24,6 +24,9 @@ use bitcoin::blockdata::Weight;
 use bitcoin::consensus::serialize;
 use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256;
+use bitcoin::locktime::relative;
+use bitcoin::locktime::relative::Height;
+use bitcoin::locktime::relative::Time;
 use bitcoin::script;
 #[cfg(feature = "bitcoinkernel")]
 use bitcoinkernel::PrecomputedTransactionData;
@@ -41,6 +44,7 @@ use super::error::BlockchainError;
 use super::udata;
 use crate::TransactionError;
 use crate::extensions::Bip30UnspendableExt;
+use crate::extensions::TransactionExt;
 use crate::pruned_utreexo::utxo_data::UtxoData;
 use crate::swift_sync_agg::SipHashKeys;
 use crate::swift_sync_agg::TxidHashMidstate;
@@ -100,6 +104,56 @@ impl From<Network> for Consensus {
     }
 }
 
+/// The lock-time cutoff for a candidate block: before CSV/BIP113 activation this is the
+/// block's own header time, and after activation it is the previous block's Median Time
+/// Past (MTP). Used to check both BIP113 (absolute lock-time) and BIP68 (relative
+/// lock-time) transaction finality.
+///
+/// BIP68 only applies once CSV has activated: Bitcoin Core only enforces relative
+/// lock-times once CSV is active, since before that `nSequence` had different
+/// (RBF-signaling) semantics. The `Mtp` variant implies BIP68 is enforced; `HeaderTime`
+/// implies it isn't.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockTimeCutoff {
+    /// Pre-CSV-activation: the candidate block's own header time.
+    HeaderTime(u32),
+    /// Post-CSV-activation: the previous block's Median Time Past.
+    Mtp(u32),
+}
+
+impl LockTimeCutoff {
+    /// Returns the cutoff value, regardless of variant. Used for the BIP113 check, which
+    /// applies at every height, just against a different cutoff before/after activation.
+    fn value(self) -> u32 {
+        match self {
+            Self::HeaderTime(value) | Self::Mtp(value) => value,
+        }
+    }
+
+    /// Returns whether a BIP68 relative `lock` is satisfied, given the number of blocks
+    /// elapsed since the spent UTXO's creation height and the UTXO's creation time.
+    ///
+    /// Always satisfied before CSV activation, since BIP68 isn't enforced yet.
+    fn relative_locktime_satisfied(
+        self,
+        lock: relative::LockTime,
+        elapsed_height: u32,
+        creation_time: u32,
+    ) -> bool {
+        let Self::Mtp(value) = self else {
+            return true;
+        };
+
+        let elapsed_intervals = value.saturating_sub(creation_time) / 512;
+
+        let h = Height::from(u16::try_from(elapsed_height).unwrap_or(u16::MAX));
+        let t =
+            Time::from_512_second_intervals(u16::try_from(elapsed_intervals).unwrap_or(u16::MAX));
+
+        lock.is_satisfied_by(h, t)
+    }
+}
+
 impl Consensus {
     /// Returns the block-finality lock-time cutoff for a candidate block.
     ///
@@ -110,11 +164,11 @@ impl Consensus {
         height: u32,
         header: &BlockHeader,
         previous_median_time_past: impl FnOnce() -> Result<u32, E>,
-    ) -> Result<u32, E> {
+    ) -> Result<LockTimeCutoff, E> {
         if height >= self.parameters.csv_activation_height {
-            previous_median_time_past()
+            previous_median_time_past().map(LockTimeCutoff::Mtp)
         } else {
-            Ok(header.time)
+            Ok(LockTimeCutoff::HeaderTime(header.time))
         }
     }
 
@@ -186,7 +240,7 @@ impl Consensus {
     #[allow(unused)]
     pub fn verify_block_transactions(
         height: u32,
-        lock_time_cutoff: u32,
+        lock_time_cutoff: LockTimeCutoff,
         mut utxos: HashMap<OutPoint, UtxoData>,
         transactions: &[Transaction],
         subsidy: Amount,
@@ -216,8 +270,14 @@ impl Consensus {
             }
 
             // Actually verify the transaction
-            let (in_value, out_value) =
-                Self::verify_transaction(transaction, &mut utxos, height, verify_script, flags)?;
+            let (in_value, out_value) = Self::verify_transaction(
+                transaction,
+                &mut utxos,
+                height,
+                lock_time_cutoff,
+                verify_script,
+                flags,
+            )?;
 
             // Fee is the difference between inputs and outputs. In the above function call we have
             // verified that `out_value <= in_value` (no underflow risk).
@@ -382,6 +442,7 @@ impl Consensus {
         transaction: &Transaction,
         utxos: &mut HashMap<OutPoint, UtxoData>,
         height: u32,
+        lock_time_cutoff: LockTimeCutoff,
         _verify_script: bool,
         _flags: u32,
     ) -> Result<(Amount, Amount), BlockchainError> {
@@ -401,6 +462,22 @@ impl Consensus {
             // A coinbase output created at height n can only be spent at height >= n + 100
             if utxo.is_coinbase && (height < utxo.creation_height + 100) {
                 Err(tx_err!(txid, CoinbaseNotMatured))?;
+            }
+
+            // BIP68: relative lock-time only applies to version >= 2 transactions, and only
+            // to inputs whose sequence number doesn't have the disable flag set.
+            if transaction.is_enforce_bip68() {
+                if let Some(lock) = input.sequence.to_relative_lock_time() {
+                    let elapsed_height = height.saturating_sub(utxo.creation_height);
+
+                    if !lock_time_cutoff.relative_locktime_satisfied(
+                        lock,
+                        elapsed_height,
+                        utxo.creation_time,
+                    ) {
+                        Err(tx_err!(txid, BadRelativeLockTime))?;
+                    }
+                }
             }
 
             // Check script sizes (spent txo pubkey, inputs are covered already)
@@ -646,7 +723,11 @@ impl Consensus {
     ///
     /// Mirrors Bitcoin Core's IsFinalTx:
     /// <https://github.com/bitcoin/bitcoin/blob/v31.0/src/consensus/tx_verify.cpp#L17-L37>
-    fn is_final_transaction(transaction: &Transaction, height: u32, lock_time_cutoff: u32) -> bool {
+    fn is_final_transaction(
+        transaction: &Transaction,
+        height: u32,
+        lock_time_cutoff: LockTimeCutoff,
+    ) -> bool {
         if transaction.lock_time == absolute::LockTime::ZERO {
             return true;
         }
@@ -654,7 +735,7 @@ impl Consensus {
         let lock_time_reached = match transaction.lock_time {
             absolute::LockTime::Blocks(lock_height) => lock_height.to_consensus_u32() < height,
             absolute::LockTime::Seconds(lock_time) => {
-                lock_time.to_consensus_u32() < lock_time_cutoff
+                lock_time.to_consensus_u32() < lock_time_cutoff.value()
             }
         };
 
@@ -1097,12 +1178,12 @@ mod tests {
         assert!(Consensus::is_final_transaction(
             &height_locked,
             ZERO_HEIGHT,
-            ZERO_BLOCK_TIME
+            LockTimeCutoff::Mtp(ZERO_BLOCK_TIME)
         ));
         assert!(Consensus::is_final_transaction(
             &time_locked,
             ZERO_HEIGHT,
-            ZERO_BLOCK_TIME
+            LockTimeCutoff::Mtp(ZERO_BLOCK_TIME)
         ));
     }
 
@@ -1126,17 +1207,17 @@ mod tests {
         assert!(Consensus::is_final_transaction(
             &below_height,
             height,
-            ZERO_BLOCK_TIME
+            LockTimeCutoff::Mtp(ZERO_BLOCK_TIME)
         ));
         assert!(!Consensus::is_final_transaction(
             &at_height,
             height,
-            ZERO_BLOCK_TIME
+            LockTimeCutoff::Mtp(ZERO_BLOCK_TIME)
         ));
         assert!(!Consensus::is_final_transaction(
             &above_height,
             height,
-            ZERO_BLOCK_TIME
+            LockTimeCutoff::Mtp(ZERO_BLOCK_TIME)
         ));
     }
 
@@ -1160,17 +1241,17 @@ mod tests {
         assert!(Consensus::is_final_transaction(
             &below_cutoff,
             ZERO_HEIGHT,
-            cutoff
+            LockTimeCutoff::Mtp(cutoff)
         ));
         assert!(!Consensus::is_final_transaction(
             &at_cutoff,
             ZERO_HEIGHT,
-            cutoff
+            LockTimeCutoff::Mtp(cutoff)
         ));
         assert!(!Consensus::is_final_transaction(
             &above_cutoff,
             ZERO_HEIGHT,
-            cutoff
+            LockTimeCutoff::Mtp(cutoff)
         ));
     }
 
@@ -1440,8 +1521,14 @@ mod tests {
                 },
             );
 
-            let spend_result =
-                Consensus::verify_transaction(spending_tx, &mut utxos, spending_height, true, 0);
+            let spend_result = Consensus::verify_transaction(
+                spending_tx,
+                &mut utxos,
+                spending_height,
+                LockTimeCutoff::Mtp(0),
+                true,
+                0,
+            );
 
             if expected_ok {
                 assert_ok!(spend_result);
@@ -1498,6 +1585,80 @@ mod tests {
     }
 
     #[test]
+    fn test_relative_locktime() {
+        let outpoint = dummy_outpoint();
+        let tx = build_tx(
+            vec![txin!(outpoint, ScriptBuf::new(), Sequence::from_height(10))],
+            vec![txout!(1, ScriptBuf::new())],
+        );
+
+        let mut utxos = HashMap::new();
+        utxos.insert(
+            outpoint,
+            UtxoData {
+                txout: txout!(1, ScriptBuf::new()),
+                is_coinbase: false,
+                creation_height: 100,
+                creation_time: 0,
+            },
+        );
+
+        // 10 blocks have passed since creation: the relative lock-time is satisfied
+        // (script verification is skipped since this test only exercises BIP68, and the
+        // dummy scripts here aren't valid to evaluate)
+        assert_ok!(Consensus::verify_transaction(
+            &tx,
+            &mut utxos.clone(),
+            110,
+            LockTimeCutoff::Mtp(0),
+            false,
+            0
+        ));
+
+        // Only 5 blocks have passed: the relative lock-time is not satisfied
+        let txid = || tx.compute_txid();
+        match Consensus::verify_transaction(&tx, &mut utxos, 105, LockTimeCutoff::Mtp(0), false, 0)
+        {
+            Err(BlockchainError::TransactionError(e)) => {
+                assert_eq!(e, tx_err!(txid, BadRelativeLockTime));
+            }
+            other => panic!("Expected a TransactionError, but got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_relative_locktime_not_enforced_before_csv_activation() {
+        // Same as `test_relative_locktime`'s not-satisfied case (only 5 of the required 10
+        // blocks have passed), but with `bip68_active = false`: before CSV activation,
+        // `nSequence` doesn't carry relative lock-time semantics, so this must pass.
+        let outpoint = dummy_outpoint();
+        let tx = build_tx(
+            vec![txin!(outpoint, ScriptBuf::new(), Sequence::from_height(10))],
+            vec![txout!(1, ScriptBuf::new())],
+        );
+
+        let mut utxos = HashMap::new();
+        utxos.insert(
+            outpoint,
+            UtxoData {
+                txout: txout!(1, ScriptBuf::new()),
+                is_coinbase: false,
+                creation_height: 100,
+                creation_time: 0,
+            },
+        );
+
+        assert_ok!(Consensus::verify_transaction(
+            &tx,
+            &mut utxos,
+            105,
+            LockTimeCutoff::HeaderTime(0),
+            false,
+            0
+        ));
+    }
+
+    #[test]
     #[cfg(feature = "bitcoinkernel")]
     fn script_verified_transaction_consumes_inputs() {
         // Transaction extracted from https://learnmeabitcoin.com/explorer/tx/0094492b6f010a5e39c2aacc97396ce9b6082dc733a7b4151ccdbd580f789278
@@ -1523,7 +1684,7 @@ mod tests {
             },
         );
         let flags = bitcoinkernel::VERIFY_P2SH;
-        Consensus::verify_transaction(&tx, &mut utxos, 0, true, flags)
+        Consensus::verify_transaction(&tx, &mut utxos, 0, LockTimeCutoff::Mtp(0), true, flags)
             .expect("Transaction should be valid");
 
         // Script verification uses the transaction-local UTXOs, while the block-wide map retains
@@ -1533,7 +1694,8 @@ mod tests {
         // Trying to verify again with an empty UTXO map must fail with this error
         let expected = tx_err!(txid, UtxoNotFound, outpoint);
 
-        match Consensus::verify_transaction(&tx, &mut utxos, 0, true, flags) {
+        match Consensus::verify_transaction(&tx, &mut utxos, 0, LockTimeCutoff::Mtp(0), true, flags)
+        {
             Err(BlockchainError::TransactionError(e)) => assert_eq!(e, expected),
             other => panic!("Expected TransactionError, got: {other:?}"),
         }
@@ -1557,14 +1719,21 @@ mod tests {
 
         // Block validation carries this scratch map from one transaction to the next, including
         // when script checks are skipped during AssumeValid validation.
-        Consensus::verify_transaction(&first, &mut utxos, 0, false, 0)
+        Consensus::verify_transaction(&first, &mut utxos, 0, LockTimeCutoff::Mtp(0), false, 0)
             .expect("first spend should be valid");
         assert!(utxos.is_empty(), "spent input must leave the UTXO map");
 
         // Trying to verify again with an empty UTXO map must fail with this error
         let expected = tx_err!(|| second.compute_txid(), UtxoNotFound, outpoint);
 
-        match Consensus::verify_transaction(&second, &mut utxos, 0, false, 0) {
+        match Consensus::verify_transaction(
+            &second,
+            &mut utxos,
+            0,
+            LockTimeCutoff::Mtp(0),
+            false,
+            0,
+        ) {
             Err(BlockchainError::TransactionError(e)) => assert_eq!(e, expected),
             other => panic!("Expected TransactionError, got: {other:?}"),
         }
@@ -1642,7 +1811,7 @@ mod tests {
 
         let tx = build_tx(vec![txin!(outpoint)], vec![txout!(1, ScriptBuf::new())]);
 
-        match Consensus::verify_transaction(&tx, &mut utxos, 0, false, 0) {
+        match Consensus::verify_transaction(&tx, &mut utxos, 0, LockTimeCutoff::Mtp(0), false, 0) {
             Err(BlockchainError::BlockValidation(BlockValidationErrors::TooManyCoins)) => (),
             other => panic!("Expected TooManyCoins, got: {other:?}"),
         }
@@ -1699,6 +1868,7 @@ mod tests {
                 &transaction,
                 &mut utxos,
                 dummy_height,
+                LockTimeCutoff::Mtp(0),
                 true,
                 bitcoinkernel::VERIFY_ALL_PRE_TAPROOT,
             );
@@ -1751,8 +1921,15 @@ mod tests {
         let oversized_out = txout!(0, oversized_script());
         let tx_with_oversized = build_tx(vec![dummy_in], vec![oversized_out.clone()]);
 
-        Consensus::verify_transaction(&tx_with_oversized, &mut utxos, dummy_height, false, flags)
-            .unwrap();
+        Consensus::verify_transaction(
+            &tx_with_oversized,
+            &mut utxos,
+            dummy_height,
+            LockTimeCutoff::Mtp(0),
+            false,
+            flags,
+        )
+        .unwrap();
 
         // 2. Register the oversized output as an available UTXO.
         let prevout = OutPoint::new(tx_with_oversized.compute_txid(), 0);
@@ -1769,9 +1946,15 @@ mod tests {
         // 3. Attempt to spend the oversized output.
         let spending_in = txin!(prevout);
         let spending_tx = build_tx(vec![spending_in], vec![txout!(0, true_script())]);
-        let err =
-            Consensus::verify_transaction(&spending_tx, &mut utxos, dummy_height, false, flags)
-                .unwrap_err();
+        let err = Consensus::verify_transaction(
+            &spending_tx,
+            &mut utxos,
+            dummy_height,
+            LockTimeCutoff::Mtp(0),
+            false,
+            flags,
+        )
+        .unwrap_err();
 
         // Check that the error is exactly what we expect.
         match err {

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -147,6 +147,7 @@ pub enum BlockValidationErrors {
     UnspendableUTXO,
     BIP94TimeWarp,
     DuplicateInput,
+    BadRelativeLockTime,
 }
 
 // Helpful macro for generating a TransactionError
@@ -245,6 +246,9 @@ impl Display for BlockValidationErrors {
             }
             Self::DuplicateInput => {
                 write!(f, "This transaction has duplicate inputs")
+            }
+            Self::BadRelativeLockTime => {
+                write!(f, "Input's relative lock-time (BIP68) has not matured yet")
             }
         }
     }

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -168,6 +168,10 @@ pub trait BlockchainInterface {
     fn get_warnings(&self) -> Vec<ChainStoreWarning> {
         vec![]
     }
+
+    /// Calculates the Median Time Past (MTP) for the block at `height`: the median of that
+    /// block's timestamp and up to the 10 timestamps before it.
+    fn get_mtp_by_height(&self, height: u32) -> Result<u32, Self::Error>;
 }
 
 /// [UpdatableChainstate] is a contract that a is expected from a chainstate
@@ -342,6 +346,10 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
 
     fn get_block_hash(&self, height: u32) -> Result<BlockHash, Self::Error> {
         T::get_block_hash(self, height)
+    }
+
+    fn get_mtp_by_height(&self, height: u32) -> Result<u32, Self::Error> {
+        T::get_mtp_by_height(self, height)
     }
 
     fn get_best_block(&self) -> Result<(u32, BlockHash), Self::Error> {

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -394,6 +394,10 @@ impl BlockchainInterface for PartialChainState {
             .ok_or(BlockchainError::BlockNotPresent)
     }
 
+    fn get_mtp_by_height(&self, height: u32) -> Result<u32, Self::Error> {
+        self.inner().median_time_past(height)
+    }
+
     fn get_best_block(&self) -> Result<(u32, bitcoin::BlockHash), Self::Error> {
         Ok((
             self.inner().final_height,

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -214,6 +214,7 @@ pub mod proof_util {
     use crate::BlockchainError;
     use crate::CompactLeafData;
     use crate::ScriptPubKeyKind;
+    use crate::extensions::TransactionExt;
     use crate::prelude::*;
     use crate::pruned_utreexo::consensus::Consensus;
     use crate::pruned_utreexo::consensus::UTREEXO_TAG_V1;
@@ -415,14 +416,16 @@ pub mod proof_util {
     /// and a function to get the block hash for a given height. Then returns a [`Result`] containing
     /// a vector with hashes for deleted leaves, and a `UtxoMap`, which is defined
     /// as [`HashMap<OutPoint, UtxoData>`].
-    pub fn process_proof<F, E>(
+    pub fn process_proof<F, G, E>(
         leaves: &[CompactLeafData],
         txdata: &[Transaction],
         height: u32,
         get_block_hash: F,
+        get_mtp: G,
     ) -> Result<ProcessedProof, E>
     where
         F: Fn(u32) -> Result<BlockHash, E>,
+        G: Fn(u32) -> Result<u32, E>,
         E: From<UtreexoLeafError>,
     {
         // Initialize return values
@@ -430,6 +433,10 @@ pub mod proof_util {
         let mut utxos = HashMap::new();
 
         let mut leaves_iter = leaves.iter().cloned();
+
+        // Every output created in this block shares the same creation MTP, so compute it once
+        // instead of on every output.
+        let block_mtp = get_mtp(height.saturating_sub(1))?;
 
         // Skip coinbase transaction
         for tx in txdata.iter().skip(1) {
@@ -443,7 +450,7 @@ pub mod proof_util {
                         txout: out.clone(),
                         is_coinbase: tx.is_coinbase(),
                         creation_height: height,
-                        creation_time: 0, // TODO add MTP(`height` - 1)
+                        creation_time: block_mtp,
                     },
                 );
             }
@@ -483,6 +490,17 @@ pub mod proof_util {
                         kind: e,
                     })?;
 
+                // creation_time is only read by the BIP68 relative lock-time check, and only
+                // when the spending input's sequence actually encodes a time-based lock, so
+                // avoid the get_mtp call otherwise.
+                let is_time_locked = input.sequence.is_time_locked();
+
+                let creation_time = if tx.is_enforce_bip68() && is_time_locked {
+                    get_mtp(creation_height - 1)?
+                } else {
+                    0
+                };
+
                 // Push the UTXO to remove from the set and its leaf hash (deletion hash)
                 del_hashes.push(leaf._get_leaf_hashes());
                 utxos.insert(
@@ -491,7 +509,7 @@ pub mod proof_util {
                         txout: leaf.utxo,
                         is_coinbase,
                         creation_height,
-                        creation_time: 0, // TODO add MTP(`creation_height` - 1)
+                        creation_time,
                     },
                 );
             }
@@ -818,13 +836,15 @@ mod test {
             spk_ty: ScriptPubKeyKind::Other(Box::new([0x51])),
         }];
 
-        // The leaf must be rejected before any block-hash lookup happens.
+        // The leaf must be rejected before any block-hash lookup happens (get_mtp is called
+        // unconditionally up front, for the block's own outputs, so it isn't part of this check).
         let get_block_hash = |_height| -> Result<BlockHash, TestErr> {
             panic!("get_block_hash must not be called for a rejected genesis leaf")
         };
+        let get_mtp = |_height| -> Result<u32, TestErr> { Ok(0) };
 
-        let TestErr::Leaf(err) =
-            process_proof(&leaves, &txdata, 100, get_block_hash).expect_err("must be rejected");
+        let TestErr::Leaf(err) = process_proof(&leaves, &txdata, 100, get_block_hash, get_mtp)
+            .expect_err("must be rejected");
 
         assert!(
             matches!(err.kind, LeafErrorKind::GenesisCreationHeight),

--- a/crates/floresta-chain/tests/transaction_tests.rs
+++ b/crates/floresta-chain/tests/transaction_tests.rs
@@ -15,6 +15,7 @@ use bitcoin::Transaction;
 use bitcoinkernel::VERIFY_ALL;
 use floresta_chain::BlockchainError;
 use floresta_chain::pruned_utreexo::consensus::Consensus;
+use floresta_chain::pruned_utreexo::consensus::LockTimeCutoff;
 use floresta_chain::pruned_utreexo::utxo_data::UtxoData;
 use serde_json::Value;
 use util::VERIFY_FLAGS_COUNT;
@@ -122,7 +123,19 @@ fn verify_tx(
         return Ok(Consensus::verify_coinbase(tx)?);
     }
     let mut coins = coins.clone();
-    Consensus::verify_transaction(tx, &mut coins, TX_HEIGHT, true, flags).map(|_| ())
+    // These test vectors exercise script verification, not BIP68 relative lock-time, and
+    // every prevout here uses a dummy creation_height/creation_time of 0 (see `PrevOut`'s
+    // `UtxoData` conversion above). Use a max cutoff so we never spuriously reject a vector
+    // due to an unrelated relative lock-time check.
+    Consensus::verify_transaction(
+        tx,
+        &mut coins,
+        TX_HEIGHT,
+        LockTimeCutoff::Mtp(u32::MAX),
+        true,
+        flags,
+    )
+    .map(|_| ())
 }
 
 /// Assert that `verify_tx(tx, coins, flags)` succeeds when `expected` and fails when `!expected`.

--- a/crates/floresta-wire/src/p2p_wire/block_proof.rs
+++ b/crates/floresta-wire/src/p2p_wire/block_proof.rs
@@ -379,6 +379,10 @@ mod utreexo_proof_tests {
             _ => Err(BlockchainError::BlockNotPresent),
         };
 
+        // This test only cares about utreexo proof/accumulator behavior, not BIP68
+        // semantics, so a dummy MTP is fine here.
+        let get_mtp = |_height| Ok(0);
+
         let state = setup_test_chain(Network::Bitcoin, AssumeValidArg::Disabled);
         let acc = Stump {
             leaves: 4784881,
@@ -397,8 +401,14 @@ mod utreexo_proof_tests {
         };
 
         // STEP 1: Verify the accumulator and the block
-        let (del_hashes, utxos) =
-            process_proof(&proof.leaf_data, &block.txdata, height, get_block_hash).unwrap();
+        let (del_hashes, utxos) = process_proof(
+            &proof.leaf_data,
+            &block.txdata,
+            height,
+            get_block_hash,
+            get_mtp,
+        )
+        .unwrap();
         let r_proof = Proof {
             targets: proof.targets,
             hashes: proof.proof_hashes,
@@ -422,8 +432,14 @@ mod utreexo_proof_tests {
         let mut invalid_txdata = block.txdata.clone();
         invalid_txdata.insert(1, spending_tx);
 
-        let (del_hashes, _utxos) =
-            process_proof(&proof.leaf_data, &invalid_txdata, height, get_block_hash).unwrap();
+        let (del_hashes, _utxos) = process_proof(
+            &proof.leaf_data,
+            &invalid_txdata,
+            height,
+            get_block_hash,
+            get_mtp,
+        )
+        .unwrap();
 
         if acc.verify(&r_proof, &to_acc_hashes(del_hashes)).unwrap() {
             panic!("Proof must be invalid")

--- a/crates/floresta-wire/src/p2p_wire/node/blocks.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/blocks.rs
@@ -283,15 +283,18 @@ where
         // The leaf data supplied by the utreexo peer is consumed here, before it is
         // authenticated, so errors must go through the same handling as `connect_block` ones;
         // otherwise a misbehaving peer would go unpunished and the block would silently stall.
-        let (del_hashes, inputs) =
-            match proof_util::process_proof(&leaf_data, &block.txdata, block_height, |h| {
-                self.chain.get_block_hash(h)
-            }) {
-                Ok(processed) => processed,
-                Err(err) => {
-                    return self.handle_process_block_error(err.into(), block, peer, utreexo_peer);
-                }
-            };
+        let (del_hashes, inputs) = match proof_util::process_proof(
+            &leaf_data,
+            &block.txdata,
+            block_height,
+            |h| self.chain.get_block_hash(h),
+            |h| self.chain.get_mtp_by_height(h),
+        ) {
+            Ok(processed) => processed,
+            Err(err) => {
+                return self.handle_process_block_error(err.into(), block, peer, utreexo_peer);
+            }
+        };
 
         if let Err(err) = self.chain.connect_block(&block, proof, inputs, del_hashes) {
             return self.handle_process_block_error(
@@ -401,7 +404,8 @@ where
             | BlockValidationErrors::BIP94TimeWarp
             | BlockValidationErrors::UnspendableUTXO
             | BlockValidationErrors::NonFinalTransaction
-            | BlockValidationErrors::CoinbaseNotMatured => {
+            | BlockValidationErrors::CoinbaseNotMatured
+            | BlockValidationErrors::BadRelativeLockTime => {
                 try_and_log!(self.chain.invalidate_block(hash));
 
                 warn!("Block {hash} is invalid, banning peer {block_peer}");

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -535,9 +535,13 @@ where
         leaf_data: &[CompactLeafData],
         height: u32,
     ) -> Result<Stump, WireError> {
-        let (del_hashes, _) = proof_util::process_proof(leaf_data, &block.txdata, height, |h| {
-            self.chain.get_block_hash(h)
-        })?;
+        let (del_hashes, _) = proof_util::process_proof(
+            leaf_data,
+            &block.txdata,
+            height,
+            |h| self.chain.get_block_hash(h),
+            |h| self.chain.get_mtp_by_height(h),
+        )?;
 
         Ok(self
             .chain
@@ -689,10 +693,13 @@ where
             .aux_data
             .expect("Block proof and leaf data should be present");
 
-        let (del_hashes, inputs) =
-            proof_util::process_proof(&leaf_data, &block.block.txdata, fork_height, |h| {
-                self.chain.get_block_hash(h)
-            })?;
+        let (del_hashes, inputs) = proof_util::process_proof(
+            &leaf_data,
+            &block.block.txdata,
+            fork_height,
+            |h| self.chain.get_block_hash(h),
+            |h| self.chain.get_mtp_by_height(h),
+        )?;
 
         let acc = self.find_accumulator_for_block(fork_height, fork).await?;
         let is_valid = self


### PR DESCRIPTION
### Description and Notes

`Consensus::verify_transaction` never checked a transaction input's relative lock-time (`nSequence`, BIP68) against the height/time the spent output was created, even though this is a mandatory consensus rule independent of OP_CSV script usage.

`verify_block_transactions`/`verify_transaction` now take the candidate block's own MTP (median time past of the preceding block) and use `bitcoin::Sequence::to_relative_lock_time()`/`relative::LockTime` to check each nSequence-enabled input against it, rejecting the block with a new `BadRelativeLockTime` error if unsatisfied.

Falls back to the block's own timestamp when prior header history isn't available (pruned/partial chains) — this can only make the check more permissive, never less.

Fixes #1238

### How to verify the changes you have done?

`cargo test -p floresta-chain --no-default-features --features flat-chainstore` — 61/61 tests pass, including a new `test_relative_locktime` covering both the satisfied and violated cases. `cargo test -p floresta-wire` — 46/46 pass. `cargo clippy -- -D warnings` clean on both crates.

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
