### PR TITLE
fix(consensus): detect duplicate-sibling Merkle trees 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
+dependencies = [
+ "bitcoin-internals 0.6.0",
+]
+
+[[package]]
 name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +340,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6fb823712b12e5cfccdb9a2b6a62de2dc42ddb5ec489511025eebeba1c21829"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 0.1.0",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 0.20.0",
 ]
@@ -367,9 +382,20 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8a45c2b41c457a9a9e4670422fcbdf109afb3b22bc920b4045e8bdfd788a3d"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 0.1.0",
  "bitcoin-internals 0.5.0",
  "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67800fcf7f3ca52f7796d4466948a424326b225950c79d1e76d0458760bb25d"
+dependencies = [
+ "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-internals 0.6.0",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1007,6 +1033,7 @@ name = "floresta-chain"
 version = "0.5.0"
 dependencies = [
  "bitcoin",
+ "bitcoin_hashes 1.1.0",
  "bitcoinkernel",
  "criterion",
  "floresta-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ readme = "README.md"
 # All dependencies MUST be pinned precisely with `X.Y.z`
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "json", "tracing", "tokio"] }
 bitcoin = { version = "=0.32.8", default-features = false }
+bitcoin_hashes = { version = "=1.1.0", default-features = false }
 clap = { version = "=4.6.1", default-features = false, features = ["derive", "std", "error-context"] }
 corepc-types = { version = "=0.15.0" }
 console-subscriber = { version = "=0.5.0", default-features = false }

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
+bitcoin_hashes = { workspace = true }
 bitcoinkernel = { version = "=0.2.1", optional = true }
 lru = { version = "=0.18.2", optional = true }
 memmap2 = { version = "=0.9.11", optional = true }
