### PR TITLE
wire: implement headers pre-sync to guard against disk-fill DoS

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -497,7 +497,7 @@ pub fn buried_deployments_for(network: Network) -> &'static [(&'static str, u32)
 /// Returns the minimum cumulative chainwork a valid chain must demonstrate.
 /// Mirrors [`nMinimumChainWork`](https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp) in Bitcoin Core.
 pub fn minimum_chain_work(network: Network) -> Work {
-    // TODO: sync this value with nMinimumChainWork in Bitcoin Core's chainparams.cpp on each Core release.
+    // TODO(@Micah-Shallom): sync this value with nMinimumChainWork in Bitcoin Core's chainparams.cpp on each Core release.
     match network {
         // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L117
         Network::Bitcoin => {

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -19,6 +19,7 @@ use core::ffi::c_uint;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Network;
+use bitcoin::Work;
 use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::constants::SUBSIDY_HALVING_INTERVAL;
 use bitcoin::p2p::ServiceFlags;
@@ -490,5 +491,35 @@ pub fn buried_deployments_for(network: Network) -> &'static [(&'static str, u32)
         Network::Testnet4 => TESTNET4_BURIED,
         Network::Signet => SIGNET_BURIED,
         Network::Regtest => REGTEST_BURIED,
+    }
+}
+
+/// Returns the minimum cumulative chainwork a valid chain must demonstrate.
+/// Mirrors [`nMinimumChainWork`](https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp) in Bitcoin Core.
+pub fn minimum_chain_work(network: Network) -> Work {
+    // TODO: sync this value with nMinimumChainWork in Bitcoin Core's chainparams.cpp on each Core release.
+    match network {
+        // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L117
+        Network::Bitcoin => {
+            Work::from_hex("0x0000000000000000000000000000000000000001128750f82f4c366153a3a030")
+                .expect("hardcoded work")
+        }
+        // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L248
+        Network::Testnet => {
+            Work::from_hex("0x0000000000000000000000000000000000000000000017dde1c649f3708d14b6")
+                .expect("hardcoded work")
+        }
+        // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L356
+        Network::Testnet4 => {
+            Work::from_hex("0x0000000000000000000000000000000000000000000009a0fe15d0177d086304")
+                .expect("hardcoded work")
+        }
+        // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L447
+        // Custom -signetchallenge signets use 0; Floresta targets the default signet.
+        Network::Signet => {
+            Work::from_hex("0x00000000000000000000000000000000000000000000000000000b463ea0a4b8")
+                .expect("hardcoded work")
+        }
+        _ => Work::from_be_bytes([0u8; 32]),
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/headers_sync.rs
+++ b/crates/floresta-wire/src/p2p_wire/headers_sync.rs
@@ -1,0 +1,898 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-peer headers pre-synchronization state machine.
+//!
+//! Protects against disk-fill DoS during initial header download. Without this
+//! guard a malicious peer can serve a long chain of individually-valid low-work
+//! headers, filling our header storage before we discover the chain is useless.
+//!
+//! The algorithm runs in two phases:
+//!
+//! **PRESYNC** -- headers are validated (PoW + continuity) but never written to
+//! disk. Sparse one-bit commitments are stored at every N-th header.
+//! Once the chain accumulates sufficient work the state advances to REDOWNLOAD.
+//!
+//! **REDOWNLOAD** -- the same headers are re-requested from the peer, verified
+//! against the stored commitments, and released from the front of the buffer once
+//! it exceeds the per-network lookahead size. When sufficient chainwork is
+//! re-accumulated all remaining buffered headers are flushed unconditionally.
+
+/// Hard cap on stored commitment bits. Bitcoin Core uses `6 * elapsed_secs / commitment_period`
+/// (headerssync.cpp:43); that dynamic bound needs the start block's MTP. 24k covers ~15M mainnet heights.
+const MAX_COMMITMENTS: u64 = 24_000;
+
+/// Byte length of the u64 commitment salt serialized as little-endian.
+const COMMITMENT_SALT_LEN: usize = 8;
+/// Total byte length of the SHA-256 input: salt (8 bytes) || block_hash (32 bytes).
+const COMMITMENT_INPUT_LEN: usize = COMMITMENT_SALT_LEN + 32;
+
+use std::collections::VecDeque;
+
+use bitcoin::BlockHash;
+use bitcoin::CompactTarget;
+use bitcoin::Network;
+use bitcoin::Target;
+use bitcoin::TxMerkleNode;
+use bitcoin::Work;
+use bitcoin::block::Header;
+use bitcoin::block::Version;
+use bitcoin::consensus::params::Params;
+use bitcoin::hashes::Hash;
+use bitcoin::hashes::sha256;
+use floresta_chain::minimum_chain_work;
+use tracing::warn;
+
+/// Stateless check that `new_bits` is a permitted successor to `old_bits` at `height`.
+///
+/// Mirrors Bitcoin Core's `PermittedDifficultyTransition` (pow.cpp): at a retarget
+/// boundary the target may move by at most 4x in either direction (capped at the
+/// network's proof-of-work limit); between boundaries it must not change at all.
+/// Needs no timestamps, so it can run on headers that are not yet in storage.
+/// Without it an attacker with limited hashrate could compress the work into a
+/// few very hard headers and have a greater chance of reaching the work
+/// threshold by luck, since expected cost is the same but variance is not.
+fn permitted_difficulty_transition(
+    params: &Params,
+    height: u32,
+    old_bits: CompactTarget,
+    new_bits: CompactTarget,
+) -> bool {
+    // Min-difficulty networks (testnet3/4, regtest) may reset to the limit at any height.
+    if params.allow_min_difficulty_blocks {
+        return true;
+    }
+
+    if u64::from(height) % params.difficulty_adjustment_interval() != 0 {
+        // Not a retarget height: difficulty must stay exactly the same.
+        return old_bits == new_bits;
+    }
+
+    let old_target = Target::from_compact(old_bits);
+    let observed = Target::from_compact(new_bits);
+
+    // Largest permitted target (easiest difficulty): old * 4, capped at the PoW limit.
+    // Round-trip through compact encoding so we compare against what `bits` can
+    // express, as Core does with SetCompact(GetCompact()).
+    let max_target = Target::from_compact(
+        old_target
+            .max_transition_threshold(params)
+            .to_compact_lossy(),
+    );
+    if observed > max_target {
+        return false;
+    }
+
+    // Smallest permitted target (hardest difficulty): old / 4.
+    let min_target = Target::from_compact(old_target.min_transition_threshold().to_compact_lossy());
+    observed >= min_target
+}
+
+/// Per-network parameters for the headers pre-synchronization algorithm.
+///
+/// Values sourced from Bitcoin Core's
+/// [`chainparams.cpp`](https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp).
+#[derive(Debug, Clone)]
+pub struct HeadersSyncParams {
+    /// Commitment slot interval: one bit is recorded per this many headers.
+    pub commitment_period: u64,
+    /// Number of headers kept in the REDOWNLOAD buffer before releasing from the front.
+    /// Sized so that ~24 commitment periods worth of headers are held before release.
+    pub redownload_buffer_size: usize,
+}
+
+impl HeadersSyncParams {
+    pub fn for_network(network: Network) -> Self {
+        match network {
+            // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L202-L203
+            Network::Bitcoin => Self {
+                commitment_period: 641,
+                redownload_buffer_size: 15218,
+            },
+            // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L311-L312
+            Network::Testnet => Self {
+                commitment_period: 673,
+                redownload_buffer_size: 14460,
+            },
+            // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L424-L425
+            Network::Testnet4 => Self {
+                commitment_period: 606,
+                redownload_buffer_size: 16092,
+            },
+            // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L549-L550
+            Network::Signet => Self {
+                commitment_period: 620,
+                redownload_buffer_size: 15724,
+            },
+            // https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainparams.cpp#L685-L686
+            _ => Self {
+                commitment_period: 275,
+                redownload_buffer_size: 7017,
+            },
+        }
+    }
+}
+
+/// The phase of the [`HeadersSyncState`] state machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PresyncPhase {
+    /// Validating headers without writing them to disk; building commitments.
+    Presync,
+    /// Chain passed the work gate; re-downloading to verify commitments.
+    Redownload,
+    /// All headers verified and released. This instance can be discarded.
+    Final,
+    /// PRESYNC was aborted because the peer's chain exceeded the internal commitment cap.
+    /// Not misbehavior; the peer is silently dropped without banning.
+    Aborted,
+}
+
+/// A block header with `prev_blockhash` elided to save memory.
+/// Dropping the 32-byte field halves per-entry cost; it is always recoverable from the preceding entry.
+#[derive(Debug, Clone)]
+pub struct CompressedHeader {
+    version: i32,
+    merkle_root: TxMerkleNode,
+    time: u32,
+    bits: CompactTarget,
+    nonce: u32,
+}
+
+impl CompressedHeader {
+    fn from_header(h: &Header) -> Self {
+        Self {
+            version: h.version.to_consensus(),
+            merkle_root: h.merkle_root,
+            time: h.time,
+            bits: h.bits,
+            nonce: h.nonce,
+        }
+    }
+
+    /// Reconstructs the full [`Header`] by reattaching `prev_blockhash`.
+    pub fn to_header(&self, prev_blockhash: BlockHash) -> Header {
+        Header {
+            version: Version::from_consensus(self.version),
+            prev_blockhash,
+            merkle_root: self.merkle_root,
+            time: self.time,
+            bits: self.bits,
+            nonce: self.nonce,
+        }
+    }
+}
+
+/// Returned by [`HeadersSyncState::process_presync`] and [`HeadersSyncState::process_redownload`] after each batch.
+#[derive(Debug, Default)]
+pub struct ProcessingResult {
+    /// Headers that passed commitment verification, ready for `accept_header`.
+    pub headers_to_accept: Vec<Header>,
+    /// Whether the caller should send the next `getheaders` to this peer.
+    pub request_more: bool,
+    /// `false` if the peer sent invalid data (bad PoW, broken continuity, or commitment
+    /// mismatch). Caller should disconnect and ban.
+    pub success: bool,
+}
+
+/// Per-peer state machine for the two-phase headers pre-synchronization protocol.
+///
+/// See the [module documentation](self) for a full description of the algorithm.
+#[derive(Debug, Clone)]
+pub struct HeadersSyncState {
+    state: PresyncPhase,
+
+    /// Height of the known block from which this sync branches.
+    pub start_height: u32,
+
+    /// Hash of the known block from which this sync branches.
+    pub start_hash: BlockHash,
+
+    /// `bits` of the known block from which this sync branches. Seeds the difficulty
+    /// transition check for the first header of each phase.
+    start_bits: CompactTarget,
+
+    /// Consensus parameters used for the difficulty transition check.
+    consensus_params: Params,
+
+    /// Minimum cumulative work the peer's chain must demonstrate before PRESYNC advances.
+    /// Mirrors Bitcoin Core's `nMinimumChainWork` per network.
+    minimum_chain_work: Work,
+
+    /// Per-network algorithm parameters.
+    params: HeadersSyncParams,
+
+    // ── PRESYNC ───────────────────────────────────────────────────────────────
+    /// Cumulative chainwork accumulated during PRESYNC.
+    presync_work: Work,
+
+    /// Height of the last header received during PRESYNC.
+    presync_height: u32,
+
+    /// Last header received during PRESYNC, kept for continuity checks and locator building.
+    presync_last_header: Option<Header>,
+
+    /// Per-session random salt for the commitment hash function.
+    /// Never transmitted; prevents an attacker from predicting commitment slots.
+    commitment_salt: u64,
+
+    /// Secret offset within each period: a commitment is stored at height `h`
+    /// when `h as u64 % params.commitment_period == commit_offset`.
+    commit_offset: u64,
+
+    /// Upper bound on stored commitment bits. Hitting this cap is not misbehavior;
+    /// it means the peer's chain is longer than our memory budget allows.
+    max_commitments: u64,
+
+    /// One-bit salted commitments recorded during PRESYNC.
+    /// Front = lowest commitment height above `start_height`.
+    /// Consumed front-to-back during REDOWNLOAD.
+    commitments: VecDeque<bool>,
+
+    // ── REDOWNLOAD ────────────────────────────────────────────────────────────
+    /// Set when re-accumulated chainwork during REDOWNLOAD meets `minimum_chain_work`.
+    /// Once set, commitment checking stops and the buffer is fully drained.
+    process_all_remaining: bool,
+
+    /// Cumulative chainwork re-accumulated during REDOWNLOAD.
+    redownload_chain_work: Work,
+
+    /// Headers received during REDOWNLOAD, not yet released to permanent storage.
+    /// Released from the front once the buffer exceeds `params.redownload_buffer_size`,
+    /// or all at once when `process_all_remaining` is set.
+    redownload_buffer: VecDeque<CompressedHeader>,
+
+    /// Height of the last header appended to `redownload_buffer`.
+    redownload_last_height: u32,
+
+    /// Hash of the last header appended to `redownload_buffer`.
+    /// Used to validate continuity of the next incoming header.
+    redownload_last_hash: BlockHash,
+
+    /// `prev_blockhash` of the current front of `redownload_buffer`.
+    /// Needed to reconstruct full headers when draining from the front.
+    redownload_first_prev_hash: BlockHash,
+}
+
+impl HeadersSyncState {
+    /// Create a new `HeadersSyncState` starting from the given chain position.
+    ///
+    /// `start_height` / `start_hash` / `start_bits` identify the last block we already
+    /// know; the peer will send headers building on top of it.
+    pub fn new(
+        start_height: u32,
+        start_hash: BlockHash,
+        start_bits: CompactTarget,
+        network: Network,
+    ) -> Self {
+        let params = HeadersSyncParams::for_network(network);
+        let salt: u64 = rand::random();
+        let commit_offset = salt % params.commitment_period;
+        let minimum_chain_work = minimum_chain_work(network);
+
+        Self {
+            state: PresyncPhase::Presync,
+            start_height,
+            start_hash,
+            start_bits,
+            consensus_params: Params::from(network),
+            minimum_chain_work,
+            params,
+            presync_work: Work::from_be_bytes([0u8; 32]),
+            presync_height: start_height,
+            presync_last_header: None,
+            commitment_salt: salt,
+            commit_offset,
+            max_commitments: MAX_COMMITMENTS,
+            commitments: VecDeque::new(),
+            process_all_remaining: false,
+            redownload_chain_work: Work::from_be_bytes([0u8; 32]),
+            redownload_buffer: VecDeque::new(),
+            redownload_last_height: start_height,
+            redownload_last_hash: start_hash,
+            redownload_first_prev_hash: start_hash,
+        }
+    }
+
+    /// Returns the current phase.
+    pub fn phase(&self) -> &PresyncPhase {
+        &self.state
+    }
+
+    /// SHA-256(salt || block_hash) LSB. The salt makes commitment slots unpredictable to the peer.
+    fn commitment_bit(&self, hash: &BlockHash) -> bool {
+        let mut input = [0u8; COMMITMENT_INPUT_LEN];
+        input[..COMMITMENT_SALT_LEN].copy_from_slice(&self.commitment_salt.to_le_bytes());
+        input[COMMITMENT_SALT_LEN..].copy_from_slice(hash.as_byte_array());
+        let digest = sha256::Hash::hash(&input);
+        (digest.as_byte_array()[0] & 1) == 1
+    }
+
+    /// Returns `true` if `height` is a commitment slot for this session.
+    fn is_commitment_height(&self, height: u32) -> bool {
+        (height as u64 % self.params.commitment_period) == self.commit_offset
+    }
+
+    /// Process a batch of headers during PRESYNC.
+    ///
+    /// Headers are validated for PoW and chain continuity but never written to
+    /// disk. Commitment bits are recorded at every `params.commitment_period` headers.
+    /// Once the chain accumulates sufficient work and the tip is recent the state
+    /// transitions to REDOWNLOAD.
+    pub fn process_presync(&mut self, headers: &[Header]) -> ProcessingResult {
+        if self.state != PresyncPhase::Presync {
+            return ProcessingResult {
+                success: false,
+                ..Default::default()
+            };
+        }
+
+        for header in headers {
+            let expected_prev = self
+                .presync_last_header
+                .as_ref()
+                .map(|h| h.block_hash())
+                .unwrap_or(self.start_hash);
+
+            if header.prev_blockhash != expected_prev {
+                return ProcessingResult {
+                    success: false,
+                    ..Default::default()
+                };
+            }
+
+            // Bound how fast the claimed difficulty may move before trusting the
+            // header's work. The exact retarget value needs epoch timestamps we do
+            // not have yet, but the permitted transition range does not.
+            let prev_bits = self
+                .presync_last_header
+                .as_ref()
+                .map(|h| h.bits)
+                .unwrap_or(self.start_bits);
+            let next_height = self.presync_height + 1;
+            if !permitted_difficulty_transition(
+                &self.consensus_params,
+                next_height,
+                prev_bits,
+                header.bits,
+            ) {
+                return ProcessingResult {
+                    success: false,
+                    ..Default::default()
+                };
+            }
+
+            // The hash must satisfy the target the header now legitimately claims.
+            if header.validate_pow(header.target()).is_err() {
+                return ProcessingResult {
+                    success: false,
+                    ..Default::default()
+                };
+            }
+
+            self.presync_work = self.presync_work + header.work();
+            self.presync_height = next_height;
+
+            if self.is_commitment_height(self.presync_height) {
+                if self.commitments.len() as u64 >= self.max_commitments {
+                    // Chain exceeds our memory budget; not misbehavior, just give up.
+                    warn!(
+                        "Peer chain exceeded presync commitment cap at height {}; aborting presync",
+                        self.presync_height
+                    );
+                    self.state = PresyncPhase::Aborted;
+                    return ProcessingResult {
+                        success: true,
+                        request_more: false,
+                        headers_to_accept: vec![],
+                    };
+                }
+                let bit = self.commitment_bit(&header.block_hash());
+                self.commitments.push_back(bit);
+            }
+
+            self.presync_last_header = Some(*header);
+        }
+
+        // Transition to REDOWNLOAD on work alone, matching Core's headerssync.cpp.
+        if self.presync_work >= self.minimum_chain_work && self.presync_last_header.is_some() {
+            self.state = PresyncPhase::Redownload;
+            return ProcessingResult {
+                request_more: false,
+                success: true,
+                headers_to_accept: vec![],
+            };
+        }
+
+        ProcessingResult {
+            request_more: true,
+            success: true,
+            headers_to_accept: vec![],
+        }
+    }
+
+    /// Process a batch of headers during REDOWNLOAD.
+    ///
+    /// Each header is validated against the commitment bits recorded during PRESYNC.
+    /// Headers are released from the front of the buffer once it exceeds
+    /// `params.redownload_buffer_size`. Once sufficient chainwork is re-accumulated,
+    /// commitment checking stops and all remaining buffered headers are flushed.
+    pub fn process_redownload(&mut self, headers: &[Header]) -> ProcessingResult {
+        if self.state != PresyncPhase::Redownload {
+            return ProcessingResult {
+                success: false,
+                ..Default::default()
+            };
+        }
+
+        for header in headers {
+            if header.prev_blockhash != self.redownload_last_hash {
+                return ProcessingResult {
+                    success: false,
+                    ..Default::default()
+                };
+            }
+
+            // Same difficulty transition bound as PRESYNC. The buffer only ever
+            // drains partially mid-sync (a full drain ends the phase), so its back
+            // is the previous header whenever it is non-empty.
+            let prev_bits = self
+                .redownload_buffer
+                .back()
+                .map(|c| c.bits)
+                .unwrap_or(self.start_bits);
+            let next_height = self.redownload_last_height + 1;
+            if !permitted_difficulty_transition(
+                &self.consensus_params,
+                next_height,
+                prev_bits,
+                header.bits,
+            ) {
+                return ProcessingResult {
+                    success: false,
+                    ..Default::default()
+                };
+            }
+
+            if header.validate_pow(header.target()).is_err() {
+                return ProcessingResult {
+                    success: false,
+                    ..Default::default()
+                };
+            }
+
+            self.redownload_last_height = next_height;
+            self.redownload_last_hash = header.block_hash();
+
+            self.redownload_chain_work = self.redownload_chain_work + header.work();
+            if self.redownload_chain_work >= self.minimum_chain_work {
+                self.process_all_remaining = true;
+            }
+
+            // Commitment verification stops once sufficient chainwork is re-accumulated.
+            if !self.process_all_remaining && self.is_commitment_height(self.redownload_last_height)
+            {
+                let expected = match self.commitments.pop_front() {
+                    Some(bit) => bit,
+                    None => {
+                        return ProcessingResult {
+                            success: false,
+                            ..Default::default()
+                        };
+                    }
+                };
+                if self.commitment_bit(&header.block_hash()) != expected {
+                    return ProcessingResult {
+                        success: false,
+                        ..Default::default()
+                    };
+                }
+            }
+
+            self.redownload_buffer
+                .push_back(CompressedHeader::from_header(header));
+        }
+
+        // Release headers from the front while the buffer exceeds the lookahead size,
+        // or drain everything once sufficient work is re-accumulated.
+        let mut headers_to_accept = Vec::new();
+        let mut prev_hash = self.redownload_first_prev_hash;
+
+        while self.redownload_buffer.len() > self.params.redownload_buffer_size
+            || (!self.redownload_buffer.is_empty() && self.process_all_remaining)
+        {
+            let compressed = self.redownload_buffer.pop_front().unwrap();
+            let header = compressed.to_header(prev_hash);
+            prev_hash = header.block_hash();
+            headers_to_accept.push(header);
+        }
+
+        self.redownload_first_prev_hash = prev_hash;
+
+        let done = self.process_all_remaining && self.redownload_buffer.is_empty();
+        if done {
+            self.state = PresyncPhase::Final;
+        }
+
+        ProcessingResult {
+            headers_to_accept,
+            request_more: !done,
+            success: true,
+        }
+    }
+
+    /// Flips the first stored commitment bit. Only available in tests.
+    #[cfg(test)]
+    fn flip_first_commitment(&mut self) {
+        if let Some(bit) = self.commitments.front_mut() {
+            *bit = !*bit;
+        }
+    }
+
+    /// Overrides the commitment cap. Only available in tests.
+    #[cfg(test)]
+    fn with_max_commitments(mut self, cap: u64) -> Self {
+        self.max_commitments = cap;
+        self
+    }
+
+    /// Overrides the minimum chain work threshold. Only available in tests.
+    #[cfg(test)]
+    fn with_minimum_chain_work(mut self, work: Work) -> Self {
+        self.minimum_chain_work = work;
+        self
+    }
+
+    // Last-seen hash from in-memory state; never touches the chainstore.
+    // Matches Core's NextHeadersRequestLocator() (headerssync.cpp:296-317).
+    pub fn next_locator_hash(&self) -> Option<BlockHash> {
+        match self.state {
+            PresyncPhase::Presync => self.presync_last_header.as_ref().map(|h| h.block_hash()),
+            PresyncPhase::Redownload => Some(self.redownload_last_hash),
+            PresyncPhase::Final | PresyncPhase::Aborted => None,
+        }
+    }
+
+    /// Overrides the REDOWNLOAD buffer size. Only available in tests.
+    #[cfg(test)]
+    fn with_redownload_buffer_size(mut self, size: usize) -> Self {
+        self.params.redownload_buffer_size = size;
+        self
+    }
+
+    /// Loads commitments from `headers` and enters REDOWNLOAD state directly.
+    ///
+    /// Simulates the PRESYNC commitment-recording pass so that REDOWNLOAD tests
+    /// can run without going through a full PRESYNC with real chainwork.
+    #[cfg(test)]
+    fn force_redownload(mut self, headers: &[Header]) -> Self {
+        for (i, header) in headers.iter().enumerate() {
+            let height = self.start_height + i as u32 + 1;
+            if self.is_commitment_height(height) {
+                self.commitments
+                    .push_back(self.commitment_bit(&header.block_hash()));
+            }
+        }
+        self.state = PresyncPhase::Redownload;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::CompactTarget;
+    use bitcoin::Network;
+    use bitcoin::TxMerkleNode;
+    use bitcoin::Work;
+    use bitcoin::block::Header;
+    use bitcoin::block::Version;
+
+    use super::*;
+
+    /// Regtest commitment period; chain lengths are multiples of this to guarantee exact slot counts.
+    const REGTEST_PERIOD: usize = 275;
+    /// Easy compact target: ~50% of nonces satisfy this, so headers mine in 1-2 tries on average.
+    const EASY_BITS: u32 = 0x207f_ffff;
+    /// Arbitrary far-past timestamp used to build test chains.
+    const ANCIENT_TIMESTAMP: u32 = 1_000_000;
+
+    /// `EASY_BITS` as a [`CompactTarget`]. Also used as the start block's bits so that
+    /// off-boundary transition checks see an unchanged difficulty.
+    fn easy_bits() -> CompactTarget {
+        CompactTarget::from_consensus(EASY_BITS)
+    }
+
+    fn make_header(prev: BlockHash, time: u32) -> Header {
+        make_header_with_bits(prev, time, easy_bits())
+    }
+
+    fn make_header_with_bits(prev: BlockHash, time: u32, bits: CompactTarget) -> Header {
+        (0u32..=u32::MAX)
+            .map(|nonce| Header {
+                version: Version::from_consensus(1),
+                prev_blockhash: prev,
+                merkle_root: TxMerkleNode::all_zeros(),
+                time,
+                bits,
+                nonce,
+            })
+            .find(|h| h.validate_pow(h.target()).is_ok())
+            .expect("no valid nonce found for EASY_BITS target")
+    }
+
+    fn make_chain(prev: BlockHash, time: u32, count: usize) -> Vec<Header> {
+        let mut out = Vec::with_capacity(count);
+        let mut prev = prev;
+        for i in 0..count {
+            let h = make_header(prev, time + i as u32);
+            prev = h.block_hash();
+            out.push(h);
+        }
+        out
+    }
+
+    #[test]
+    fn difficulty_transition_off_boundary_requires_unchanged_bits() {
+        let params = Params::from(Network::Bitcoin);
+        // A real historic mainnet target, well below the PoW limit.
+        let old = CompactTarget::from_consensus(0x1b04_04cb);
+        let other = CompactTarget::from_consensus(0x1b04_04cc);
+
+        assert!(permitted_difficulty_transition(&params, 1, old, old));
+        assert!(!permitted_difficulty_transition(&params, 1, old, other));
+        assert!(!permitted_difficulty_transition(&params, 2015, old, other));
+    }
+
+    #[test]
+    fn difficulty_transition_at_boundary_allows_at_most_4x() {
+        let params = Params::from(Network::Bitcoin);
+        let old = CompactTarget::from_consensus(0x1b04_04cb);
+        let old_target = Target::from_compact(old);
+
+        // Exactly 4x easier and 4x harder are the permitted extremes.
+        let easiest = old_target
+            .max_transition_threshold(&params)
+            .to_compact_lossy();
+        let hardest = old_target.min_transition_threshold().to_compact_lossy();
+        assert!(permitted_difficulty_transition(&params, 2016, old, old));
+        assert!(permitted_difficulty_transition(&params, 2016, old, easiest));
+        assert!(permitted_difficulty_transition(&params, 2016, old, hardest));
+
+        // Bumping the compact exponent moves the target by 256x: far outside the clamp.
+        let way_easier = CompactTarget::from_consensus(0x1c04_04cb);
+        let way_harder = CompactTarget::from_consensus(0x1a04_04cb);
+        assert!(!permitted_difficulty_transition(
+            &params, 2016, old, way_easier
+        ));
+        assert!(!permitted_difficulty_transition(
+            &params, 2016, old, way_harder
+        ));
+    }
+
+    #[test]
+    fn difficulty_transition_is_unchecked_on_min_difficulty_networks() {
+        let params = Params::from(Network::Regtest);
+        let old = CompactTarget::from_consensus(0x1b04_04cb);
+        let way_easier = CompactTarget::from_consensus(0x1c04_04cb);
+        assert!(permitted_difficulty_transition(&params, 1, old, way_easier));
+        assert!(permitted_difficulty_transition(
+            &params, 2016, old, way_easier
+        ));
+    }
+
+    #[test]
+    fn presync_rejects_illegal_difficulty_jump() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Bitcoin);
+
+        // Header 2 changes `bits` off a retarget boundary: consensus-invalid on mainnet.
+        let h1 = make_header(genesis, ANCIENT_TIMESTAMP);
+        let h2 = make_header_with_bits(
+            h1.block_hash(),
+            ANCIENT_TIMESTAMP + 1,
+            CompactTarget::from_consensus(0x207f_fffe),
+        );
+
+        let result = state.process_presync(&[h1, h2]);
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn redownload_rejects_illegal_difficulty_jump() {
+        let genesis = BlockHash::all_zeros();
+        let huge_work = Work::from_be_bytes([0xff; 32]);
+        let good = make_chain(genesis, ANCIENT_TIMESTAMP, 3);
+
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Bitcoin)
+            .with_minimum_chain_work(huge_work)
+            .force_redownload(&good);
+
+        // Replay with header 2's `bits` changed off-boundary; hash and PoW are re-mined so
+        // only the transition check can reject it.
+        let bad_h2 = make_header_with_bits(
+            good[0].block_hash(),
+            ANCIENT_TIMESTAMP + 1,
+            CompactTarget::from_consensus(0x207f_fffe),
+        );
+        let result = state.process_redownload(&[good[0], bad_h2]);
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn presync_transitions_to_redownload_on_sufficient_work() {
+        let genesis = BlockHash::all_zeros();
+        // On Regtest minimum_chain_work = 0, so any non-empty batch satisfies the gate.
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest);
+
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, 5);
+        let result = state.process_presync(&chain);
+
+        assert!(result.success);
+        assert!(!result.request_more);
+        assert_eq!(*state.phase(), PresyncPhase::Redownload);
+    }
+
+    #[test]
+    fn presync_rejects_broken_continuity() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest);
+
+        let mut chain = make_chain(genesis, ANCIENT_TIMESTAMP, 5);
+        chain[2].prev_blockhash = BlockHash::all_zeros();
+
+        let result = state.process_presync(&chain);
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn redownload_rejects_broken_continuity() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest);
+
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, 5);
+        let _ = state.process_presync(&chain);
+        assert_eq!(*state.phase(), PresyncPhase::Redownload);
+
+        let mut bad = make_chain(BlockHash::all_zeros(), ANCIENT_TIMESTAMP, 3);
+        bad[0].prev_blockhash = chain[3].block_hash();
+
+        let result = state.process_redownload(&bad);
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn redownload_succeeds_with_matching_chain() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest);
+
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, REGTEST_PERIOD);
+        let _ = state.process_presync(&chain);
+        assert_eq!(*state.phase(), PresyncPhase::Redownload);
+
+        // REDOWNLOAD: replay the same chain. On Regtest (min_chain_work = 0),
+        // process_all_remaining is set immediately so all headers are released at once.
+        let result = state.process_redownload(&chain);
+        assert!(result.success);
+        assert!(!result.headers_to_accept.is_empty());
+    }
+
+    #[test]
+    fn redownload_releases_all_headers_and_reaches_final() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest);
+
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, REGTEST_PERIOD);
+        let _ = state.process_presync(&chain);
+        assert_eq!(*state.phase(), PresyncPhase::Redownload);
+
+        let result = state.process_redownload(&chain);
+        assert!(result.success);
+        assert_eq!(result.headers_to_accept.len(), chain.len());
+        assert_eq!(*state.phase(), PresyncPhase::Final);
+    }
+
+    #[test]
+    fn presync_stays_in_presync_below_minimum_work() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Bitcoin);
+
+        // Easy-difficulty headers have negligible work vs mainnet nMinimumChainWork.
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, 5);
+        let result = state.process_presync(&chain);
+
+        assert!(result.success);
+        assert!(result.request_more);
+        assert_eq!(*state.phase(), PresyncPhase::Presync);
+    }
+
+    #[test]
+    fn presync_stays_in_presync_below_signet_minimum_work() {
+        let genesis = BlockHash::all_zeros();
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Signet);
+
+        // Easy-difficulty headers have negligible work vs signet's nMinimumChainWork.
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, 5);
+        let result = state.process_presync(&chain);
+
+        assert!(result.success);
+        assert!(result.request_more);
+        assert_eq!(*state.phase(), PresyncPhase::Presync);
+    }
+
+    #[test]
+    fn presync_aborts_gracefully_at_max_commitments() {
+        let genesis = BlockHash::all_zeros();
+        // Cap at 1 so the second commitment slot triggers the abort.
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest)
+            .with_max_commitments(1);
+
+        // 2 * REGTEST_PERIOD headers → exactly 2 commitment slots.
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, 2 * REGTEST_PERIOD);
+        let result = state.process_presync(&chain);
+
+        assert!(result.success);
+        assert!(!result.request_more);
+        assert!(result.headers_to_accept.is_empty());
+        assert_eq!(*state.phase(), PresyncPhase::Aborted);
+    }
+
+    #[test]
+    fn redownload_releases_headers_incrementally_via_buffer_size() {
+        let genesis = BlockHash::all_zeros();
+        // Use a huge minimum work so process_all_remaining stays false, exercising the
+        // buffer-size drain path rather than the flush-all path.
+        let huge_work = Work::from_be_bytes([0xff; 32]);
+        // 4 * REGTEST_PERIOD headers → 4 commitment slots.
+        let chain = make_chain(genesis, ANCIENT_TIMESTAMP, 4 * REGTEST_PERIOD);
+
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest)
+            .with_minimum_chain_work(huge_work)
+            .with_redownload_buffer_size(275)
+            .force_redownload(&chain);
+
+        // Feed 2 * REGTEST_PERIOD headers: buffer grows then drains back to REGTEST_PERIOD.
+        let result = state.process_redownload(&chain[..2 * REGTEST_PERIOD]);
+        assert!(result.success);
+        assert_eq!(result.headers_to_accept.len(), REGTEST_PERIOD);
+        assert!(result.headers_to_accept.len() < 2 * REGTEST_PERIOD);
+        assert_ne!(*state.phase(), PresyncPhase::Final);
+    }
+
+    #[test]
+    fn redownload_rejects_commitment_mismatch() {
+        let genesis = BlockHash::all_zeros();
+        // Use huge minimum work so process_all_remaining stays false and commitment
+        // checking remains active throughout REDOWNLOAD.
+        let huge_work = Work::from_be_bytes([0xff; 32]);
+        // REGTEST_PERIOD headers → exactly one commitment slot.
+        let bulk = make_chain(genesis, ANCIENT_TIMESTAMP, REGTEST_PERIOD);
+
+        let mut state = HeadersSyncState::new(0, genesis, easy_bits(), Network::Regtest)
+            .with_minimum_chain_work(huge_work)
+            .force_redownload(&bulk);
+
+        // Flip the stored bit so the replayed chain fails the commitment check.
+        state.flip_first_commitment();
+
+        let result = state.process_redownload(&bulk);
+        assert!(!result.success);
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -92,6 +92,7 @@ pub mod address_man;
 pub mod bitcoin_socket_addr;
 pub mod block_proof;
 pub mod error;
+pub(crate) mod headers_sync;
 pub mod network_message_ext;
 pub mod node;
 pub mod node_context;

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 use bitcoin::Network;
 use floresta_chain::AssumeUtreexoValue;
 
+use self::node::chain_selector_ctx::DEFAULT_MAX_TIP_AGE;
+
 #[derive(Debug, Clone)]
 /// Configuration for the Utreexo node.
 pub struct UtreexoNodeConfig {
@@ -66,6 +68,10 @@ pub struct UtreexoNodeConfig {
     pub allow_v1_fallback: bool,
     /// Whether to disable DNS seeds. Defaults to false.
     pub disable_dns_seeds: bool,
+    /// Maximum age in seconds a chain tip may have before the node refuses to leave IBD.
+    /// Defaults to 86400 (24 hours). Set to `u32::MAX` to disable
+    /// (e.g. in tests using historical block fixtures).
+    pub max_tip_age_secs: u32,
 }
 
 impl Default for UtreexoNodeConfig {
@@ -84,6 +90,7 @@ impl Default for UtreexoNodeConfig {
             filter_start_height: None,
             user_agent: format!("floresta:{}", env!("CARGO_PKG_VERSION")),
             allow_v1_fallback: true,
+            max_tip_age_secs: DEFAULT_MAX_TIP_AGE,
         }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -48,6 +48,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bitcoin::Block;
 use bitcoin::BlockHash;
@@ -68,6 +70,7 @@ use rustreexo::stump::Stump;
 use tokio::time;
 use tokio::time::MissedTickBehavior;
 use tokio::time::timeout;
+use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -84,6 +87,9 @@ use crate::node_context::LoopControl;
 use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
 use crate::p2p_wire::error::WireError;
+use crate::p2p_wire::headers_sync::HeadersSyncState;
+use crate::p2p_wire::headers_sync::PresyncPhase;
+use crate::p2p_wire::headers_sync::ProcessingResult;
 use crate::p2p_wire::peer::PeerMessages;
 
 #[derive(Debug, Default, Clone)]
@@ -100,6 +106,9 @@ pub struct ChainSelector {
 
     /// Keep track each peer's tip
     tip_cache: HashMap<PeerId, BlockHash>,
+
+    /// Per-peer headers pre-synchronization state machines.
+    presync_states: HashMap<PeerId, HeadersSyncState>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -137,6 +146,11 @@ pub enum PeerCheck {
     BothUnresponsivePeers,
 }
 
+/// Maximum age in seconds a chain tip may have before the node refuses to leave IBD.
+///
+/// Mirrors Bitcoin Core's [`DEFAULT_MAX_TIP_AGE`](https://github.com/bitcoin/bitcoin/blob/8d5515465542336d3d0fb83935d79783e91048a0/src/kernel/chainstatemanager_opts.h#L24).
+pub(crate) const DEFAULT_MAX_TIP_AGE: u32 = 24 * 60 * 60;
+
 impl NodeContext for ChainSelector {
     const REQUEST_TIMEOUT: u64 = 60; // Ban peers stalling our IBD
 
@@ -172,23 +186,75 @@ where
             return Ok(());
         }
 
-        info!(
-            "Downloading headers from peer={peer} at height={} hash={}",
-            self.chain.get_best_block()?.0 + 1,
-            headers[0].block_hash()
-        );
+        // Presync only guards the initial DownloadingHeaders phase against disk-fill DoS.
+        // During LookingForForks, headers may start at an arbitrary fork point below our tip;
+        // routing them through presync would fail the continuity check and wrongly ban the peer.
+        if !matches!(self.context.state, ChainSelectorState::DownloadingHeaders) {
+            for header in &headers {
+                if let Err(e) = self.chain.accept_header(*header) {
+                    error!("Error while accepting fork header from peer={peer} err={e}");
+                    self.disconnect_and_ban(peer)?;
+                    return Ok(());
+                }
+            }
+            let last = headers.last().unwrap().block_hash();
+            self.context
+                .tip_cache
+                .entry(peer)
+                .and_modify(|e| *e = last)
+                .or_insert(last);
+            self.last_tip_update = Instant::now();
+            self.request_headers(last)?;
+            return Ok(());
+        }
 
-        for header in headers.iter() {
+        // Route through the headers pre-sync state machine before touching permanent storage.
+        let (start_height, start_hash) = self.chain.get_best_block()?;
+        let start_bits = self.chain.get_block_header(&start_hash)?.bits;
+        let network = self.network;
+
+        let (result, presync_start, phase_after) = {
+            let state = self.context.presync_states.entry(peer).or_insert_with(|| {
+                HeadersSyncState::new(start_height, start_hash, start_bits, network)
+            });
+
+            info!(
+                "Downloading headers from peer={peer} at height={} hash={}",
+                state.start_height + 1,
+                headers[0].block_hash()
+            );
+
+            let result = match state.phase() {
+                PresyncPhase::Presync => state.process_presync(&headers),
+                PresyncPhase::Redownload => state.process_redownload(&headers),
+                PresyncPhase::Final | PresyncPhase::Aborted => ProcessingResult {
+                    success: true,
+                    ..Default::default()
+                },
+            };
+
+            (result, state.start_hash, state.phase().clone())
+        };
+
+        if !result.success {
+            error!("Peer {peer} failed headers presync, disconnecting and banning");
+            self.context.presync_states.remove(&peer);
+            self.disconnect_and_ban(peer)?;
+            return Ok(());
+        }
+
+        // Accept only headers that passed commitment verification.
+        for header in &result.headers_to_accept {
             if let Err(e) = self.chain.accept_header(*header) {
                 error!("Error while downloading headers from peer={peer} err={e}");
-
+                self.context.presync_states.remove(&peer);
                 self.disconnect_and_ban(peer)?;
-
-                let peer = self.peers.get(&peer).unwrap();
+                let peer_info = self.peers.get(&peer).unwrap();
                 self.common.address_man.update_set_state(
-                    peer.address.id,
+                    peer_info.address.id,
                     AddressState::Banned(ChainSelector::BAN_TIME),
                 );
+                return Ok(());
             }
         }
 
@@ -198,9 +264,45 @@ where
             .entry(peer)
             .and_modify(|e| *e = last)
             .or_insert(last);
-
         self.last_tip_update = Instant::now();
-        self.request_headers(last)
+
+        match phase_after {
+            // PRESYNC just passed the tip-age gate; begin REDOWNLOAD from the start.
+            PresyncPhase::Redownload if !result.request_more => {
+                debug!(
+                    "Peer={peer} passed the presync work gate at tip={last}, redownloading headers for commitment verification"
+                );
+                let locator = self
+                    .chain
+                    .get_block_locator_for_tip(presync_start)
+                    .unwrap_or_default();
+                self.send_to_peer(peer, NodeRequest::GetHeaders(locator))?;
+            }
+            // REDOWNLOAD complete; discard state and continue with the normal sync flow.
+            PresyncPhase::Final => {
+                debug!("Peer={peer} finished headers redownload, presync complete at tip={last}");
+                self.context.presync_states.remove(&peer);
+                self.request_headers(last)?;
+            }
+            // Commitment cap hit; not misbehavior, silently drop this peer's presync.
+            PresyncPhase::Aborted => {
+                self.context.presync_states.remove(&peer);
+            }
+            // Still in PRESYNC or mid-REDOWNLOAD; request the next batch from this peer.
+            // Use an in-memory locator hash -- presync headers are never on disk.
+            _ => {
+                if let Some(hash) = self
+                    .context
+                    .presync_states
+                    .get(&peer)
+                    .and_then(|s| s.next_locator_hash())
+                {
+                    self.send_to_peer(peer, NodeRequest::GetHeaders(vec![hash]))?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Parses a serialized Utreexo accumulator into a [`Stump`].
@@ -621,6 +723,27 @@ where
     async fn empty_headers_message(&mut self, peer: PeerId) -> Result<(), WireError> {
         match self.context.state {
             ChainSelectorState::DownloadingHeaders => {
+                let (best_height, tip_hash) = self.chain.get_best_block()?;
+
+                // Skip the tip-age check at genesis: the genesis timestamp (~2009) is always
+                // stale and would trap regtest or a cold-start node in IBD indefinitely.
+                if best_height > 0 {
+                    let tip_time = self.chain.get_block_header(&tip_hash)?.time;
+                    let now: u32 = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_secs() as u32)
+                        .unwrap_or(0);
+                    let tip_age = now.saturating_sub(tip_time);
+
+                    if tip_age > self.config.max_tip_age_secs {
+                        warn!(
+                            tip_age,
+                            "header sync reached a stale tip; staying in IBD until the chain advances"
+                        );
+                        return Ok(());
+                    }
+                }
+
                 info!("Finished downloading headers from peer={peer}, checking if our peers agree");
                 self.poke_peers()?;
                 self.context.state = ChainSelectorState::LookingForForks(Instant::now());

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -186,10 +186,11 @@ where
             return Ok(());
         }
 
-        // Presync only guards the initial DownloadingHeaders phase against disk-fill DoS.
-        // During LookingForForks, headers may start at an arbitrary fork point below our tip;
-        // routing them through presync would fail the continuity check and wrongly ban the peer.
-        if !matches!(self.context.state, ChainSelectorState::DownloadingHeaders) {
+        // Gate on per-peer presync state, not the global ChainSelector phase. Once any
+        // peer advances the state to LookingForForks, peers that are still mid-presync
+        // must continue routing through their own state machine. Peers with no active
+        // presync entry have already completed presync and go directly to accept_header.
+        if !self.context.presync_states.contains_key(&peer) {
             for header in &headers {
                 if let Err(e) = self.chain.accept_header(*header) {
                     error!("Error while accepting fork header from peer={peer} err={e}");
@@ -1178,12 +1179,32 @@ where
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Instant;
 
+    use bitcoin::CompactTarget;
+    use bitcoin::Network;
+    use bitcoin::TxMerkleNode;
+    use bitcoin::block::Version;
+    use bitcoin::hashes::Hash;
+    use floresta_chain::AssumeValidArg;
     use floresta_chain::ChainState;
     use floresta_chain::FlatChainStore;
+    use floresta_chain::FlatChainStoreConfig;
+    use floresta_common::Ema;
+    use floresta_mempool::Mempool;
     use rustreexo::node_hash::BitcoinNodeHash;
+    use tokio::sync::Mutex;
+    use tokio::sync::RwLock;
+    use tokio::sync::mpsc::unbounded_channel;
 
     use super::*;
+    use crate::UtreexoNodeConfig;
+    use crate::address_man::AddressMan;
+    use crate::node::ConnectionKind;
+    use crate::node::LocalPeerView;
+    use crate::node::NodeRequest;
+    use crate::node::PeerStatus;
+    use crate::p2p_wire::transport::TransportProtocol;
 
     type TestNode = UtreexoNode<Arc<ChainState<FlatChainStore>>, ChainSelector>;
 
@@ -1284,6 +1305,107 @@ mod tests {
                     BitcoinNodeHash::from([0u8; 32]),
                 ],
             },
+        );
+    }
+
+    /// Reproduces the shared-state race: once any peer pushes the global ChainSelector state
+    /// to `LookingForForks`, headers from a peer that is still mid-presync must continue
+    /// routing through that peer's presync state machine rather than bypassing it.
+    ///
+    /// The test builds a chain of easy-PoW headers rooted at `BlockHash::all_zeros()`.
+    /// On Signet that parent is unknown, so `accept_header` rejects them -- if the global-
+    /// state gate incorrectly bypasses presync, the peer gets banned. If presync correctly
+    /// gates per-peer, the headers accumulate work inside the state machine and the peer
+    /// remains connected while waiting for more batches.
+    #[tokio::test]
+    async fn presync_gate_is_per_peer_not_global() {
+        let datadir = format!("./tmp-db/{}.cs_presync_race", rand::random::<u32>());
+        let chainstore = FlatChainStore::new(FlatChainStoreConfig::new(&datadir)).unwrap();
+        let chain = Arc::new(
+            ChainState::open(chainstore, Network::Signet, AssumeValidArg::Disabled).unwrap(),
+        );
+        let mempool = Arc::new(Mutex::new(Mempool::new(1000)));
+        let kill_signal = Arc::new(RwLock::new(false));
+
+        let mut node = TestNode::new(
+            UtreexoNodeConfig {
+                network: Network::Signet,
+                max_tip_age_secs: u32::MAX,
+                ..Default::default()
+            },
+            chain,
+            mempool,
+            None,
+            kill_signal,
+            AddressMan::new(None, &[]),
+        )
+        .unwrap();
+
+        // Wire up peer B with a live channel so send_to_peer doesn't error.
+        const PEER_B: u32 = 1;
+        let (peer_b_tx, _peer_b_rx) = unbounded_channel::<NodeRequest>();
+        node.peers.insert(
+            PEER_B,
+            LocalPeerView {
+                message_times: Ema::with_half_life_50(),
+                address: "127.0.0.1:8334".parse().unwrap(),
+                services: ServiceFlags::NONE,
+                user_agent: "test_peer".to_string(),
+                height: 0,
+                time_offset: 0,
+                state: PeerStatus::Ready,
+                channel: peer_b_tx,
+                kind: ConnectionKind::Regular(ServiceFlags::NONE),
+                banscore: 0,
+                _last_message: Instant::now(),
+                transport_protocol: TransportProtocol::V2,
+            },
+        );
+
+        // Simulate peer A having already finished: global state is now LookingForForks.
+        node.context.state = ChainSelectorState::LookingForForks(Instant::now());
+
+        // Peer B was mid-presync when peer A triggered the transition.
+        let genesis =
+            bitcoin::BlockHash::from_raw_hash(bitcoin::hashes::sha256d::Hash::all_zeros());
+        let easy_bits = CompactTarget::from_consensus(0x207f_ffff);
+        node.context.presync_states.insert(
+            PEER_B,
+            HeadersSyncState::new(0, genesis, easy_bits, Network::Signet),
+        );
+
+        // Build easy-PoW headers rooted at all_zeros.
+        // On Signet, all_zeros is not the real genesis hash, so accept_header rejects them.
+        // Presync only checks continuity and accumulates work, so it accepts them.
+        let mut headers = Vec::new();
+        let mut prev = genesis;
+        for i in 0..5u32 {
+            let h = (0u32..)
+                .map(|nonce| bitcoin::block::Header {
+                    version: Version::from_consensus(1),
+                    prev_blockhash: prev,
+                    merkle_root: TxMerkleNode::from_raw_hash(
+                        bitcoin::hashes::sha256d::Hash::all_zeros(),
+                    ),
+                    time: 1_000_000 + i,
+                    bits: easy_bits,
+                    nonce,
+                })
+                .find(|h| h.validate_pow(h.target()).is_ok())
+                .unwrap();
+            prev = h.block_hash();
+            headers.push(h);
+        }
+
+        node.handle_headers(PEER_B, headers).await.unwrap();
+
+        // Correct behavior: presync ran per-peer, accumulated work, peer B stays connected.
+        // Bug behavior: global gate bypassed presync, accept_header rejected the unknown-
+        // parent headers, peer B was banned.
+        assert_eq!(
+            node.peers.get(&PEER_B).map(|p| p.state),
+            Some(PeerStatus::Ready),
+            "peer B must stay connected while presync accumulates work on its active state"
         );
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
@@ -4,6 +4,8 @@
 
 use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bitcoin::p2p::ServiceFlags;
 use floresta_chain::ThreadSafeChain;
@@ -15,6 +17,7 @@ use tokio::time;
 use tokio::time::MissedTickBehavior;
 use tracing::debug;
 use tracing::info;
+use tracing::warn;
 
 use crate::node::ConnectionKind;
 use crate::node::InflightRequests;
@@ -235,16 +238,36 @@ where
             .get_validation_index()
             .expect("validation index block should present");
 
-        let best_block = self
+        let (best_block, tip_hash) = self
             .chain
             .get_best_block()
-            .expect("best block should present")
-            .0;
+            .expect("best block should present");
 
         if validation_index == best_block {
-            info!("IBD is finished, switching to normal operation mode");
-            self.chain.update_ibd(IBDState::Done);
-            return LoopControl::Break;
+            // Skip the tip-age check at genesis: the genesis timestamp (~2009) would
+            // always look stale and trap regtest nodes in IBD indefinitely.
+            let stale = best_block > 0 && {
+                let tip_time = self
+                    .chain
+                    .get_block_header(&tip_hash)
+                    .expect("tip header is always present")
+                    .time;
+                let now: u32 = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs() as u32)
+                    .unwrap_or(0);
+                now.saturating_sub(tip_time) > self.config.max_tip_age_secs
+            };
+
+            if stale {
+                warn!(
+                    "validation caught up to a stale tip; chain store may be stuck, staying in IBD"
+                );
+            } else {
+                info!("IBD is finished, switching to normal operation mode");
+                self.chain.update_ibd(IBDState::Done);
+                return LoopControl::Break;
+            }
         }
 
         periodic_job!(

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -203,6 +203,7 @@ pub fn get_node_config(
         pow_fraud_proofs,
         datadir: datadir.as_ref().into(),
         user_agent: "node_test".to_string(),
+        max_tip_age_secs: u32::MAX,
         ..Default::default()
     }
 }


### PR DESCRIPTION
## Summary

Implements the two-phase headers pre-synchronization protocol to protect against disk-fill DoS during initial header download.

Without this guard a peer can serve a long chain of individually-valid low-work headers that fill header storage before we discover the chain has insufficient work. The two-pass design:

- **PRESYNC**: headers are validated (PoW + continuity) but not written to disk. A salted one-bit commitment is stored at a per-network interval (641 headers on mainnet, 275 on Regtest).
- **REDOWNLOAD**: the same range is re-fetched, each header verified against its commitment, then released from the front of a per-network buffer once it exceeds the lookahead size (15,218 headers on mainnet). Once re-accumulated chainwork meets the network minimum, the buffer drains unconditionally.

The salt is random per-session and never transmitted, so the peer cannot predict which heights are commitment slots.

The commitment cap (`MAX_COMMITMENTS = 24_000`) is a fixed generous bound; Bitcoin Core computes this dynamically as `6 * elapsed_secs / commitment_period`. Dynamic cap support will be introduced in a follow-up PR once MTP threading is in place.

Closes #1162