### PR TITLE
fix(mempool): Avoid panic on empty block template

### DIFF
--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -119,7 +119,9 @@ impl MempoolBase for Mempool {
             txdata: txs,
         };
 
-        block.header.merkle_root = block.compute_merkle_root().unwrap();
+        block.header.merkle_root = block
+            .compute_merkle_root()
+            .unwrap_or_else(TxMerkleNode::all_zeros);
         block
     }
 
@@ -576,6 +578,23 @@ mod tests {
 
         assert_eq!(block.txdata.len(), 1);
         assert!(block.check_merkle_root());
+    }
+
+    #[test]
+    fn test_gbt_empty_mempool() {
+        let mempool = Mempool::new(10_000_000);
+
+        let target = Target::MAX_ATTAINABLE_REGTEST;
+        let block = mempool.get_block_template(
+            block::Version::ONE,
+            bitcoin::BlockHash::all_zeros(),
+            0,
+            target.to_compact_lossy(),
+            4_000_000,
+        );
+
+        assert!(block.txdata.is_empty());
+        assert_eq!(block.header.merkle_root, TxMerkleNode::all_zeros());
     }
 
     #[test]


### PR DESCRIPTION
### Description and Notes

`get_block_template` builds an unsolved block from the current mempool. After selecting transactions, it sets `header.merkle_root` from `block.compute_merkle_root()`. The `block.compute_merkle_root()` call returns `None` when `txdata` is empty (empty mempool or every tx filtered out by weight).

Previously the result was unconditionally `unwrap()`'d, so building a template from an empty mempool could panic the process instead of returning a header with a well-defined root.

This PR replaces the unwrap with `unwrap_or_else(TxMerkleNode::all_zeros)`, matching the zero root already used when the header is constructed.

A unit regression test is added.

#### Changelog

```
fix(mempool): avoid panic on empty block template
 - use unwrap_or_else(TxMerkleNode::all_zeros) when compute_merkle_root returns None
 - add test_gbt_empty_mempool regression test
```

### To verify changes

- `cargo test -p floresta-mempool test_gbt_empty_mempool`
- `cargo test -p floresta-mempool`