### PR TITLE
fix(rpc): findtxout inconsistencies and tests 

### DIFF
--- a/crates/floresta-node/src/json_rpc/blockchain.rs
+++ b/crates/floresta-node/src/json_rpc/blockchain.rs
@@ -30,8 +30,6 @@ use floresta_chain::extensions::HeaderExt;
 use floresta_chain::extensions::WorkExt;
 use floresta_wire::node_interface::ChainMethods;
 use miniscript::descriptor::checksum;
-use serde_json::Value;
-use serde_json::json;
 use tracing::debug;
 
 use super::res::GetBlockHeaderRes;
@@ -41,7 +39,6 @@ use super::server::RpcChain;
 use super::server::RpcImpl;
 use crate::json_rpc::res::GetBlockRes;
 use crate::json_rpc::res::RescanConfidence;
-use crate::json_rpc::server::SERIALIZATION_EXPECT_MSG;
 use crate::json_rpc::server::to_core_asm_string;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
@@ -664,10 +661,10 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         txid: Txid,
         vout: u32,
         script: ScriptBuf,
-        height: u32,
-    ) -> Result<Value, JsonRpcError> {
-        if let Some(txout) = self.wallet.get_utxo(&OutPoint { txid, vout }) {
-            return Ok(serde_json::to_value(txout).expect(SERIALIZATION_EXPECT_MSG));
+        height_hint: u32,
+    ) -> Result<Option<GetTxOut>, JsonRpcError> {
+        if let Some(txout) = self.get_tx_out(txid, vout, false)? {
+            return Ok(Some(txout));
         }
 
         // if we are on IBD, we don't have any filters to find this txout.
@@ -680,43 +677,40 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             return Err(JsonRpcError::NoBlockFilters);
         };
 
+        debug!("Searching for {txid}:{vout}");
+
         self.wallet.cache_address(script.clone());
         let filter_key = script.to_bytes();
         let candidates = cfilters
             .match_any(
                 vec![filter_key.as_slice()],
-                Some(height),
+                Some(height_hint),
                 None,
                 self.chain.clone(),
             )
             .map_err(|e| JsonRpcError::Filters(e.to_string()))?;
 
         for candidate in candidates {
-            let candidate = self.node.get_block(candidate).await;
-            let candidate = match candidate {
-                Err(e) => {
-                    return Err(JsonRpcError::Node(e.to_string()));
-                }
-                Ok(None) => {
-                    return Err(JsonRpcError::Node(format!(
-                        "BUG: block {candidate:?} is a match in our filters, but we can't get it?"
-                    )));
-                }
-                Ok(Some(candidate)) => candidate,
+            let found = self
+                .node
+                .get_block(candidate)
+                .await
+                .map_err(|e| JsonRpcError::Node(e.to_string()))?;
+
+            let Some(found) = found else {
+                return Err(JsonRpcError::Node(format!(
+                    "BUG: block {candidate:?} is a match in our filters, but we can't get it?"
+                )));
             };
 
-            let Ok(Some(height)) = self.chain.get_block_height(&candidate.block_hash()) else {
+            let Ok(Some(height)) = self.chain.get_block_height(&found.block_hash()) else {
                 return Err(JsonRpcError::BlockNotFound);
             };
 
-            self.wallet.block_process(&candidate, height);
+            self.wallet.block_process(&found, height);
         }
 
-        let val = match self.get_tx_out(txid, vout, false)? {
-            Some(gettxout) => json!(gettxout),
-            None => json!({}),
-        };
-        Ok(val)
+        self.get_tx_out(txid, vout, false)
     }
 
     // getroots

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -331,9 +331,12 @@ async fn handle_json_rpc_request(
             let vout = get_at(&params, 1, "vout")?;
             let script: String = get_at(&params, 2, "script")?;
             let script = ScriptBuf::from_hex(&script).map_err(|_| JsonRpcError::InvalidScript)?;
-            let height = get_at(&params, 3, "height")?;
+            let height = get_at(&params, 3, "height_hint")?;
 
-            state.clone().find_tx_out(txid, vout, script, height).await
+            state
+                .find_tx_out(txid, vout, script, height)
+                .await
+                .map(|v| serde_json::to_value(v).expect(SERIALIZATION_EXPECT_MSG))
         }
 
         "getblock" => {

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -141,7 +141,7 @@ pub trait FlorestaRPC {
         outpoint: u32,
         script: String,
         height_hint: u32,
-    ) -> Result<Value>;
+    ) -> Result<Option<GetTxOut>>;
     #[doc = include_str!("../../../doc/rpc/getmemoryinfo.md")]
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
     #[doc = include_str!("../../../doc/rpc/getrpcinfo.md")]
@@ -175,7 +175,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         outpoint: u32,
         script: String,
         height_hint: u32,
-    ) -> Result<Value> {
+    ) -> Result<Option<GetTxOut>> {
         self.call(
             "findtxout",
             &[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,13 @@ from test_framework.constants import (
 from test_framework.node import Node, NodeType
 from test_framework.util import Utility
 
+# The default arguments for an `utreexod` acting as a server for our tests.
+UTREEXOD_ARGS = [
+    f"--miningaddr={WALLET_ADDRESS}",
+    "--utreexoproofindex",
+    "--prune=0",
+]
+
 
 @pytest.fixture(scope="session", autouse=True)
 def validate_and_check_environment():
@@ -144,11 +151,7 @@ def utreexod_node(node_manager) -> Node:
     """Single `utreexod` node with default configurations, started and ready for testing"""
     node = node_manager.add_node_extra_args(
         variant=NodeType.UTREEXOD,
-        extra_args=[
-            f"--miningaddr={WALLET_ADDRESS}",
-            "--utreexoproofindex",
-            "--prune=0",
-        ],
+        extra_args=UTREEXOD_ARGS,
     )
     node_manager.run_node(node)
     return node
@@ -220,6 +223,49 @@ def florestad_bitcoind_utreexod_with_chain(
         return florestad_node, bitcoind_node, utreexod_node
 
     return _create_nodes_with_chain
+
+
+@pytest.fixture
+def florestad_bitcoind_utreexod_with_filters(
+    florestad_node, bitcoind_node, add_node_with_extra_args, node_manager
+) -> Callable[..., tuple[Node, Node, Node]]:
+    """
+    Variant of `florestad_bitcoind_utreexod_with_chain` whose utreexod serves
+    compact block filters.
+
+    Utreexod only advertises NODE_COMPACT_FILTERS when started with
+    `--cfilters`, and florestad needs such a peer to download the filters that
+    back RPCs scanning them, like `findtxout`.
+    """
+
+    def _create_nodes_with_filters(
+        blocks: int = 100,
+        floresta_descriptors: List[str] | None = None,
+    ) -> tuple[Node, Node, Node]:
+        if floresta_descriptors is None:
+            floresta_descriptors = [
+                WALLET_DESCRIPTOR_EXTERNAL,
+                WALLET_DESCRIPTOR_INTERNAL,
+            ]
+
+        for descriptor in floresta_descriptors:
+            florestad_node.rpc.load_descriptor(descriptor)
+
+        utreexod_node = add_node_with_extra_args(
+            variant=NodeType.UTREEXOD,
+            extra_args=UTREEXOD_ARGS + ["--cfilters"],
+        )
+        utreexod_node.rpc.generate(blocks)
+
+        node_manager.connect_nodes(florestad_node, utreexod_node)
+        time.sleep(3)
+        node_manager.connect_nodes(bitcoind_node, utreexod_node)
+        time.sleep(1)
+        node_manager.connect_nodes(florestad_node, bitcoind_node)
+
+        return florestad_node, bitcoind_node, utreexod_node
+
+    return _create_nodes_with_filters
 
 
 @pytest.fixture(scope="class")
@@ -328,11 +374,7 @@ def shared_utreexod_node(shared_node_manager) -> Node:
     """Single utreexod node shared across all methods in a test class."""
     node = shared_node_manager.add_node_extra_args(
         variant=NodeType.UTREEXOD,
-        extra_args=[
-            f"--miningaddr={WALLET_ADDRESS}",
-            "--utreexoproofindex",
-            "--prune=0",
-        ],
+        extra_args=UTREEXOD_ARGS,
     )
     shared_node_manager.run_node(node)
     return node

--- a/tests/floresta-cli/findtxout.py
+++ b/tests/floresta-cli/findtxout.py
@@ -13,8 +13,6 @@ from test_framework.constants import (
 )
 from test_framework.util import compare_fields, wait_until
 
-IGNORE_FIELDS = ["bestblock", "confirmations"]
-
 BLOCKS = 20
 
 # Utreexod pays every coinbase to the same address, so the scan below ends up
@@ -31,12 +29,24 @@ def find_coinbase_output(florestad, bitcoind, height: int) -> tuple[str, str, di
     """
     Return the `(txid, scriptPubKey hex, gettxout result)` of the coinbase
     output of the block at `height`, using bitcoind as the reference node.
+
+    Both `bestblock` and `confirmations` are relative to the chain tip, so
+    the nodes must agree on it for the reference to be comparable. Nothing is
+    mined while the test runs, which keeps that true for every later call.
     """
+    tip = florestad.rpc.get_bestblockhash()
+    assert tip == bitcoind.rpc.get_bestblockhash(), "Nodes disagree on the chain tip."
+
     block_hash = florestad.rpc.get_blockhash(height)
     txid = florestad.rpc.get_block(block_hash)["tx"][0]
 
     reference = bitcoind.rpc.get_txout(txid, vout=0, include_mempool=False)
     assert reference is not None, f"Txout for tx {txid} is None in Bitcoind."
+
+    # Pin what the tip-relative fields are expected to hold, so a mismatch
+    # points at the value itself instead of at a node lagging behind.
+    assert reference["bestblock"] == tip
+    assert reference["confirmations"] == florestad.rpc.get_block_count() - height + 1
 
     return txid, reference["scriptPubKey"]["hex"], reference
 
@@ -97,12 +107,12 @@ def test_find_txout(
         error_msg=f"findtxout didn't find {txid}:0",
     )
 
-    compare_fields(found["txout"], reference, ignore_fields=IGNORE_FIELDS)
+    compare_fields(found["txout"], reference)
 
     log.info("The scanned output should now be cached on the wallet...")
     txout_cached = florestad.rpc.get_txout(txid, vout=0, include_mempool=False)
     assert txout_cached is not None, f"Txout for tx {txid} wasn't cached in Floresta."
-    compare_fields(txout_cached, reference, ignore_fields=IGNORE_FIELDS)
+    compare_fields(txout_cached, reference)
 
     log.info(f"An output that doesn't exist on {txid} shouldn't be found...")
     assert florestad.rpc.find_txout(txid, MISSING_VOUT, script, height) is None
@@ -131,8 +141,4 @@ def test_find_txout(
     )
 
     log.info("...while the output we cached still comes back, from the wallet")
-    compare_fields(
-        florestad.rpc.find_txout(txid, 0, script, height),
-        reference,
-        ignore_fields=IGNORE_FIELDS,
-    )
+    compare_fields(florestad.rpc.find_txout(txid, 0, script, height), reference)

--- a/tests/floresta-cli/findtxout.py
+++ b/tests/floresta-cli/findtxout.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+findtxout.py
+
+This functional test cli utility to interact with a Floresta node with `findtxout` command.
+"""
+
+import pytest
+from test_framework.constants import (
+    JSONRPC_ERRCODE_NO_BLOCK_FILTERS,
+    JSONRPC_ERRMSG_NO_BLOCK_FILTERS,
+)
+from test_framework.util import compare_fields, wait_until
+
+IGNORE_FIELDS = ["bestblock", "confirmations"]
+
+BLOCKS = 20
+
+# Utreexod pays every coinbase to the same address, so the scan below ends up
+# caching all of them. These are mined elsewhere to leave one output in the chain
+# that our wallet never learns about.
+UNCACHED_BLOCKS = 2
+
+# A vout that no coinbase transaction has, used to check the "block was found,
+# but the output isn't there" path.
+MISSING_VOUT = 99
+
+
+def find_coinbase_output(florestad, bitcoind, height: int) -> tuple[str, str, dict]:
+    """
+    Return the `(txid, scriptPubKey hex, gettxout result)` of the coinbase
+    output of the block at `height`, using bitcoind as the reference node.
+    """
+    block_hash = florestad.rpc.get_blockhash(height)
+    txid = florestad.rpc.get_block(block_hash)["tx"][0]
+
+    reference = bitcoind.rpc.get_txout(txid, vout=0, include_mempool=False)
+    assert reference is not None, f"Txout for tx {txid} is None in Bitcoind."
+
+    return txid, reference["scriptPubKey"]["hex"], reference
+
+
+# pylint: disable=too-many-locals
+@pytest.mark.rpc
+def test_find_txout(
+    setup_logging, florestad_bitcoind_utreexod_with_filters, node_manager
+):
+    """
+    Test the `findtxout` command for outputs that our wallet doesn't track.
+
+    No descriptor is loaded, so florestad's wallet is empty and `findtxout`
+    must fall back to the compact block filters to locate the output. Once
+    found, the output is cached, so `gettxout` and any further `findtxout`
+    call must answer with the very same structure.
+    """
+    log = setup_logging
+    florestad, bitcoind, utreexod = florestad_bitcoind_utreexod_with_filters(
+        BLOCKS, floresta_descriptors=[]
+    )
+
+    log.info("Waiting for Floresta and Bitcoind to sync with Utreexod...")
+    node_manager.wait_for_sync_nodes()
+
+    log.info(f"Mining {UNCACHED_BLOCKS} blocks paying someone we don't watch...")
+    bitcoind.rpc.generate_block(UNCACHED_BLOCKS)
+    node_manager.wait_for_sync_nodes()
+
+    height = BLOCKS // 2
+    txid, script, reference = find_coinbase_output(florestad, bitcoind, height)
+
+    # Left alone until the very end: asking for it now would cache it too.
+    uncached_txid, uncached_script, _ = find_coinbase_output(
+        florestad, bitcoind, BLOCKS + 1
+    )
+
+    log.info(f"Floresta shouldn't know anything about {txid}:0 yet...")
+    assert florestad.rpc.get_txout(txid, vout=0, include_mempool=False) is None
+
+    # The height is only a hint: filters are sought in 50k block strides, so
+    # anything below that mark is scanned from the genesis anyway. Hinting a
+    # height past the output must still find it.
+    #
+    # Filters are also downloaded in background after the IBD, so the first
+    # lookups may legitimately find nothing until they arrive.
+    log.info(f"Searching {txid}:0 on the filters, hinting height {BLOCKS}...")
+    found = {}
+
+    def scanned_filters() -> bool:
+        """Try to find the output, keeping the last answer around."""
+        found["txout"] = florestad.rpc.find_txout(txid, 0, script, BLOCKS)
+        return found["txout"] is not None
+
+    wait_until(
+        scanned_filters,
+        timeout=60,
+        error_msg=f"findtxout didn't find {txid}:0",
+    )
+
+    compare_fields(found["txout"], reference, ignore_fields=IGNORE_FIELDS)
+
+    log.info("The scanned output should now be cached on the wallet...")
+    txout_cached = florestad.rpc.get_txout(txid, vout=0, include_mempool=False)
+    assert txout_cached is not None, f"Txout for tx {txid} wasn't cached in Floresta."
+    compare_fields(txout_cached, reference, ignore_fields=IGNORE_FIELDS)
+
+    log.info(f"An output that doesn't exist on {txid} shouldn't be found...")
+    assert florestad.rpc.find_txout(txid, MISSING_VOUT, script, height) is None
+
+    # Asking again would find it either way, from the wallet or by scanning the
+    # filters a second time, so take the filters away: whatever answers now can
+    # only be the wallet. The lookup for them happens after the wallet is checked,
+    # which is what we're relying on.
+    log.info("Restarting Floresta without the filters to fall back on...")
+    florestad.stop()
+    florestad.daemon.set_extra_args(["--no-cfilters"])
+    florestad.start()
+
+    # Back on its feet before we ask: `find_tx_out` bails out on the IBD before it
+    # ever reaches for the filters, and it's the filters we want it to answer about.
+    node_manager.connect_nodes(florestad, utreexod)
+    node_manager.wait_for_sync_nodes()
+
+    log.info(f"An output we never cached, {uncached_txid}:0, is now unanswerable...")
+    florestad.rpc.ensure_rpc_call_error(
+        method="findtxout",
+        params=[uncached_txid, 0, uncached_script, height],
+        expected_status_code=503,
+        expected_rpcerror_code=JSONRPC_ERRCODE_NO_BLOCK_FILTERS,
+        expected_message=JSONRPC_ERRMSG_NO_BLOCK_FILTERS,
+    )
+
+    log.info("...while the output we cached still comes back, from the wallet")
+    compare_fields(
+        florestad.rpc.find_txout(txid, 0, script, height),
+        reference,
+        ignore_fields=IGNORE_FIELDS,
+    )

--- a/tests/floresta-cli/gettxout.py
+++ b/tests/floresta-cli/gettxout.py
@@ -9,8 +9,6 @@ This functional test cli utility to interact with a Floresta node with `gettxout
 import pytest
 from test_framework.util import compare_fields
 
-IGNORE_FIELDS = ["bestblock", "confirmations"]
-
 
 # pylint: disable=too-many-locals
 @pytest.mark.rpc
@@ -25,7 +23,14 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain, node_m
     log.info("Waiting for Floresta and Bitcoind to sync with Utreexod...")
     node_manager.wait_for_sync_nodes()
 
+    # `bestblock` and `confirmations` are relative to the chain tip, so both
+    # nodes must agree on it for the comparison below to hold. Nothing is
+    # mined while the test runs, which keeps that true for the whole loop.
     log.info("Comparing gettxout results between Floresta and Bitcoind...")
+    assert (
+        florestad.rpc.get_bestblockhash() == bitcoind.rpc.get_bestblockhash()
+    ), "Nodes disagree on the chain tip."
+
     for height in range(2, blocks):
         block_hash = florestad.rpc.get_blockhash(height)
         block = florestad.rpc.get_block(block_hash)
@@ -39,4 +44,4 @@ def test_get_txout(setup_logging, florestad_bitcoind_utreexod_with_chain, node_m
             txout_bitcoind = bitcoind.rpc.get_txout(tx, vout=0, include_mempool=False)
             assert txout_bitcoind is not None, f"Txout for tx {tx} is None in Bitcoind."
 
-            compare_fields(txout_floresta, txout_bitcoind, ignore_fields=IGNORE_FIELDS)
+            compare_fields(txout_floresta, txout_bitcoind)

--- a/tests/test_framework/constants.py
+++ b/tests/test_framework/constants.py
@@ -35,11 +35,13 @@ JSONRPC_ERRCODE_INVALID_REQUEST = -32600
 JSONRPC_ERRCODE_METHOD_NOT_FOUND = -32601
 JSONRPC_ERRCODE_INVALID_PARAMS = -32602
 JSONRPC_ERRCODE_INTERNAL = -32603
+JSONRPC_ERRCODE_NO_BLOCK_FILTERS = -32092
 
 # JSON-RPC error message constants
 JSONRPC_ERRMSG_MISSING_PARAMS = "Missing parameter"
 JSONRPC_ERRMSG_WRONG_PARAM_TYPE = "Invalid parameter type"
 JSONRPC_ERRMSG_METHOD_NOT_FOUND = "Method not found"
+JSONRPC_ERRMSG_NO_BLOCK_FILTERS = "Block filters not available"
 JSONRPC_ERRMSG_INVALID_VERSION = "The request contains a invalid jsonrpc version"
 JSONRPC_ERRMSG_MALFORMATED_PARAMS = (
     "A parameter is malformated, the parameter MUST be an array or an object"

--- a/tests/test_framework/rpc/floresta.py
+++ b/tests/test_framework/rpc/floresta.py
@@ -40,3 +40,15 @@ class FlorestaRPC(BaseRPC):
         Load a script descriptor into the wallet.
         """
         return self.perform_request("loaddescriptor", params=[descriptor])
+
+    def find_txout(self, txid: str, vout: int, script: str, height_hint: int):
+        """
+        Find a transaction output that our wallet doesn't track, scanning the
+        compact block filters from `height_hint` onwards.
+
+        Returns the same structure as `gettxout`, or `None` if the output
+        can't be found.
+        """
+        return self.perform_request(
+            "findtxout", params=[txid, vout, script, height_hint]
+        )


### PR DESCRIPTION
### Description and Notes

While reviewing #1247 I noticed we had some inconsistencies sitting on `findtxout`, a floresta flavored rpc that goes after caching txouts using cfilters.

This pr fix some inconsistencies on the server side, making it more consistent and well-tested.

### How to verify the changes you have done?

On the type change for `findtxout`:  Its internal signature was returning a generic json `Value` which is bad by itself but were needed because if a txout is already known the returned type was different, only a subset of what `gettxout` returns for us. Now we delegate again to `gettxout` to answer when the txout is not cached already and to return the exact same result if it was.

On the test: `findtxout` is very alike to `gettxout` but it was not tested. This pr includes a new test for it exercising its features and failures excluding the height_hint path because of how cfilters work now. I left a note for when we finish reworking it.

On the fields that were previously ignored both on `findtxout` and `gettxout`: Perhaps at the time of writing the tests for gettxout we still had some problems with nodes syncing during the tests, now we have stronger tools to assert on it. This pr also stops ignoring those fields specially because they are too important to be left aside, they are literally a difference between a valid spending and an invalid one.
