### PR TITLE
fix: check receiving addresses timestamp

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -661,10 +661,26 @@ where
         peer: u32,
         addresses: Vec<AddrV2Message>,
     ) -> Result<(), WireError> {
-        self.inflight.remove(&InflightRequests::GetAddresses);
+        /// Don't allow addresses whose timestamp are more than 10 minutes into the future, or an
+        /// attacker could make us drop all addresses from our address manager with their own.
+        const ADDRESS_TIME_CUTOFF: u64 = 600; // 10 minutes
+
         debug!("Got {} addresses from peer {}", addresses.len(), peer);
-        let addresses: Vec<_> = addresses.into_iter().map(|addr| addr.into()).collect();
-        self.address_man.push_addresses(&addresses);
+        self.inflight.remove(&InflightRequests::GetAddresses);
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System clock isn't working")
+            .as_secs();
+
+        let cutoff = now + ADDRESS_TIME_CUTOFF;
+        let good_addresses: Vec<_> = addresses
+            .into_iter()
+            .filter(|addr| u64::from(addr.time) < cutoff)
+            .map(|addr| addr.into())
+            .collect();
+
+        self.address_man.push_addresses(&good_addresses);
 
         // For feeler peers, we ask for addresses to populate our address manager,
         // then disconnect them

--- a/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/peer_man.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::time::Duration;
 use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -661,10 +662,25 @@ where
         peer: u32,
         addresses: Vec<AddrV2Message>,
     ) -> Result<(), WireError> {
-        self.inflight.remove(&InflightRequests::GetAddresses);
+        /// Don't allow addresses whose timestamp are more than 10 minutes into the future, or an
+        /// attacker could make us drop all addresses from our address manager with their own.
+        const ADDRESS_TIME_CUTOFF: Duration = Duration::from_secs(600); // 10 minutes
+
         debug!("Got {} addresses from peer {}", addresses.len(), peer);
-        let addresses: Vec<_> = addresses.into_iter().map(|addr| addr.into()).collect();
-        self.address_man.push_addresses(&addresses);
+        self.inflight.remove(&InflightRequests::GetAddresses);
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System clock isn't working");
+
+        let cutoff = now + ADDRESS_TIME_CUTOFF;
+        let good_addresses: Vec<_> = addresses
+            .into_iter()
+            .filter(|addr| u64::from(addr.time) < cutoff.as_secs())
+            .map(|addr| addr.into())
+            .collect();
+
+        self.address_man.push_addresses(&good_addresses);
 
         // For feeler peers, we ask for addresses to populate our address manager,
         // then disconnect them

--- a/tests/p2p/p2p_addr_relay.py
+++ b/tests/p2p/p2p_addr_relay.py
@@ -6,6 +6,8 @@ Verifies that the node correctly handles address messages (addr and addrv2),
 enforces message size limits, and responds to getaddr requests appropriately.
 """
 
+import time
+
 import pytest
 
 from test_framework.messages import msg_addrv2, msg_sendaddrv2, msg_getaddr
@@ -13,6 +15,7 @@ from test_framework.p2p import (
     P2PInterface,
 )
 from test_framework.util import wait_until
+from test_framework.messages import CAddress
 
 
 class AddrReceiver(P2PInterface):
@@ -77,6 +80,21 @@ class TestP2pAddrRelay:
 
         self.p2p_conn.send_without_ping(msg_sendaddrv2())
         self.check_disconnection(self.p2p_conn)
+
+        future_address = CAddress()
+        future_address.net = future_address.NET_TORV3
+        future_address.port = 8080
+        future_address.nServices = 1033
+        future_address.ip = (
+            "nix2iapg23s2g6tog6vmmr2xgywfly5522c27hnp7qwm5qyk73mufvyd.onion"
+        )
+        future_address.time = int(time.time()) + 60 * 60 * 24
+
+        self.default_msg.addrs.append(future_address)
+
+        self.log.info(
+            "Testing that addrv2 addresses more than ten minutes in the future are ignored"
+        )
 
         self.log.info("Testing addrv2 message ")
         self.connect_p2p()


### PR DESCRIPTION
Bitcoin Core checks AddrV2 messages' timestamp, and prevents them from being too far into the future. For us, if they are too into the future, they would take the top of our address manager and not be evicted, even if it's just boggus addresses created by an attacker.

This commit fixes that by dropping any address who's timestamp is more than ten minutes into the future. I'm not disconnecting the peer, as some clock drift might cause us to perceive that for some addresses.

Credit for this finding goes to the bitcoinfuzz project that found it while differential testing floresta's AddrV2 code with Bitcoin Core's.