### PR TITLE
docs(rpc): add findtxout endpoint documentation

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -395,7 +395,13 @@ pub enum Methods {
         node_id: Option<usize>,
     },
 
-    #[command(name = "findtxout")]
+    #[doc = include_str!("../../../doc/rpc/findtxout.md")]
+    #[command(
+        name = "findtxout",
+        about = "Finds an unspent transaction output (UTXO) using compact block filters",
+        long_about = Some(include_str!("../../../doc/rpc/findtxout.md")),
+        disable_help_subcommand = true
+    )]
     FindTxOut {
         txid: Txid,
         vout: u32,

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -130,11 +130,7 @@ pub trait FlorestaRPC {
     /// The peer can be referenced either by node_address or node_id.
     /// If referencing by node_id, an empty string must be passed as the node_address.
     fn disconnect_node(&self, node_address: String, node_id: Option<usize>) -> Result<Value>;
-    /// Finds an specific utxo in the chain
-    ///
-    /// You can use this to look for a utxo. If it exists, it will return the amount and
-    /// scriptPubKey of this utxo. It returns an empty object if the utxo doesn't exist.
-    /// You must have enabled block filters by setting the `blockfilters=1` option.
+    #[doc = include_str!("../../../doc/rpc/findtxout.md")]
     fn find_tx_out(
         &self,
         tx_id: Txid,

--- a/doc/rpc/findtxout.md
+++ b/doc/rpc/findtxout.md
@@ -1,0 +1,68 @@
+# `findtxout`
+
+Finds a specific unspent transaction output (UTXO) in the chain.
+
+## Usage
+
+### Synopsis
+
+```bash
+floresta-cli findtxout <txid> <vout> <script> [<height_hint>]
+```
+
+### Examples
+
+```bash
+# Look for output 0 of a transaction, providing its scriptPubKey hex
+floresta-cli findtxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 0014c664139327b98043febeab6434eba89bb196d1af
+
+# Same lookup, but start scanning from block height 800000 to speed things up
+floresta-cli findtxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510db7ab8 0 0014c664139327b98043febeab6434eba89bb196d1af 800000
+```
+
+## Arguments
+
+`txid` - (string, required) The transaction id that created the output.
+
+`vout` - (numeric, required) The index of the output within that transaction.
+
+`script` - (string, required) The scriptPubKey of the output, hex encoded. This is what gets matched against the block filters, so it must be correct for the output to be found.
+
+`height_hint` - (numeric, optional, default=0) The block height to start scanning from. Providing a height close to where the output was created avoids scanning the whole chain and makes the lookup much faster.
+
+## Returns
+
+### Ok Response
+
+If the output is found, it returns the [`gettxout`](gettxout.md) response. It may also return the following variant:
+
+* `bestblock`: (string) The hash of the block at the tip of the chain
+* `confirmations`: (numeric) The number of confirmations
+* `value`: (numeric) The transaction value in BTC
+* `scriptPubKey`: (json object)
+  * `asm`: (string) The assembled scriptPubKey
+  * `hex`: (string) The raw scriptPubKey
+  * `type`: (string) The type, e.g. pubkeyhash
+  * `addresses`: (array of strings) bitcoin addresses
+* `coinbase`: (boolean) Coinbase or not
+
+Or currently:
+
+- `value` - (numeric) The output value in satoshis.
+- `script_pubkey` - (string) The output scriptPubKey, hex encoded.
+
+### Error Enum `JsonRpcError`
+
+* `InInitialBlockDownload` - The node is still doing its initial block download, so there are no filters to scan yet.
+* `NoBlockFilters` - Block filters are not enabled. You must start the node with `blockfilters=1` to use this method.
+* `Filters` - Something went wrong while matching against the block filters.
+* `Node` - A node level error happened while fetching a candidate block.
+* `BlockNotFound` - A matched block could not be located in the chain.
+
+## Notes
+
+- This is a Floresta flavored RPC and is not part of the Bitcoin Core RPC spec. Unlike `gettxout`, which only looks at outputs already cached by the wallet, `findtxout` uses block filters to scan the chain for an output that the wallet doesn't know about yet. If the output is found it is cached, so subsequent calls to `gettxout` will return it too.
+- If the output can't be found (it doesn't exist or has already been spent), an empty object `{}` is returned.
+- You must enable block filters by setting the `blockfilters=1` option, otherwise this method returns `NoBlockFilters`.
+- Passing a good `height_hint` matters a lot for performance, since without it the scan starts from the beginning of the chain.
+- Related methods: `gettxout`, which returns an output only if it is already in the wallet cache.


### PR DESCRIPTION
### Description and Notes

This PR adds comprehensive documentation for the `findtxout` JSON-RPC endpoint as part of the RPC documentation initiative.

Specifically:
- Created `doc/rpc/findtxout.md` following the template standard, covering parameter definitions (`txid`, `vout`, `script`, `height_hint`), return response schema (`value`, `scriptPubKey` object), and `blockfilters=1` usage requirements.
- Linked `doc/rpc/findtxout.md` into the `FlorestaRPC::find_tx_out` trait definition in `crates/floresta-rpc/src/rpc.rs`.
- Wired `doc/rpc/findtxout.md` into the `Methods::FindTxOut` CLI subcommand documentation in `bin/floresta-cli/src/main.rs`.

Closes #799

### How to verify the changes you have done

You can verify these documentation changes by running local lints, building rustdoc, or checking `floresta-cli` help output:

1. Verify Lints & Formatting:
   cargo fmt --all --check
   cargo clippy --workspace --all-targets --all-features -- -D warnings

2. Verify Library Rustdoc:
   cargo doc --package floresta-rpc --open

3. Verify CLI Help Output:
   cargo run --bin floresta-cli -- findtxout --help

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above