@@ -34,6 +35,9 @@ twox-hash = { version = "=2.1.2", default-features = false, features = ["xxhash3
 # Local dependencies
 floresta-common = { workspace = true, features = ["std"] }
 floresta-metrics = { workspace = true, optional = true }
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+bitcoin_hashes = { workspace = true, features = ["cpufeatures"] }
 
 [dev-dependencies]
 bitcoin = { workspace = true, features = ["serde"] }

--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -16,6 +16,7 @@ use bitcoin::block::Version as HeaderVersion;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::deserialize;
 use bitcoin::constants::genesis_block;
+use bitcoin::merkle_tree;
 use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::SamplingMode;
@@ -27,6 +28,7 @@ use floresta_chain::FlatChainStore;
 use floresta_chain::FlatChainStoreConfig;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::pruned_utreexo::consensus::Consensus;
+use floresta_chain::pruned_utreexo::merkle::ConsensusMerkle;
 use floresta_chain::pruned_utreexo::utxo_data::UtxoData;
 use rustreexo::proof::Proof;
 
@@ -162,7 +164,7 @@ fn check_merkle_root_benchmark(c: &mut Criterion) {
     let block_bytes = zstd::decode_all(block_file).unwrap();
     let block: Block = deserialize(&block_bytes).unwrap();
 
-    // Both are equivalent: sanity check both before the benchmark
+    // Both implementations agree on this valid block.
     assert!(block.check_merkle_root());
     Consensus::check_merkle_root(&block).unwrap();
 
@@ -172,6 +174,20 @@ fn check_merkle_root_benchmark(c: &mut Criterion) {
 
     c.bench_function("Consensus::check_merkle_root", |b| {
         b.iter(|| black_box(Consensus::check_merkle_root(&block)))
+    });
+
+    // Now benchmark merkle reduction only, given this txid list.
+    let txids: Vec<_> = block.txdata.iter().map(|tx| tx.compute_txid()).collect();
+
+    c.bench_function("bitcoin::merkle_tree::calculate_root", |b| {
+        b.iter(|| {
+            let hash_iter = black_box(&txids).iter().map(|txid| txid.to_raw_hash());
+            black_box(merkle_tree::calculate_root(hash_iter))
+        })
+    });
+
+    c.bench_function("ConsensusMerkle::calculate_root", |b| {
+        b.iter(|| black_box(ConsensusMerkle::calculate_root(black_box(&txids))))
     });
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -26,7 +26,6 @@ use bitcoin::blockdata::Weight;
 use bitcoin::consensus::serialize;
 use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256;
-use bitcoin::merkle_tree;
 use bitcoin::script;
 #[cfg(feature = "bitcoinkernel")]
 use bitcoinkernel::PrecomputedTransactionData;
@@ -578,25 +577,6 @@ impl Consensus {
         }
 
         Ok(txids)
-    }
-
-    /// Checks if the merkle root of the header matches the merkle root of the transaction list.
-    ///
-    /// Unlike [`Block::check_merkle_root`], this function returns the list of computed [`Txid`]s
-    /// if the merkle roots matched, or `None` otherwise.
-    ///
-    /// The merkle root is computed in the same way as [`Block::compute_merkle_root`].
-    pub fn check_merkle_root(block: &Block) -> Option<Vec<Txid>> {
-        let txids: Vec<_> = block.txdata.iter().map(|obj| obj.compute_txid()).collect();
-
-        // Copy the hashes into an iterator, as `calculate_root` requires ownership
-        let hashes_iter = txids.iter().copied().map(|txid| txid.to_raw_hash());
-
-        let calculated = merkle_tree::calculate_root(hashes_iter).map(|h| h.into());
-        match calculated {
-            Some(merkle_root) if block.header.merkle_root == merkle_root => Some(txids),
-            _ => None,
-        }
     }
 
     /// Validates a block under AssumeValid SwiftSync, where previous outputs are unavailable,
@@ -1321,6 +1301,32 @@ mod tests {
                 panic!("merkle roots shouldn't match");
             }
         }
+    }
+
+    #[test]
+    fn rejects_cve_2012_2459_duplicate_subtree_mutation() {
+        let mut block = decode_block("./testdata/block_866342/raw.zst");
+        block.txdata.truncate(6);
+        block.header.merkle_root = block.compute_merkle_root().unwrap();
+
+        assert!(Consensus::check_merkle_root(&block).is_some());
+
+        // CVE-2012-2459:
+        // `[1, 2, 3, 4, 5, 6]` and `[1, 2, 3, 4, 5, 6, 5, 6]` have the same Merkle root.
+        block.txdata.extend_from_within(4..6);
+        assert_eq!(block.txdata.len(), 8);
+
+        // A root-only check accepts it, but consensus mutation detection must reject it.
+        assert!(block.check_merkle_root());
+        assert!(Consensus::check_merkle_root(&block).is_none());
+
+        let consensus = Consensus::from(Network::Bitcoin);
+        assert!(matches!(
+            consensus.check_block(&block, 866_342),
+            Err(BlockchainError::BlockValidation(
+                BlockValidationErrors::BadMerkleRoot
+            ))
+        ));
     }
 
     /// Modifies historical block at height 866,342 by adding one extra transaction so that the

--- a/crates/floresta-chain/src/pruned_utreexo/merkle.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/merkle.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bitcoin transaction Merkle-root calculation and mutation detection.
+//!
+//! Bitcoin duplicates the final hash when a tree level has an odd length:
+//!
+//! ```text
+//!            A                         A
+//!        ┌───┴───┐                 ┌───┴───┐
+//!        B       C                 B       C
+//!      ┌─┴─┐   ┌─┴─┐             ┌─┴─┐   ┌─┴─┐
+//!      D   E   F   F*            D   E   F   F
+//!     ┌┴┐ ┌┴┐ ┌┴┐               ┌┴┐ ┌┴┐ ┌┴┐ ┌┴┐
+//!     1 2 3 4 5 6               1 2 3 4 5 6 5 6
+//! ```
+//!
+//! In the first tree, the second level is `[D, E, F]`, while `F*` is Bitcoin's
+//! synthetic duplicate. In the second, both `F` nodes are real, so both transaction
+//! lists produce the same root `A`.
+//! This is [CVE-2012-2459](https://www.cve.org/CVERecord?id=CVE-2012-2459).
+//!
+//! To detect this mutation, equal real siblings are recorded before adding Bitcoin's
+//! synthetic odd-tail duplicate. Mutated transaction data must be rejected without
+//! permanently invalidating the block header, since an unmutated block can have the
+//! same hash.
+//!
+//! This follows Bitcoin Core's
+//! [`ComputeMerkleRoot`](https://github.com/bitcoin/bitcoin/blob/v31.0/src/consensus/merkle.cpp#L46-L63)
+//! semantics.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use bitcoin::Block;
+use bitcoin::Transaction;
+use bitcoin::TxMerkleNode;
+use bitcoin::Txid;
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::Hash;
+use bitcoin_hashes::HashEngine as _;
+use bitcoin_hashes::Sha256d;
+
+use super::consensus::Consensus;
+
+#[derive(Clone, Copy)]
+/// Floresta's consensus-compatible Bitcoin transaction Merkle backend.
+pub struct ConsensusMerkle;
+
+impl ConsensusMerkle {
+    /// Computes a transaction Merkle root and reports equal real sibling hashes.
+    ///
+    /// Rust counterpart of Bitcoin Core's [`ComputeMerkleRoot`]. Returns `(root, mutated)`.
+    /// The root always covers the entire input, including when `mutated` is true.
+    /// Unlike Core's zero hash for an empty list, this returns `None`.
+    /// Synthetic siblings added for odd-length levels are not mutations.
+    ///
+    /// [`ComputeMerkleRoot`]: https://github.com/bitcoin/bitcoin/blob/v31.0/src/consensus/merkle.cpp#L46-L63
+    pub fn calculate_root(txids: &[Txid]) -> Option<(TxMerkleNode, bool)> {
+        let mut level: Vec<[u8; 32]> = txids.iter().map(|txid| txid.to_byte_array()).collect();
+
+        if level.is_empty() {
+            return None;
+        }
+
+        // Scratch space for each level's packed `left || right` inputs.
+        let mut inputs = Vec::<[u8; 64]>::with_capacity(level.len().div_ceil(2));
+        let mut mutated = false;
+
+        while level.len() > 1 {
+            for pair in level.chunks_exact(2) {
+                mutated |= pair[0] == pair[1];
+            }
+
+            Self::reduce_level(&mut level, &mut inputs);
+        }
+
+        let root = TxMerkleNode::from_byte_array(level[0]);
+        Some((root, mutated))
+    }
+
+    fn reduce_level(level: &mut Vec<[u8; 32]>, inputs: &mut Vec<[u8; 64]>) {
+        let parent_count = level.len().div_ceil(2);
+        inputs.resize(parent_count, [0; 64]);
+
+        // Pack each pair, duplicating an unpaired final hash.
+        let pairs = level.chunks(2);
+
+        for (input, pair) in inputs.iter_mut().zip(pairs) {
+            let (left, right) = match pair {
+                [left, right] => (left, right),
+                [left] => (left, left),
+                _ => unreachable!("chunks(2) yields chunks of one or two elements"),
+            };
+
+            input[..32].copy_from_slice(left);
+            input[32..].copy_from_slice(right);
+        }
+
+        // Hash all parents into the front of `level`.
+        Sha256d::hash_64_many(&mut level[..parent_count], inputs);
+        level.truncate(parent_count);
+    }
+}
+
+impl Consensus {
+    /// Validates a block's transaction Merkle commitment for consensus.
+    ///
+    /// Returns the computed [`Txid`]s only when the header commits to their Merkle root
+    /// and the tree has no duplicate-sibling mutation ([CVE-2012-2459]). Bitcoin Core
+    /// performs these checks across [`BlockMerkleRoot`] and [`CheckMerkleRoot`]. This
+    /// method combines them and returns the transaction IDs for reuse.
+    ///
+    /// [`Block::check_merkle_root`] only checks that the root matches and does not
+    /// detect mutation. Use this method instead for consensus validation.
+    ///
+    /// [CVE-2012-2459]: https://www.cve.org/CVERecord?id=CVE-2012-2459
+    /// [`BlockMerkleRoot`]: https://github.com/bitcoin/bitcoin/blob/v31.0/src/consensus/merkle.cpp#L66-L74
+    /// [`CheckMerkleRoot`]: https://github.com/bitcoin/bitcoin/blob/v31.0/src/validation.cpp#L3869-L3894
+    pub fn check_merkle_root(block: &Block) -> Option<Vec<Txid>> {
+        let txids: Vec<_> = block.txdata.iter().map(compute_txid).collect();
+
+        // Core defines the root of an empty transaction list as zero.
+        let (root, mutated) =
+            ConsensusMerkle::calculate_root(&txids).unwrap_or((TxMerkleNode::all_zeros(), false));
+
+        (!mutated && block.header.merkle_root == root).then_some(txids)
+    }
+}
+
+#[rustfmt::skip]
+/// Computes a non-witness transaction ID using the newer `bitcoin_hashes` SHA256d engine.
+///
+/// This mirrors rust-bitcoin's [`Transaction::compute_txid`], but uses `bitcoin_hashes` 1.x
+/// with its `cpufeatures`-enabled ARM SHA2 implementation.
+///
+/// TODO: Remove this helper once our rust-bitcoin dependency provides the same acceleration.
+fn compute_txid(tx: &Transaction) -> Txid {
+    struct NewTxidEngine(bitcoin_hashes::sha256d::HashEngine);
+
+    impl bitcoin::io::Write for NewTxidEngine {
+        fn write(&mut self, buf: &[u8]) -> bitcoin::io::Result<usize> {
+            self.0.input(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> bitcoin::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut enc = NewTxidEngine(Sha256d::engine());
+    tx.version.consensus_encode(&mut enc).expect("engines don't error");
+    tx.input.consensus_encode(&mut enc).expect("engines don't error");
+    tx.output.consensus_encode(&mut enc).expect("engines don't error");
+    tx.lock_time.consensus_encode(&mut enc).expect("engines don't error");
+
+    Txid::from_byte_array(Sha256d::from_engine(enc.0).to_byte_array())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::Network;
+    use bitcoin::TxMerkleNode;
+    use bitcoin::Txid;
+    use bitcoin::constants::genesis_block;
+    use bitcoin::hashes::Hash;
+    use bitcoin::merkle_tree;
+
+    use crate::pruned_utreexo::consensus::Consensus;
+    use crate::pruned_utreexo::merkle::ConsensusMerkle;
+    use crate::pruned_utreexo::merkle::compute_txid;
+
+    fn unique_txids(count: u8) -> Vec<Txid> {
+        (0..count)
+            .map(|value| Txid::from_byte_array([value; 32]))
+            .collect()
+    }
+
+    #[test]
+    fn matches_rust_bitcoin_roots() {
+        for count in 0..=16 {
+            let txids = unique_txids(count);
+            let expected = merkle_tree::calculate_root(txids.iter().map(|txid| txid.to_raw_hash()))
+                .map(TxMerkleNode::from);
+
+            let actual = ConsensusMerkle::calculate_root(&txids);
+            assert_eq!(actual.map(|(root, _)| root), expected);
+            assert!(!actual.is_some_and(|(_, mutated)| mutated));
+        }
+    }
+
+    #[test]
+    fn detects_duplicate_subtrees() {
+        for count in [3, 6, 12] {
+            let txids = unique_txids(count);
+            let mut duplicated = txids.clone();
+            let duplicate_count = count.next_power_of_two() - count;
+            duplicated.extend_from_slice(&txids[usize::from(count - duplicate_count)..]);
+
+            let (root, mutated) = ConsensusMerkle::calculate_root(&txids).unwrap();
+            let (duplicated_root, duplicated_mutated) =
+                ConsensusMerkle::calculate_root(&duplicated).unwrap();
+
+            assert_eq!(root, duplicated_root);
+            assert!(!mutated);
+            assert!(duplicated_mutated);
+        }
+    }
+
+    #[test]
+    fn detects_non_tail_duplicate_subtree() {
+        let mut txids = unique_txids(8);
+
+        // [0, 1, 0, 1, 4, 5, 6, 7]
+        txids[2] = txids[0];
+        txids[3] = txids[1];
+
+        let (_, mutated) = ConsensusMerkle::calculate_root(&txids).unwrap();
+
+        assert!(mutated);
+    }
+
+    #[test]
+    fn empty_block_uses_core_zero_root() {
+        let mut block = genesis_block(Network::Regtest);
+        block.txdata.clear();
+
+        assert!(Consensus::check_merkle_root(&block).is_none());
+
+        block.header.merkle_root = TxMerkleNode::all_zeros();
+        // Such block is invalid, but not considered mutated.
+        assert_eq!(Consensus::check_merkle_root(&block), Some(Vec::new()));
+    }
+
+    #[test]
+    fn compute_txid_matches_rust_bitcoin_and_excludes_witness() {
+        let mut tx = genesis_block(Network::Bitcoin).txdata[0].clone();
+        let expected = tx.compute_txid();
+
+        assert_eq!(compute_txid(&tx), expected);
+
+        tx.input[0].witness.push([42u8; 32]);
+
+        assert_eq!(tx.compute_txid(), expected);
+        assert_eq!(compute_txid(&tx), expected);
+    }
+}

--- a/crates/floresta-chain/src/pruned_utreexo/merkle.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/merkle.rs
@@ -38,8 +38,10 @@ use bitcoin::TxMerkleNode;
 use bitcoin::Txid;
 use bitcoin::consensus::Encodable;
 use bitcoin::hashes::Hash;
+use bitcoin::hashes::sha256d;
 use bitcoin_hashes::HashEngine as _;
 use bitcoin_hashes::Sha256d;
+use floresta_common::MerkleBackend;
 
 use super::consensus::Consensus;
 
@@ -128,6 +130,57 @@ impl Consensus {
     }
 }
 
+impl MerkleBackend for ConsensusMerkle {
+    /// Computes the sibling hashes needed to prove a transaction's inclusion.
+    ///
+    /// Returns `None` when `leaves` is empty or `position` is out of bounds.
+    /// For valid positions, this is equivalent to Bitcoin Core's
+    /// [`TransactionMerklePath`], using the same batched level reduction as
+    /// [`ConsensusMerkle::calculate_root`].
+    ///
+    /// Example:
+    ///
+    /// ```text
+    ///                 root (0)
+    ///           ┌─────────┴─────────┐
+    ///        H01 (0)             H23 (1)
+    ///      ┌────┴────┐         ┌────┴────┐
+    ///    0 (00)    1 (01)    2 (10)    3 (11)
+    /// ```
+    ///
+    /// Parentheses contain each node's binary index within its level. At each level,
+    /// `position ^ 1` selects the sibling and `position >> 1` selects the parent.
+    /// When a sibling is missing, Bitcoin's odd-tail rule uses the current node itself.
+    ///
+    /// [`TransactionMerklePath`]: https://github.com/bitcoin/bitcoin/blob/v31.0/src/consensus/merkle.cpp#L172-L180
+    fn calculate_branch(
+        &self,
+        leaves: &[sha256d::Hash],
+        mut position: usize,
+    ) -> Option<Vec<sha256d::Hash>> {
+        if position >= leaves.len() {
+            return None;
+        }
+
+        let mut level: Vec<[u8; 32]> = leaves.iter().map(|hash| hash.to_byte_array()).collect();
+        let mut inputs = Vec::<[u8; 64]>::with_capacity(level.len().div_ceil(2));
+        let mut branch = Vec::new();
+
+        while level.len() > 1 {
+            // Flip the low bit to switch between the left and right child of a pair.
+            // If the sibling is missing, Bitcoin's odd-tail rule duplicates the final child.
+            let sibling = level.get(position ^ 1).copied().unwrap_or(level[position]);
+            branch.push(sha256d::Hash::from_byte_array(sibling));
+
+            Self::reduce_level(&mut level, &mut inputs);
+            // Move to the parent index.
+            position >>= 1;
+        }
+
+        Some(branch)
+    }
+}
+
 #[rustfmt::skip]
 /// Computes a non-witness transaction ID using the newer `bitcoin_hashes` SHA256d engine.
 ///
@@ -165,7 +218,9 @@ mod tests {
     use bitcoin::Txid;
     use bitcoin::constants::genesis_block;
     use bitcoin::hashes::Hash;
+    use bitcoin::hashes::sha256d;
     use bitcoin::merkle_tree;
+    use floresta_common::MerkleBackend;
 
     use crate::pruned_utreexo::consensus::Consensus;
     use crate::pruned_utreexo::merkle::ConsensusMerkle;
@@ -187,6 +242,51 @@ mod tests {
             let actual = ConsensusMerkle::calculate_root(&txids);
             assert_eq!(actual.map(|(root, _)| root), expected);
             assert!(!actual.is_some_and(|(_, mutated)| mutated));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_branch_positions() {
+        assert!(ConsensusMerkle.calculate_branch(&[], 0).is_none());
+
+        let leaves = [Txid::all_zeros().to_raw_hash()];
+        assert!(
+            ConsensusMerkle
+                .calculate_branch(&leaves, leaves.len())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn branches_reconstruct_root() {
+        for count in 1..=16 {
+            let txids = unique_txids(count);
+            let leaves: Vec<_> = txids.iter().map(|txid| txid.to_raw_hash()).collect();
+            let expected_root = merkle_tree::calculate_root(leaves.iter().copied()).unwrap();
+
+            for (position, leaf) in leaves.iter().copied().enumerate() {
+                let branch = ConsensusMerkle.calculate_branch(&leaves, position).unwrap();
+
+                let mut hash = leaf;
+                let mut index = position;
+
+                for sibling in branch {
+                    let (left, right) = if index & 1 == 0 {
+                        (hash, sibling)
+                    } else {
+                        (sibling, hash)
+                    };
+
+                    let mut input = [0; 64];
+                    input[..32].copy_from_slice(&left.to_byte_array());
+                    input[32..].copy_from_slice(&right.to_byte_array());
+
+                    hash = sha256d::Hash::hash(&input);
+                    index >>= 1;
+                }
+
+                assert_eq!(hash, expected_root);
+            }
         }
     }
 

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod consensus;
 #[cfg(feature = "flat-chainstore")]
 pub mod flat_chain_store;
+pub mod merkle;
 pub mod partial_chain;
 pub mod udata;
 

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -151,8 +151,8 @@ impl PartialChainStateInner {
         self.median_time_past(height.saturating_sub(1))
     }
 
-    /// Process a block, given the proof, inputs, and deleted hashes. If we find an error,
-    /// we save it.
+    /// Process a block, given the proof, inputs, and deleted hashes.
+    /// If we find an error that proves the assumed chain invalid, we save it.
     pub fn process_block(
         &mut self,
         block: &bitcoin::Block,
@@ -164,7 +164,14 @@ impl PartialChainStateInner {
 
         if let Err(BlockchainError::BlockValidation(e)) = self.validate_block(block, height, inputs)
         {
-            self.error = Some(e.clone());
+            // These errors may describe a mutated payload for an otherwise valid header.
+            // Another peer can still provide the valid block, so don't poison this chain.
+            if !matches!(
+                e,
+                BlockValidationErrors::BadMerkleRoot | BlockValidationErrors::BadWitnessCommitment
+            ) {
+                self.error = Some(e.clone());
+            }
             return Err(BlockchainError::BlockValidation(e));
         }
 
@@ -532,7 +539,7 @@ mod tests {
 
     #[test]
     fn test_with_invalid_block() {
-        fn run(block: &str, reason: BlockValidationErrors) {
+        fn run(block: &str, reason: BlockValidationErrors, caches_error: bool) {
             let genesis = parse_block(
                 "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f20020000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000",
             );
@@ -542,22 +549,34 @@ mod tests {
             let res = chainstate.connect_block(&block, Proof::default(), HashMap::new(), vec![]);
 
             match res {
-                Err(BlockchainError::BlockValidation(_e)) if matches!(reason, _e) => {}
-                _ => panic!("unexpected {res:?}"),
+                Err(BlockchainError::BlockValidation(error)) if error == reason => {}
+                other => panic!("unexpected {other:?}"),
             };
+
+            assert_eq!(chainstate.has_invalid_blocks(), caches_error);
         }
         run(
             "0000002000226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f39adbcd7823048d34357bdca86cd47172afe2a4af8366b5b34db36df89386d49b23ec964ffff7f20000000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff165108feddb99c6b8435060b2f503253482f627463642fffffffff0100f2052a01000000160014806cef41295922d32ddfca09c26cc4acd36c3ed000000000",
             BlockValidationErrors::BlockExtendsAnOrphanChain,
+            true,
         );
         run(
             "0000002000226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f40adbcd7823048d34357bdca86cd47172afe2a4af8366b5b34db36df89386d49b23ec964ffff7f20000000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff165108feddb99c6b8435060b2f503253482f627463642fffffffff0100f2052a01000000160014806cef41295922d32ddfca09c26cc4acd36c3ed000000000",
             BlockValidationErrors::BadMerkleRoot,
+            false, // Potentially mutated block, original txdata may be valid
+        );
+        // Valid Merkle root, but the coinbase has witness data without a witness commitment
+        run(
+            "0000002000226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f39adbcd7823048d34357bdca86cd47172afe2a4af8366b5b34db36df89386d49b23ec964ffff7f200000000001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff165108feddb99c6b8435060b2f503253482f627463642fffffffff0100f2052a01000000160014806cef41295922d32ddfca09c26cc4acd36c3ed001010000000000",
+            BlockValidationErrors::BadWitnessCommitment,
+            false,
         );
     }
+
     fn parse_block(hex: &str) -> Block {
         deserialize_hex(hex).unwrap()
     }
+
     fn get_empty_pchain(blocks: Vec<Header>) -> PartialChainState {
         PartialChainStateInner {
             assume_valid: true,

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -31,10 +31,12 @@ use sha2::Digest;
 #[cfg(feature = "std")]
 mod ema;
 pub mod macros;
+pub mod merkle;
 pub mod spsc;
 
 #[cfg(feature = "std")]
 pub use ema::Ema;
+pub use merkle::MerkleBackend;
 pub use spsc::Channel;
 
 /// Computes the SHA-256 digest of the byte slice data and returns a [Hash] from `bitcoin_hashes`.

--- a/crates/floresta-common/src/merkle.rs
+++ b/crates/floresta-common/src/merkle.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use alloc::vec::Vec;
+
+use bitcoin::hashes::sha256d;
+
+// TODO This trait should be moved to floresta-domain (see https://github.com/getfloresta/Floresta/issues/1270).
+/// Backend for constructing Bitcoin transaction Merkle branches.
+pub trait MerkleBackend: Send + Sync {
+    /// Returns the sibling hashes for `position`, or `None` when it is out of bounds.
+    fn calculate_branch(
+        &self,
+        leaves: &[sha256d::Hash],
+        position: usize,
+    ) -> Option<Vec<sha256d::Hash>>;
+}

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -965,6 +965,7 @@ mod test {
     use floresta_chain::ChainState;
     use floresta_chain::FlatChainStore;
     use floresta_chain::FlatChainStoreConfig;
+    use floresta_chain::pruned_utreexo::merkle::ConsensusMerkle;
     use floresta_common::assert_ok;
     use floresta_common::get_spk_hash;
     use floresta_mempool::Mempool;
@@ -1034,7 +1035,7 @@ mod test {
     fn get_test_cache() -> Arc<AddressCache<KvDatabase>> {
         let test_id: u32 = rand::random();
         let cache = KvDatabase::new(format!("./tmp-db/{test_id}.floresta")).unwrap();
-        let cache = AddressCache::new(cache);
+        let cache = AddressCache::new(cache, ConsensusMerkle);
 
         // Inserting test transactions in the wallet
         let (transaction, proof) = get_test_transaction();

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -25,6 +25,7 @@ use floresta_chain::FlatChainStore as ChainStore;
 use floresta_chain::FlatChainStoreConfig;
 #[cfg(feature = "zmq-server")]
 use floresta_chain::pruned_utreexo::BlockchainInterface;
+use floresta_chain::pruned_utreexo::merkle::ConsensusMerkle;
 #[cfg(feature = "json-rpc")]
 use floresta_common::NetworkExt;
 use floresta_common::try_and_log;
@@ -723,7 +724,7 @@ impl Florestad {
         let database = KvDatabase::new(&self.config.datadir)
             .map_err(FlorestadError::CouldNotOpenKvDatabase)?;
 
-        let wallet = AddressCache::new(database);
+        let wallet = AddressCache::new(database, ConsensusMerkle);
 
         wallet
             .setup()

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -20,6 +20,7 @@ use bitcoin::ScriptBuf;
 use bitcoin::hashes::sha256;
 use floresta_chain::BlockConsumer;
 use floresta_chain::UtxoData;
+pub use floresta_common::MerkleBackend;
 use floresta_common::get_spk_hash;
 
 pub mod descriptor;
@@ -208,7 +209,12 @@ struct AddressCacheInner<D: AddressCacheDatabase> {
 impl<D: AddressCacheDatabase> AddressCacheInner<D> {
     /// Iterates through a block, finds transactions destined to ourselves.
     /// Returns all transactions we found.
-    fn block_process(&mut self, block: &Block, height: u32) -> Vec<(Transaction, TxOut)> {
+    fn block_process(
+        &mut self,
+        block: &Block,
+        height: u32,
+        merkle: &dyn MerkleBackend,
+    ) -> Vec<(Transaction, TxOut)> {
         let mut my_transactions = Vec::new();
         // Check if this transaction spends from one of our utxos
         for (position, transaction) in block.txdata.iter().enumerate() {
@@ -229,7 +235,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                         .get(txin.previous_output.vout as usize)
                         .expect("Did we cache an invalid utxo?");
 
-                    let merkle_block = MerkleProof::from_block(block, position as u64);
+                    let merkle_block = MerkleProof::from_block(block, position as u64, merkle);
 
                     self.cache_transaction(
                         transaction,
@@ -249,7 +255,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
                 if self.script_set.contains(&hash) {
                     my_transactions.push((transaction.clone(), output.clone()));
 
-                    let merkle_block = MerkleProof::from_block(block, position as u64);
+                    let merkle_block = MerkleProof::from_block(block, position as u64, merkle);
 
                     self.cache_transaction(
                         transaction,
@@ -583,6 +589,7 @@ impl<D: AddressCacheDatabase> AddressCacheInner<D> {
 /// methods, to store all data
 pub struct AddressCache<D: AddressCacheDatabase> {
     inner: RwLock<AddressCacheInner<D>>,
+    merkle: Box<dyn MerkleBackend>,
 }
 
 impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressCache<D> {
@@ -601,9 +608,10 @@ impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressC
 }
 
 impl<D: AddressCacheDatabase> AddressCache<D> {
-    pub fn new(database: D) -> Self {
+    pub fn new(database: D, merkle: impl MerkleBackend + 'static) -> Self {
         Self {
             inner: RwLock::new(AddressCacheInner::new(database)),
+            merkle: Box::new(merkle),
         }
     }
 
@@ -721,7 +729,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
 
     pub fn block_process(&self, block: &Block, height: u32) -> Vec<(Transaction, TxOut)> {
         let mut inner = self.inner.write().expect("poisoned lock");
-        inner.block_process(block, height)
+        inner.block_process(block, height, self.merkle.as_ref())
     }
 
     pub fn get_address_utxos(&self, script_hash: &Hash) -> Option<Vec<(TxOut, OutPoint)>> {
@@ -852,6 +860,7 @@ mod test {
     use bitcoin::consensus::deserialize;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::hashes::sha256;
+    use floresta_chain::pruned_utreexo::merkle::ConsensusMerkle;
     use floresta_common::get_spk_hash;
     use floresta_common::prelude::*;
 
@@ -870,7 +879,7 @@ mod test {
 
     fn get_test_cache() -> AddressCache<MemoryDatabase> {
         let database = MemoryDatabase::new();
-        AddressCache::new(database)
+        AddressCache::new(database, ConsensusMerkle)
     }
 
     fn get_test_address() -> (Address<NetworkChecked>, sha256::Hash) {

--- a/crates/floresta-watch-only/src/merkle.rs
+++ b/crates/floresta-watch-only/src/merkle.rs
@@ -11,6 +11,8 @@ use floresta_common::prelude::*;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::MerkleBackend;
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 /// A Merkle inclusion proof for a [`Transaction`](bitcoin::Transaction).
 pub struct MerkleProof {
@@ -54,9 +56,15 @@ impl MerkleProof {
     /// Creates a new proof from a list of hashes and a target. Target is a 64 bits
     /// unsigned integer indicating the index of a transaction we with to prove. Note that
     /// this only proves one tx at the time.
-    pub fn from_block_hashes(tx_list: Vec<sha256d::Hash>, target: u64) -> Self {
+    pub fn from_block_hashes(
+        tx_list: Vec<sha256d::Hash>,
+        target: u64,
+        merkle: &dyn MerkleBackend,
+    ) -> Self {
         let target_hash = tx_list[target as usize];
-        let (_, proof) = Self::transverse(tx_list, Vec::new(), target);
+        let proof = merkle
+            .calculate_branch(&tx_list, target as usize)
+            .expect("target is in transaction list");
         Self {
             target: target_hash.into(),
             pos: target,
@@ -66,13 +74,13 @@ impl MerkleProof {
 
     /// Same as [MerkleProof::from_block_hashes] but you give a block instead of a list of
     /// hashes.
-    pub fn from_block(block: &Block, target: u64) -> Self {
+    pub fn from_block(block: &Block, target: u64, merkle: &dyn MerkleBackend) -> Self {
         let tx_list: Vec<_> = block
             .txdata
             .iter()
             .map(|tx| tx.compute_txid().to_raw_hash())
             .collect();
-        Self::from_block_hashes(tx_list, target)
+        Self::from_block_hashes(tx_list, target, merkle)
     }
 
     /// Verifies a proof by hashing up all nodes until reach a root, and compare `root` with
@@ -92,17 +100,6 @@ impl MerkleProof {
         Ok(root == computed)
     }
 
-    /// Returns the position of a node's parent
-    fn get_parent(pos: u64) -> u64 {
-        (pos ^ 1) / 2
-    }
-
-    /// Returns a node's sibling. This is useful because we have to copy a node's sibling
-    /// to proof, so we can compute it's parent.
-    fn get_sibling(pos: u64) -> u64 {
-        pos ^ 1
-    }
-
     /// Computes the hash of two node's parent, by taking sha256d(left_child | right_child), where |
     /// means byte-wise concatenation.
     fn parent_hash(left: &[u8], right: &[u8]) -> sha256d::Hash {
@@ -110,58 +107,6 @@ impl MerkleProof {
         engine.input(left);
         engine.input(right);
         sha256d::Hash::from_engine(engine)
-    }
-
-    /// Iterates over the tree, collecting required nodes for proof, internally we compute
-    /// all intermediate nodes, but don't keep them.
-    fn transverse(
-        nodes: Vec<sha256d::Hash>,
-        mut proof: Vec<sha256d::Hash>,
-        target: u64,
-    ) -> (Vec<sha256d::Hash>, Vec<sha256d::Hash>) {
-        // We reached a root. This is the recursion base
-        if nodes.len() == 1 {
-            return (nodes, proof);
-        }
-        // Here we store all nodes for the next row
-        let mut new_nodes = Vec::new();
-        // Grab a node's sibling. In a Merkle Tree, our target nodes are given, and its parent
-        // can be computed using available data. We must only provide a node's sibling, so verifier
-        // can get a parent hash.
-        let sibling = Self::get_sibling(target);
-
-        // This if catches an edge case where we try to get a sibling from the last node
-        // in a non-perfect tree. This yields an out-of-bound read from nodes.
-        if sibling != nodes.len() as u64 {
-            proof.push(nodes[sibling as usize]);
-        } else {
-            proof.push(nodes[target as usize]);
-        }
-        // If the row has a odd number of nodes, we must repeat the last node to force it
-        // even.
-        let node_count = nodes.len();
-
-        let pairs = if node_count % 2 == 0 {
-            node_count / 2
-        } else {
-            // (node_count + 1) / 2
-            node_count.div_ceil(2)
-        };
-
-        for idx in 0..pairs {
-            if (2 * idx + 1) >= node_count {
-                new_nodes.push(Self::parent_hash(
-                    nodes[2 * idx].as_ref(),
-                    nodes[2 * idx].as_ref(),
-                ));
-            } else {
-                new_nodes.push(Self::parent_hash(
-                    nodes[2 * idx].as_ref(),
-                    nodes[2 * idx + 1].as_ref(),
-                ));
-            }
-        }
-        Self::transverse(new_nodes, proof, Self::get_parent(target))
     }
 }
 
@@ -209,9 +154,12 @@ impl Encodable for MerkleProof {
 mod test {
     use core::str::FromStr;
 
+    use bitcoin::Txid;
     use bitcoin::consensus::deserialize;
+    use bitcoin::hashes::Hash;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::hashes::sha256d;
+    use floresta_chain::pruned_utreexo::merkle::ConsensusMerkle;
     use floresta_common::prelude::*;
 
     use super::MerkleProof;
@@ -232,9 +180,27 @@ mod test {
             .iter()
             .map(|txid| sha256d::Hash::from_str(txid).unwrap())
             .collect();
-        let proof = MerkleProof::from_block_hashes(hashes, 2);
+        let proof = MerkleProof::from_block_hashes(hashes, 2, &ConsensusMerkle);
         assert_eq!(Ok(true), proof.verify(root));
     }
+
+    #[test]
+    fn all_branches_match_calculated_root() {
+        for count in 1..=16 {
+            let txids: Vec<_> = (0..count)
+                .map(|value| Txid::from_byte_array([value; 32]))
+                .collect();
+            let root = ConsensusMerkle::calculate_root(&txids).unwrap().0;
+            let hashes: Vec<_> = txids.iter().map(|txid| txid.to_raw_hash()).collect();
+
+            for position in 0..u64::from(count) {
+                let proof =
+                    MerkleProof::from_block_hashes(hashes.clone(), position, &ConsensusMerkle);
+                assert_eq!(proof.verify(*root.as_raw_hash()), Ok(true));
+            }
+        }
+    }
+
     #[test]
     fn test_serialization() {
         use bitcoin::consensus::serialize;
@@ -254,7 +220,7 @@ mod test {
             .map(|txid| sha256d::Hash::from_str(txid).unwrap())
             .collect();
 
-        let proof = MerkleProof::from_block_hashes(hashes, 2);
+        let proof = MerkleProof::from_block_hashes(hashes, 2, &ConsensusMerkle);
         let ser_proof = serialize(&proof);
         let de_proof = deserialize::<MerkleProof>(&ser_proof).unwrap();
 
@@ -268,7 +234,7 @@ mod test {
         // credit to @jaonoctus for finding it.
         let block_hex = Vec::from_hex("000000200e7a1b4acac9d0fede38780af685f4f2468f379441da88d9333190e9fd000000de17ded487dedf4febfc2062696f726daf82c387c40ac6bf3f730cb6b8078ea6c7cb5c631e52011eafd2850109010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff040310bf01feffffff02cdf7052a0100000016001481113cad52683679a83e76f76f84a4cfe36f75010000000000000000776a24aa21a9ed1a57f94172436261a598a05fd00f5dc6f0af113118b2ad0fd5ab067cdf14d0844c4fecc7daa2490047304402200188f50f763b594ad2515b5fe7a6ccd0651cb21a57f7c9462517809b0a71056a022073de9d51712ed92333fdf103021ab15f9d7ee438a9f40c4d21a2aae25e30a746010001200000000000000000000000000000000000000000000000000000000000000000000000000200000000010600f477f4573600d59279b8590ad2f393e80e35a4747a6bb980ed435cae516a470100000000fdffffffeeed54083b3a3b3d5fbd2b89dbd584cf9473caecff5307ef6a45d4bf895d3c9f0100000000fdffffff71998948a594919d5f458ca629851af2cddc6a707a46953946fa169785809cc50000000000fdffffff95aff1490be1d5cd7c0147cad2f09e85419661322abe55177e6c37cf74a274da0100000000fdffffff3989e6239f74d9f01863b9cdeb139c911f864e56f42d9a423e2fb56b8acff0e40100000000fdffffffa14095a3c7134dcfe63670990f1aae604e9c75c995bbe4e786d5dad9e210bdfa0100000000fdffffff011e21730200000000160014167905ff5769be1088fba282d5f2fe083eafd24f024730440220524dae54f383a34a3605a0fdd403f5e69e991675d4d631925fd38b16f11d965b02207946cd9a39407d722cb3407913dfd13970b347473e87fdf2dfa3d5ea9dc2e14d012102e62ff0a4b5f94bed13bda49c6f28016a4c462246ca234d91010050d67a766d850247304402206e2410b4b76d09b4c67c84f005d84e46e9d444495734dd3037f1cd8ac938de8602206da11b400e7b02a7ee6a51cb7b42b893db214a2ffff2eac75502429f50b03f8301210215a12de3be0588cc75b0f4c313dae06dbd9ecee933532f4d792bc25fa7a866aa024730440220255e7e199d8dfdc3764e7328b96a26d014f337d27f6629022bc4d6499af832020220703ae4dee6b14a568c877e31af8ead209316891a33eee085dc695ae7fc1cfc84012103dceb3c814a400f39c67d4cd71f926bf1e1dc8944445f712a3ea583ea5f4d1e9b0247304402203a5eb82548dd0ff5f443b66e7f26f5c846315cfbfe488854027dc417c27993090220058ce815c913b0a4b24bd8d9db0a350f5c3bb2b4dcdec2a002a24c440b8496e0012102e8f9662c11aec882442f42dad5d7c19373249793a2a6b630c1971c8e2930ad0f0247304402203411bb65d910def1892d83dba89c6ea6664313eda18af70248884efe4ec6c204022029845c30b2904b60ab5fe6e19cf448f970dfe61cf2e4079482c55f1bb8b8cf4a0121030e8756107674bf33e2392d77f20d2890570c605282e665ec56358b72861219da02473044022075517e3dcfde63549abb19db17fe8a88b2cc643c921b295388c79f78936d3d8802202699e190c42a53856e99211f7b2a702fbc29466bfcac5d7a10e57fd77c109b1801210381477a1e64fda3873c3833c7cbe12cf0a8379a10c57e143be887cf5a53fe46bc0ebf0100020000000001011963991b6c03ca15f9ec0e4ad611e474c3277d0c3655bc9d797de1c14ab7aa7c0100000000feffffff0240420f00000000001600142349b57a01d75c7c858ac751f897239a86bbf04bb873285d5106000016001414bf9b0fe92caa0097b63a1ef3ea275d410fd98d02473044022054b442f21f988a0b97e6d7e8b24e23ccfecfaa12c0eb9eb96775a7765af941de022050d04a2db06e86fe9c9f90fee1169648cf9531e4c3697a744296f6b61324f4830121028bf1e30de43373796a0991b98aa5a4195c86495fba684656a26b0096df3110990fbf010002000000000101344f1ef28a664fe17a4aa50b8d3009ef6c6e49b85d66f8f9b3449bb74582ea350000000000feffffff0240420f0000000000160014e44b51eb316763098c5d18de6ca8b2c0a59c0e17bc9ce6df4f0600001600145fd025abef9e808689076765f4f0c56738c59f39024730440220479115072916500cffc1cc52fd889e5bf832a353125a1bdece97f7563feb5e090220504c4c7dd6a1f6cb0c2ba50c44187f46075dd8b20f94ad6c8b6bafc790dbcc31012102f2bdad8ec4652cb21e7605f26bc81ca66c10ff28e0f3d2a0ea19fc8cd52099b10fbf010002000000000101edd9a6cc38a24a387dc9abe7a1701886fcb2320657b144d0d0316e8ca43ae3d70000000000feffffff0240420f000000000022512010e8ae98031a5708b4bf6569c51f2fff6b000d0237d094bba411b684bb91357aafcb93035206000016001460f37086e9aaae4ddbf4b239482368a10d9c41c70247304402201ee3fdce8f0fb88e23ebdb43fab44044d099f85f506a93feb18b3dd2396b10f002206e82dab913ea09a62509b34b9d1799682af3dc2852a7ca3a851f0d377f8f387001210263bb044157db46c69b30e280e1b012aeeef7e4d2e324bb1badf6b271eea081d50fbf010002000000000101716c42179f6c5c18bb8c648fbb5697e4ada7a3661d6dc41988898b4a3366f00b0000000000feffffff028fbb1b0c000000001600145cb211255a52a72c50ff28125e6d19c3783634246a2b010000000000160014b323d1a6d231f481ec9d0edb4b6628ad7c3013ed02473044022013a5cf7f8b40b66b49d1d3b0da3b045c55eb65da1f0ab5b51925ad1ab74676420220670a2cc57fdd95bec289f3659254683401f550ead6c518ea69b2ac5e154a984d012102638e70a1e4a118a68d0a222d6783bb89308e54c403b44347c140c47d9f3f00290fbf0100020000000001018aece6fc6208c756036d569293b3f309fd753b7e72aef0d57d9d937db72721cf0100000000feffffff02590db89c5006000016001456e2f3da4da33aef14ddfcb6b732a81ff7e8675d40420f00000000002251205e15d348f226d1ea063a79e25aace48990dc473f61ae23f517e07f2917ac721c024730440220545d47834d82f7701cf229d5261f7de206f935ba4b0b58bb89d515add9a900d402207fd29ec10e8e2c935aba34c22d9dc8fc37b32cb0ab4ab4bff91fe6c68456b0c1012103ae5be7da80c63939f16a801363033d52c4e551b55eb1329d09ffa244e0d793290fbf010002000000000101911cf9966a3d8cd2bfb90f6f5d099c1e568a55bdcc55c4e6c041fc600614a3520100000000feffffff020dce63d44e0600001600145cee73b449f3da151659deb159148753c283381140420f0000000000225120b3b15df11fed9bca782f500031c94efc4ed8e4b0521c00295784d7dc5ac8684c02473044022046abbd3a4c279ddd535c3695bb89300f46494411f29c617862ccbb38b923ee740220638ad662b069c9977d4ac51065b493545ff3f4a890c05b42717be6d5ab9b3bd201210254f0f69224472b7f6a0849587a171637916a274d7ddef895dba298e6a1d89dbfadbe0100020000000001013d154c4a311dc630d1b3b403a327f03c07348b6c6cf0557500ef518ca412a2990000000000feffffff026d0833374d060000160014359a35960efb7c6ad62119702edf555163c03ab640420f0000000000225120dd0440d706666db07ae597a02d7af497d8fe1fdf059d1ca0b3c13b6d00a7d24f02473044022038535e6b04102ac866e896a33692e4050339de1f078b375c72d14914133cf9c6022034ad2f08092667cf8e5c60973771bef68315a47dff73f8ad4f0ef1d4a7d863110121032a42df4c108ad44282a75746f52161759aff3adc38bde305be7f5ddf172860120ebf0100").unwrap();
         let block = deserialize(&block_hex).unwrap();
-        let merkle = MerkleProof::from_block(&block, 8);
+        let merkle = MerkleProof::from_block(&block, 8, &ConsensusMerkle);
 
         assert!(
             merkle

--- a/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/chain_selector_ctx.rs
@@ -58,6 +58,7 @@ use floresta_chain::ChainBackend;
 use floresta_chain::CompactLeafData;
 use floresta_chain::proof_util;
 use floresta_chain::pruned_utreexo::IBDState;
+use floresta_chain::pruned_utreexo::consensus::Consensus;
 use floresta_common::service_flags;
 use floresta_common::try_and_log;
 use rand::rng;
@@ -479,9 +480,9 @@ where
                         return Err(WireError::PeerMisbehaving);
                     }
 
-                    // Check if the blocks was maliciously mutated by our peer
-                    let is_mutated =
-                        !(recv_block.check_merkle_root() && recv_block.check_witness_commitment());
+                    // Check if the block was maliciously mutated by our peer
+                    let is_mutated = Consensus::check_merkle_root(&recv_block).is_none()
+                        || !recv_block.check_witness_commitment();
 
                     if is_mutated {
                         error!(

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["chain-flat-chainstore", "mempool", "wire"]
 [[example]]
 name = "watch-only"
 path = "examples/watch_only.rs"
-required-features = ["common", "watch-only-memory-database"]
+required-features = ["chain", "common", "watch-only-memory-database"]
 
 [dependencies]
 floresta-chain = { path = "../floresta-chain", optional = true, default-features = false }

--- a/crates/floresta/examples/watch_only.rs
+++ b/crates/floresta/examples/watch_only.rs
@@ -5,6 +5,7 @@
 use bitcoin::ScriptBuf;
 use bitcoin::consensus::deserialize;
 use bitcoin::hashes::hex::FromHex;
+use floresta::chain::pruned_utreexo::merkle::ConsensusMerkle;
 use floresta::common::get_spk_hash;
 use floresta::watch_only::AddressCache;
 use floresta::watch_only::memory_database::MemoryDatabase;
@@ -17,7 +18,7 @@ fn main() {
     // the `AddressCacheDatabase` trait.
     let wallet_data = MemoryDatabase::new();
     // Then, we create the wallet itself.
-    let wallet = AddressCache::new(wallet_data);
+    let wallet = AddressCache::new(wallet_data, ConsensusMerkle);
     // Now, we need to add the addresses we want to watch. We can add them one by one, or
     // we can add a descriptor that will generate the addresses for us. Here, we use a
     // descriptor that generates P2WPKH addresses. The descriptor is parsed using the

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -18,6 +18,7 @@ Available fuzz targets:
 - `disk_block_header_roundtrip`
 - `flat_chainstore_header_insertion`
 - `local_address_str`
+- `merkle_root`
 - `onion_address_rtt`
 - `onion_address_str_parse`
 - `p2p_v2_message`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,6 +28,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "merkle_root"
+path = "fuzz_targets/merkle_root.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "utreexo_proof_des"
 path = "fuzz_targets/utreexo_proof_des.rs"
 test = false

--- a/fuzz/fuzz_targets/merkle_root.rs
+++ b/fuzz/fuzz_targets/merkle_root.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use bitcoin::TxMerkleNode;
+use bitcoin::Txid;
+use bitcoin::hashes::Hash;
+use bitcoin::hashes::sha256d;
+use bitcoin::merkle_tree;
+use floresta_chain::pruned_utreexo::merkle::ConsensusMerkle;
+use libfuzzer_sys::fuzz_target;
+
+const MAX_LEAVES: usize = 256;
+
+/// Asserts our merkle root result matches that of `rust-bitcoin`.
+fn assert_root_matches(txids: &[Txid]) -> Option<(TxMerkleNode, bool)> {
+    let hashes = txids.iter().map(|txid| txid.to_raw_hash());
+    let expected = merkle_tree::calculate_root(hashes).map(TxMerkleNode::from);
+    let actual = ConsensusMerkle::calculate_root(txids);
+
+    assert_eq!(actual.as_ref().map(|(root, _)| *root), expected);
+    actual
+}
+
+fuzz_target!(|data: &[u8]| {
+    let depth = data.first().copied().unwrap_or_default();
+    let data = data.get(1..).unwrap_or_default();
+
+    // Hash short chunks into varied leaves
+    let txids: Vec<_> = data
+        .chunks(4)
+        .take(MAX_LEAVES)
+        .enumerate()
+        .map(|(index, chunk)| {
+            let mut txid = sha256d::Hash::hash(chunk).to_byte_array();
+            txid[0] = index as u8; // keeps every leaf distinct
+            Txid::from_byte_array(txid)
+        })
+        .collect();
+
+    assert_root_matches(&txids);
+
+    let available = txids.len() / 3;
+    if available == 0 {
+        return;
+    }
+
+    // Choose a fuzz-controlled power-of-two size so each group is a complete subtree.
+    let subtree_size = 1 << (u32::from(depth) % (available.ilog2() + 1));
+    let base = &txids[..3 * subtree_size]; // [A, B, C]
+    let mut duplicated = base.to_vec();
+    duplicated.extend_from_slice(&base[2 * subtree_size..]); // [A, B, C, C]
+
+    // [A, B, C] hashes as if C was repeated, but that internal copy is not a mutation.
+    let (root, base_mutated) = assert_root_matches(base).expect("non-empty");
+
+    // [A, B, C, C] hashes to the same root, but we detect the illegal mutation.
+    let (duplicated_root, duplicated_mutated) =
+        assert_root_matches(&duplicated).expect("non-empty");
+
+    assert!(!base_mutated);
+    assert!(duplicated_mutated);
+    assert_eq!(root, duplicated_root);
+});


### PR DESCRIPTION
### Description and Notes

Floresta was using `bitcoin::merkle_tree::calculate_root`, but it doesn't detect duplicate siblings, meaning malicious duplicate transactions in a block will still match the merkle root. This fixes [CVE-2012-2459](https://www.cve.org/CVERecord?id=CVE-2012-2459) by truly detecting mutation and refactors the new merkle tree logic into `merkle.rs`.

We also take the opportunity to use the `bitcoin_hashes` 1.x changes to have ARM64 SHA2 acceleration and SIMD support for the merkle reduction. These optimizations made the new `Consensus::check_merkle_root` implementation around 6 times faster on Apple M5.

The Merkle root check (txid computations and Merkle reduction) was taking around 3,700 µs and now it is down to 617 µs (-83%). For Merkle reduction alone, which benefits from SIMD, it goes from 1,500 µs to 220 µs (-85%).

The big jump here is using the dedicated SHA2 instructions, and the txid computation part will improve further if the `bitcoin_hashes` SIMD implementation becomes available for multi-block SHA2 inputs.

<img width="703" height="633" alt="Captura de pantalla 2026-08-08 a las 23 05 31" src="https://github.com/user-attachments/assets/deed17e6-74cf-4ba1-afde-65ebd30110ee" />

### How to verify the changes you have done?

Read the tests and especially verify that the new `calculate_root` function is, like Core, checking no pair at each tree level is identical.