### PR TITLE
chore(deps): bump the all group across 1 directory with 3 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f6b9ae59887c395c907855e24b48cf61593a44a2d6757b1ada83d5a2d6b85a"
+checksum = "f106cca655869522988b976127096f0aa36e0f1a8ff1f1f425a5c85b61e59391"
 dependencies = [
  "base64 0.22.1",
  "bitreq",
@@ -1852,9 +1852,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1965,9 +1965,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "13.0.0"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867b1f11e0545ad5ebbddd8a9f18756d9657a6758bf10d96cf15ddd0b726b650"
+checksum = "cd35e2c377504e50159561884b03610711db6c2fec6c89f2b98d94016684726b"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ console-subscriber = { version = "=0.5.0", default-features = false }
 dns-lookup = { version = "=2.1.1" }
 hex = { version = "=0.4.3" }
 kv = { version = "=0.24.0" }
-miniscript = { version = "=13.0.0", default-features = false }
+miniscript = { version = "=13.1.0", default-features = false }
 rand = { version = "=0.10.1" }
 rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "pem"] } # note: >0.14.7 requires Rust 1.86.0
 rustreexo = { version = "=0.6.0" }

--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 bitcoin = { workspace = true }
 clap = { workspace = true, optional = true }
 corepc-types = { workspace = true }
-jsonrpc = { version = "=0.20.0", features = ["bitreq_http"], optional = true }
+jsonrpc = { version = "=0.20.1", features = ["bitreq_http"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 # All dependencies MUST be pinned precisely with `X.Y.z`
 arbitrary = { version = "=1.4.2", features = ["derive"] }
 bitcoin = { workspace = true }
-libfuzzer-sys = { version = "=0.4.12" }
+libfuzzer-sys = { version = "=0.4.13" }
 tempfile = { workspace = true }
 
 # Local dependencies


### PR DESCRIPTION
Overwrite https://github.com/getfloresta/Floresta/pull/1257.

Updates the dependencies from the original Dependabot PR while preserving compatibility with the project's current MSRV (Rust 1.85.0). The updates for `criterion`, `tonic`, `tonic-prost`, and `rcgen` were intentionally omitted because they require a newer Rust version.

Updating `bitcoin` to `0.32.10` causes issues when deserializing P2P messages, preventing the node from synchronizing with other peers.


Bumps the all group with 3 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [miniscript](https://github.com/rust-bitcoin/rust-miniscript) | `13.0.0` | `13.1.0` |
| [jsonrpc](https://github.com/rust-bitcoin/corepc) | `0.20.0` | `0.20.1` |
| [libfuzzer-sys](https://github.com/rust-fuzz/libfuzzer) | `0.4.12` | `0.4.13` |


Updates `miniscript` from 13.0.0 to 13.1.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rust-bitcoin/rust-miniscript/blob/master/CHANGELOG.md">miniscript's changelog</a>.</em></p>
<blockquote>
<h1>13.1.0 - June 9, 2026</h1>
<ul>
<li>plan: make <code>Plan</code>'s <code>descriptor</code> field public.
<a href="https://redirect.github.com/rust-bitcoin/rust-miniscript/pull/978">#978</a></li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/c9ed0006144ad92436191047edd4132f79e5916a"><code>c9ed000</code></a> Merge <a href="https://redirect.github.com/rust-bitcoin/rust-miniscript/issues/985">rust-bitcoin/rust-miniscript#985</a>: Release 13.1.0</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/93399d8bb3a334b12dc672498fedf61a1f507d30"><code>93399d8</code></a> Release 13.1.0</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/86bd5c53bd228facff5215825b1be6e1fff2e2e3"><code>86bd5c5</code></a> Merge <a href="https://redirect.github.com/rust-bitcoin/rust-miniscript/issues/978">rust-bitcoin/rust-miniscript#978</a>: Backport rust-bitcoin/rust-miniscript...</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/9e1ced68ed00e33f07dd448b482ddc6a71088eb9"><code>9e1ced6</code></a> chore: remove outdated TODO</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/5248db139d77a12d09bf97f6dd11fa9e2b585640"><code>5248db1</code></a> feat: expose <code>Plan.descriptor</code> field</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/d60078fc6557405742b9a52dbcfbfc89fcbf20fe"><code>d60078f</code></a> Merge <a href="https://redirect.github.com/rust-bitcoin/rust-miniscript/issues/968">rust-bitcoin/rust-miniscript#968</a>: 13.x: Preserve finalized PSBT inputs</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/aecd5dc25bd4effd994c2b13c619b12d86040d72"><code>aecd5dc</code></a> Remove link to doc file</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/f24a5b547f2b3ac66535dd10cc72f10785a87ddf"><code>f24a5b5</code></a> 13.x: Bump version to 13.0.1</li>
<li><a href="https://github.com/rust-bitcoin/rust-miniscript/commit/894fe4aabbfa58edd14984a66ee0d6905e6dd1a2"><code>894fe4a</code></a> 13.x: Preserve finalized PSBT inputs</li>
<li>See full diff in <a href="https://github.com/rust-bitcoin/rust-miniscript/compare/13.0.0...miniscript-13.1.0">compare view</a></li>
</ul>
</details>
<br />

Updates `jsonrpc` from 0.20.0 to 0.20.1
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/addf46fb024c9d1610d5a8b104d9a0b271ac2094"><code>addf46f</code></a> Merge <a href="https://redirect.github.com/rust-bitcoin/corepc/issues/608">rust-bitcoin/corepc#608</a>: Prepare stack of releases</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/9f851165d812c329d4b16fbaf01f1020526e63f2"><code>9f85116</code></a> electrsd: Bump version to 0.40.0</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/37de741e47e5998ff38de73247ea7ebb17dde1d5"><code>37de741</code></a> bitcoind: Bump version to 0.40.0</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/890371ae04b47c9639cd107dacd7392cc8d5ebb7"><code>890371a</code></a> client: Bump version to 0.15.0</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/b8b50f747fd1a97470d120c460ab14954b146f6f"><code>b8b50f7</code></a> types: Bump version to 0.14.0</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/0d08ee00f67ce1ec62abaafd21649c827282f757"><code>0d08ee0</code></a> jsonrcp: Bump version to 0.20.1</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/018691b83e5b0c8b360e204c874db74e498f02b3"><code>018691b</code></a> bitreq: Bump version to 0.3.6</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/e56500e749ac5ffc1914e3b07b8a53b939e1221c"><code>e56500e</code></a> Merge <a href="https://redirect.github.com/rust-bitcoin/corepc/issues/610">rust-bitcoin/corepc#610</a>: Gate out core tests from v31</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/fd3709c7f6299af87af31b86a9c966ca051b84cf"><code>fd3709c</code></a> Gate out core tests from v31</li>
<li><a href="https://github.com/rust-bitcoin/corepc/commit/c01eb4f38000157d411bebd6435b81061fb1f2d7"><code>c01eb4f</code></a> Merge <a href="https://redirect.github.com/rust-bitcoin/corepc/issues/606">rust-bitcoin/corepc#606</a>: tests: add curated list of client test invaria...</li>
<li>Additional commits viewable in <a href="https://github.com/rust-bitcoin/corepc/compare/jsonrpc-0.20.0...jsonrpc-0.20.1">compare view</a></li>
</ul>
</details>
<br />

Updates `libfuzzer-sys` from 0.4.12 to 0.4.13
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rust-fuzz/libfuzzer/blob/main/CHANGELOG.md">libfuzzer-sys's changelog</a>.</em></p>
<blockquote>
<h2>0.4.13</h2>
<p>Released 2026-06-04.</p>
<h3>Changed</h3>
<ul>
<li>Updated docs for the <code>fuzz_mutator!</code> macro to link to <a href="https://docs.rs/mutatis">the <code>mutatis</code>
crate</a>, which is a helpful crate when writing complex
custom mutators.</li>
</ul>
<hr />
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-fuzz/libfuzzer/commit/719e4efb9b8857ebaa782ae59376c8cbb78fed0f"><code>719e4ef</code></a> Merge pull request <a href="https://redirect.github.com/rust-fuzz/libfuzzer/issues/144">#144</a> from fitzgen/bump-to-0.4.13</li>
<li><a href="https://github.com/rust-fuzz/libfuzzer/commit/2500b23c78391c022f57ff1ee359b186ad48464d"><code>2500b23</code></a> Bump to version 0.4.13</li>
<li><a href="https://github.com/rust-fuzz/libfuzzer/commit/e9120b05b4d85d4c3d70a98f4c9eafce6d6d60d0"><code>e9120b0</code></a> Merge pull request <a href="https://redirect.github.com/rust-fuzz/libfuzzer/issues/143">#143</a> from fitzgen/link-to-mutatis-from-fuzz-mutator</li>
<li><a href="https://github.com/rust-fuzz/libfuzzer/commit/0743afb84597680abf52881307a9c37ae9eadbf0"><code>0743afb</code></a> Link to <code>mutatis</code> from the <code>fuzz_mutator!</code> docs</li>
<li>See full diff in <a href="https://github.com/rust-fuzz/libfuzzer/compare/0.4.12...0.4.13">compare view</a></li>
</ul>
</details>
<br />


