### PR TITLE
test(wire): exercise the V1 read path and the peer liveness deadlines

### DIFF
--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -42,6 +42,10 @@ metrics = { workspace = true,  optional = true }
 [dev-dependencies]
 zstd = { workspace = true }
 derive_more = { version = "=2.1.1", features = ["constructor"] }
+# `test-util` enables the pausable virtual clock (`tokio::time::pause`/`advance`
+# and `#[tokio::test(start_paused = true)]`). Being a dev-dependency, it only
+# affects test builds, so production binaries keep the real clock.
+tokio = { workspace = true, features = ["test-util"] }
 
 # Local dev-dependencies
 floresta-mempool = { workspace = true }

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -373,12 +373,11 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                 }
             }
 
-            // Send a ping to check if this peer is still good
+            // Send a ping to check if this peer is still good.
+            // Only ping if nothing is in flight; otherwise, let the ping-timeout loop
+            // recycle and check the handshake deadline while we wait.
             let last_message = self.last_message.elapsed();
-            if last_message > self.timeouts.send_ping_timeout {
-                if self.last_ping.is_some() {
-                    continue;
-                }
+            if last_message > self.timeouts.send_ping_timeout && self.last_ping.is_none() {
                 let nonce = rand::random();
                 self.last_ping = Some(Instant::now());
                 self.write(NetworkMessage::Ping(nonce)).await?;
@@ -1141,6 +1140,87 @@ mod tests {
         drop(node_receiver);
     }
 
+    /// A deadline far enough away that it cannot fire during a test.
+    ///
+    /// Each test below leaves every deadline it is not exercising far in the future, so
+    /// whichever error comes out identifies the deadline under test with no ambiguity and
+    /// no cross-deadline race.
+    const NEVER: Duration = Duration::from_secs(3600);
+
+    /// Baseline test deadlines: nothing fires, and the loop wakes up every 10ms.
+    ///
+    /// The poll interval matters as much as the deadlines: a deadline is only observed when
+    /// the loop wakes up, so the effective timeout is the deadline rounded up to the next
+    /// multiple of `request_poll_interval`. Keeping the poll interval well under the
+    /// deadline under test keeps that rounding negligible.
+    fn fast_timeouts() -> PeerTimeouts {
+        PeerTimeouts {
+            ping_timeout: NEVER,
+            send_ping_timeout: NEVER,
+            handshake_timeout: NEVER,
+            request_poll_interval: Duration::from_millis(10),
+        }
+    }
+
+    /// A peer that never answers our `version` but goes quiet long enough to earn a ping must
+    /// still be dropped once `handshake_timeout` elapses.
+    ///
+    /// Before the fix, the bare `continue` skipped the rest of the loop body, so once a ping
+    /// was in flight the handshake deadline was never re-checked and only `ping_timeout` could
+    /// end the connection. Note that the production defaults hide this: a ping needs 60s of
+    /// silence (`send_ping_timeout`), by which point the 10s handshake deadline has long since
+    /// fired. Only configurable deadlines make the skipped check observable.
+    #[tokio::test]
+    async fn test_handshake_timeout_fires_with_ping_in_flight() {
+        let SetupData {
+            mut peer,
+            actor_sender,
+            node_receiver,
+            node_sender,
+        } = create_peer_with(PeerTimeouts {
+            handshake_timeout: Duration::from_millis(300),
+            send_ping_timeout: Duration::from_millis(100),
+            ping_timeout: Duration::from_millis(500),
+            ..fast_timeouts()
+        });
+
+        // Start with no ping in flight, so the loop itself sends one after send_ping_timeout.
+        peer.last_ping = None;
+
+        let start = Instant::now();
+
+        let fut = tokio::spawn(peer.read_loop());
+
+        // Never reply to the `version` we send out; the peer stays in `State::SentVersion`.
+        // After send_ping_timeout (~100ms), the loop sends a ping and sets last_ping.
+        // Before the fix, the bare `continue` would skip all deadline checks after that point.
+        // With the fix, the loop continues to check the handshake_timeout (~300ms), which
+        // fires before ping_timeout (~500ms).
+        let err = tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("peer never gave up on the unfinished handshake even with a ping in flight")
+            .unwrap()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, PeerError::UnexpectedMessage),
+            "expected the handshake deadline to fire, got {err:?}"
+        );
+        assert!(
+            start.elapsed() >= Duration::from_millis(300),
+            "deadline fired too early"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "deadline fired too late; ping_timeout, not handshake_timeout, was checked"
+        );
+
+        // Prevents those channels from being dropped, so we don't get a `Channel` error
+        drop(actor_sender);
+        drop(node_receiver);
+        drop(node_sender);
+    }
+
     /// Pins down the production deadlines.
     ///
     /// [`PeerTimeouts`] exists so that behavioural tests can dial these down to milliseconds,
@@ -1163,7 +1243,8 @@ mod tests {
         assert!(defaults.request_poll_interval < defaults.ping_timeout);
         assert!(defaults.request_poll_interval < defaults.send_ping_timeout);
 
-        // We must give the remote a chance to answer before we hang up on it.
+        // The loop only pings when nothing is in flight, so the two deadlines compose
+        // independently and the ordering is a policy choice, not a correctness invariant.
         assert!(defaults.ping_timeout < defaults.send_ping_timeout);
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -64,6 +64,17 @@ const PING_TIMEOUT: Duration = Duration::from_secs(30);
 /// If the last message we've got was more than 60, send out a ping
 const SEND_PING_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// How long a peer has to answer our `version` before we give up on the handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long the peer loop blocks waiting for a node request before waking up to
+/// re-check the liveness deadlines.
+///
+/// This is the resolution of every deadline below: a deadline can only be noticed
+/// on a loop iteration, so the *effective* timeout is the deadline rounded up to the
+/// next multiple of this interval.
+const REQUEST_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
 /// The command string for the "utreexo proof" message
 const UTREEXO_PROOF_CMD_STRING: &str = "uproof";
 
@@ -98,6 +109,39 @@ enum State {
     SentVersion(Instant),
     SentVerack,
     Connected,
+}
+
+/// The liveness deadlines that govern a peer connection.
+///
+/// Production always uses [`PeerTimeouts::default`], which is wired to the module
+/// constants ([`PING_TIMEOUT`], [`SEND_PING_TIMEOUT`], [`HANDSHAKE_TIMEOUT`] and
+/// [`REQUEST_POLL_INTERVAL`]). Making them per-[`Peer`] data rather than hardcoded
+/// constants is what lets tests drive the very same code paths at millisecond scale,
+/// against the real clock, instead of needing a mockable clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerTimeouts {
+    /// If we send a ping and the peer takes longer than this to reply, disconnect.
+    pub ping_timeout: Duration,
+
+    /// If we haven't heard anything from the peer for this long, send it a ping.
+    pub send_ping_timeout: Duration,
+
+    /// How long the peer has to answer our `version` before we drop the connection.
+    pub handshake_timeout: Duration,
+
+    /// How often the peer loop wakes up to re-check the deadlines above.
+    pub request_poll_interval: Duration,
+}
+
+impl Default for PeerTimeouts {
+    fn default() -> Self {
+        Self {
+            ping_timeout: PING_TIMEOUT,
+            send_ping_timeout: SEND_PING_TIMEOUT,
+            handshake_timeout: HANDSHAKE_TIMEOUT,
+            request_poll_interval: REQUEST_POLL_INTERVAL,
+        }
+    }
 }
 
 pub struct MessageActor<R: AsyncRead + Unpin + Send> {
@@ -162,6 +206,7 @@ pub struct Peer<T: AsyncWrite + Unpin + Send + Sync> {
     // This is kept as an option to avoid the need to keep the other half around during tests.
     cancellation_sender: Option<oneshot::Sender<()>>,
     transport_protocol: TransportProtocol,
+    timeouts: PeerTimeouts,
 }
 
 #[derive(Debug)]
@@ -289,7 +334,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         self.state = State::SentVersion(Instant::now());
         loop {
             tokio::select! {
-                request = tokio::time::timeout(Duration::from_secs(2), self.node_requests.recv()) => {
+                request = tokio::time::timeout(self.timeouts.request_poll_interval, self.node_requests.recv()) => {
                     match request {
                         Ok(None) => {
                             return Err(PeerError::Channel);
@@ -323,14 +368,14 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
 
             // If we send a ping and our peer doesn't respond in time, disconnect
             if let Some(when) = self.last_ping {
-                if when.elapsed() > PING_TIMEOUT {
+                if when.elapsed() > self.timeouts.ping_timeout {
                     return Err(PeerError::PingTimeout);
                 }
             }
 
             // Send a ping to check if this peer is still good
             let last_message = self.last_message.elapsed();
-            if last_message > SEND_PING_TIMEOUT {
+            if last_message > self.timeouts.send_ping_timeout {
                 if self.last_ping.is_some() {
                     continue;
                 }
@@ -356,7 +401,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             }
 
             if let State::SentVersion(when) = self.state {
-                if Instant::now().duration_since(when) > Duration::from_secs(10) {
+                if Instant::now().duration_since(when) > self.timeouts.handshake_timeout {
                     return Err(PeerError::UnexpectedMessage);
                 }
             }
@@ -749,6 +794,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             our_best_block,
             cancellation_sender: Some(cancellation_sender),
             transport_protocol,
+            timeouts: PeerTimeouts::default(),
         };
 
         spawn(peer.read_loop());
@@ -938,6 +984,7 @@ mod tests {
     use crate::node::NodeRequest;
     use crate::p2p_wire::peer::Peer;
     use crate::p2p_wire::peer::PeerError;
+    use crate::p2p_wire::peer::PeerTimeouts;
     use crate::p2p_wire::peer::ReaderMessage;
     use crate::p2p_wire::peer::State;
     use crate::p2p_wire::peer::peer_utils;
@@ -962,6 +1009,15 @@ mod tests {
     }
 
     fn create_peer() -> SetupData {
+        create_peer_with(PeerTimeouts::default())
+    }
+
+    /// Same as [`create_peer`], but with the liveness deadlines dialled down to whatever
+    /// the caller needs.
+    ///
+    /// Tests use millisecond-scale deadlines so the real code paths run against the real
+    /// clock in well under a second.
+    fn create_peer_with(timeouts: PeerTimeouts) -> SetupData {
         let (node_tx, node_receiver) = unbounded_channel();
         let (node_sender, node_requests) = unbounded_channel();
         let (actor_sender, actor_receiver) = unbounded_channel();
@@ -1003,6 +1059,7 @@ mod tests {
             current_best_block: 0,
             transport_protocol: TransportProtocol::V1,
             cancellation_sender: Some(cancellation_sender),
+            timeouts,
         };
 
         SetupData {
@@ -1082,5 +1139,31 @@ mod tests {
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
         drop(node_receiver);
+    }
+
+    /// Pins down the production deadlines.
+    ///
+    /// [`PeerTimeouts`] exists so that behavioural tests can dial these down to milliseconds,
+    /// which means no such test says anything about the values a real peer uses. These are the
+    /// numbers the rest of the network sees, so they get asserted literally rather than against
+    /// the constants they come from — comparing a constant to itself would pass no matter what
+    /// it is changed to.
+    #[test]
+    fn test_default_timeouts_match_production_values() {
+        let defaults = PeerTimeouts::default();
+
+        assert_eq!(defaults.ping_timeout, Duration::from_secs(30));
+        assert_eq!(defaults.send_ping_timeout, Duration::from_secs(60));
+        assert_eq!(defaults.handshake_timeout, Duration::from_secs(10));
+        assert_eq!(defaults.request_poll_interval, Duration::from_secs(2));
+
+        // A deadline is only noticed on a loop wake-up, so a poll interval coarser than a
+        // deadline would silently stretch that deadline out to the poll interval.
+        assert!(defaults.request_poll_interval < defaults.handshake_timeout);
+        assert!(defaults.request_poll_interval < defaults.ping_timeout);
+        assert!(defaults.request_poll_interval < defaults.send_ping_timeout);
+
+        // We must give the remote a chance to answer before we hang up on it.
+        assert!(defaults.ping_timeout < defaults.send_ping_timeout);
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -1162,6 +1162,180 @@ mod tests {
         }
     }
 
+    /// Walks the peer through `version`/`verack` so it reaches [`State::Connected`].
+    fn complete_handshake(actor_sender: &mut UnboundedSender<ReaderMessage>, peer: &LocalAddress) {
+        send_to_peer(
+            actor_sender,
+            peer_utils::build_version_message("/Floresta-test:0.0.0/".into(), 0, peer),
+        );
+        send_to_peer(actor_sender, NetworkMessage::Verack);
+    }
+
+    /// A peer that never answers our ping must be disconnected once `ping_timeout` elapses.
+    #[tokio::test]
+    async fn test_unanswered_ping_disconnects() {
+        let SetupData {
+            peer,
+            mut actor_sender,
+            node_receiver,
+            node_sender,
+        } = create_peer_with(PeerTimeouts {
+            ping_timeout: Duration::from_millis(200),
+            ..fast_timeouts()
+        });
+        let address = peer.address.clone();
+
+        // `create_peer_with` leaves a ping in flight, which we will never answer.
+        assert!(peer.last_ping.is_some());
+
+        let fut = tokio::spawn(peer.read_loop());
+        complete_handshake(&mut actor_sender, &address);
+
+        let err = tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("peer never gave up on the unanswered ping")
+            .unwrap()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, PeerError::PingTimeout),
+            "expected the ping deadline to fire, got {err:?}"
+        );
+
+        // Prevents those channels from being dropped, so we don't get a `Channel` error
+        drop(node_receiver);
+        drop(node_sender);
+    }
+
+    /// The positive counterpart to [`test_unanswered_ping_disconnects`]: a peer that *does*
+    /// answer our ping gets `last_ping` cleared and must stay connected.
+    ///
+    /// This is the case that had no coverage at all. Every other test either never sends a
+    /// pong or never waits long enough for the ping deadline to matter, so dropping the
+    /// `self.last_ping = None` from the `Pong` arm was completely invisible — a peer that
+    /// answers every ping perfectly would still be disconnected every 30 seconds.
+    #[tokio::test]
+    async fn test_pong_clears_ping_and_peer_stays_connected() {
+        let SetupData {
+            peer,
+            mut actor_sender,
+            node_receiver,
+            node_sender,
+        } = create_peer_with(PeerTimeouts {
+            ping_timeout: Duration::from_millis(200),
+            ..fast_timeouts()
+        });
+        let address = peer.address.clone();
+
+        let fut = tokio::spawn(peer.read_loop());
+        complete_handshake(&mut actor_sender, &address);
+
+        // Answer the ping that `create_peer_with` left in flight.
+        send_to_peer(&mut actor_sender, NetworkMessage::Pong(0));
+
+        // Well past `ping_timeout`: had the pong not cleared `last_ping`, the peer would
+        // already have bailed out with `PeerError::PingTimeout`.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        assert!(
+            !fut.is_finished(),
+            "peer disconnected even though it received a pong"
+        );
+
+        node_sender.send(NodeRequest::Shutdown).unwrap();
+        let peer = tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("peer did not honour the shutdown request")
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            peer.last_ping.is_none(),
+            "a pong must clear the in-flight ping"
+        );
+
+        // Prevents this channel from being dropped, so we don't get a `Channel` error
+        drop(node_receiver);
+    }
+
+    /// Exercises the other half of the liveness exchange: *we* ping *them*.
+    ///
+    /// The peer starts with nothing in flight and the remote goes quiet. After
+    /// `send_ping_timeout` the loop must send its own ping, and then, with no pong coming
+    /// back, give up after `ping_timeout`. Arriving at `PingTimeout` at all is what proves
+    /// the ping was sent: the test writer is a no-op sink and cannot be inspected.
+    #[tokio::test]
+    async fn test_silent_peer_is_pinged_then_times_out() {
+        let SetupData {
+            mut peer,
+            mut actor_sender,
+            node_receiver,
+            node_sender,
+        } = create_peer_with(PeerTimeouts {
+            send_ping_timeout: Duration::from_millis(100),
+            ping_timeout: Duration::from_millis(200),
+            ..fast_timeouts()
+        });
+        let address = peer.address.clone();
+
+        // Nothing in flight: the loop itself has to decide to send a ping.
+        peer.last_ping = None;
+
+        let fut = tokio::spawn(peer.read_loop());
+        complete_handshake(&mut actor_sender, &address);
+
+        let err = tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("peer never pinged the silent remote, or never timed it out")
+            .unwrap()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, PeerError::PingTimeout),
+            "expected the ping deadline to fire, got {err:?}"
+        );
+
+        // Prevents those channels from being dropped, so we don't get a `Channel` error
+        drop(node_receiver);
+        drop(node_sender);
+    }
+
+    /// A peer that opens a connection but never answers our `version` must be dropped once
+    /// `handshake_timeout` elapses.
+    #[tokio::test]
+    async fn test_handshake_timeout_disconnects() {
+        let SetupData {
+            mut peer,
+            actor_sender,
+            node_receiver,
+            node_sender,
+        } = create_peer_with(PeerTimeouts {
+            handshake_timeout: Duration::from_millis(200),
+            ..fast_timeouts()
+        });
+
+        // Only the handshake deadline may fire.
+        peer.last_ping = None;
+
+        let fut = tokio::spawn(peer.read_loop());
+
+        // Never reply to the `version` we send out; the peer stays in `State::SentVersion`.
+        let err = tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("peer never gave up on the unfinished handshake")
+            .unwrap()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, PeerError::UnexpectedMessage),
+            "expected the handshake deadline to fire, got {err:?}"
+        );
+
+        // Prevents those channels from being dropped, so we don't get a `Channel` error
+        drop(actor_sender);
+        drop(node_receiver);
+        drop(node_sender);
+    }
+
     /// A peer that never answers our `version` but goes quiet long enough to earn a ping must
     /// still be dropped once `handshake_timeout` elapses.
     ///

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -1175,7 +1175,7 @@ mod tests {
     #[tokio::test]
     async fn test_unanswered_ping_disconnects() {
         let SetupData {
-            peer,
+            mut peer,
             mut actor_sender,
             node_receiver,
             node_sender,
@@ -1187,6 +1187,10 @@ mod tests {
 
         // `create_peer_with` leaves a ping in flight, which we will never answer.
         assert!(peer.last_ping.is_some());
+
+        // Re-stamp the deadline after setup, so the deadline floor can never predate this instant.
+        let start = Instant::now();
+        peer.last_ping = Some(Instant::now());
 
         let fut = tokio::spawn(peer.read_loop());
         complete_handshake(&mut actor_sender, &address);
@@ -1200,6 +1204,10 @@ mod tests {
         assert!(
             matches!(err, PeerError::PingTimeout),
             "expected the ping deadline to fire, got {err:?}"
+        );
+        assert!(
+            start.elapsed() >= Duration::from_millis(200),
+            "deadline fired too early"
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
@@ -1280,6 +1288,10 @@ mod tests {
         // Nothing in flight: the loop itself has to decide to send a ping.
         peer.last_ping = None;
 
+        // Re-stamp the deadline after setup, so the deadline floor can never predate this instant.
+        let start = Instant::now();
+        peer.last_message = Instant::now();
+
         let fut = tokio::spawn(peer.read_loop());
         complete_handshake(&mut actor_sender, &address);
 
@@ -1292,6 +1304,10 @@ mod tests {
         assert!(
             matches!(err, PeerError::PingTimeout),
             "expected the ping deadline to fire, got {err:?}"
+        );
+        assert!(
+            start.elapsed() >= Duration::from_millis(300),
+            "deadline fired too early"
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
@@ -1316,6 +1332,8 @@ mod tests {
         // Only the handshake deadline may fire.
         peer.last_ping = None;
 
+        let start = Instant::now();
+
         let fut = tokio::spawn(peer.read_loop());
 
         // Never reply to the `version` we send out; the peer stays in `State::SentVersion`.
@@ -1328,6 +1346,10 @@ mod tests {
         assert!(
             matches!(err, PeerError::UnexpectedMessage),
             "expected the handshake deadline to fire, got {err:?}"
+        );
+        assert!(
+            start.elapsed() >= Duration::from_millis(200),
+            "deadline fired too early"
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -373,9 +373,11 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                 }
             }
 
-            // Send a ping to check if this peer is still good.
-            // Only ping if nothing is in flight; otherwise, let the ping-timeout loop
-            // recycle and check the handshake deadline while we wait.
+            // Send a ping to check if this peer is still good. If one is already in flight
+            // we simply let it be — the deadline above is what gives up on it. This used to
+            // `continue`, which also skipped every check below, most notably the handshake
+            // deadline: a peer that never answered our `version` but stayed quiet long
+            // enough to earn a ping would never be re-checked against `handshake_timeout`.
             let last_message = self.last_message.elapsed();
             if last_message > self.timeouts.send_ping_timeout && self.last_ping.is_none() {
                 let nonce = rand::random();
@@ -960,6 +962,7 @@ pub enum PeerMessages {
 mod tests {
     use std::net::Ipv4Addr;
     use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
     use std::time::Duration;
     use std::time::Instant;
 
@@ -989,6 +992,7 @@ mod tests {
     use crate::p2p_wire::peer::peer_utils;
     use crate::p2p_wire::transport::WriteTransport;
     use crate::p2p_wire::transport::test_transport::Writer;
+    use crate::p2p_wire::transport::test_transport::create_reader_v1;
 
     /// All the data needed to run a test.
     struct SetupData {
@@ -1033,7 +1037,7 @@ mod tests {
         let peer = Peer {
             address,
             our_best_block: 0,
-            writer: WriteTransport::V1(Writer, Network::Regtest),
+            writer: WriteTransport::V1(Writer::new(), Network::Regtest),
             state: State::Connected,
             kind: ConnectionKind::Manual,
             id: 0,
@@ -1067,6 +1071,31 @@ mod tests {
             node_sender,
             node_receiver,
         }
+    }
+
+    /// Same as [`create_peer_with`], but the peer's writer keeps a copy of every byte it
+    /// sends, so a test can decode what actually went out on the wire.
+    fn create_recording_peer_with(timeouts: PeerTimeouts) -> (SetupData, Arc<StdMutex<Vec<u8>>>) {
+        let (writer, sent) = Writer::recording();
+        let mut setup = create_peer_with(timeouts);
+        setup.peer.writer = WriteTransport::V1(writer, Network::Regtest);
+
+        (setup, sent)
+    }
+
+    /// Decodes everything a recording [`Writer`] captured, so a test can assert on the
+    /// actual wire traffic rather than on a side effect of the code path.
+    ///
+    /// Stops at the first decoding failure, which is how the end of the captured bytes
+    /// shows up.
+    async fn decode_sent_messages(bytes: Vec<u8>) -> Vec<NetworkMessage> {
+        let mut transport = create_reader_v1(bytes);
+        let mut messages = Vec::new();
+        while let Ok(message) = transport.read_message().await {
+            messages.push(message);
+        }
+
+        messages
     }
 
     fn send_to_peer(
@@ -1188,7 +1217,8 @@ mod tests {
         // `create_peer_with` leaves a ping in flight, which we will never answer.
         assert!(peer.last_ping.is_some());
 
-        // Re-stamp the deadline after setup, so the deadline floor can never predate this instant.
+        // Re-stamped after `start` so the assertion below is sound: the deadline's reference
+        // instant must not predate `start`, or the error can surface just under 200ms.
         let start = Instant::now();
         peer.last_ping = Some(Instant::now());
 
@@ -1207,7 +1237,8 @@ mod tests {
         );
         assert!(
             start.elapsed() >= Duration::from_millis(200),
-            "deadline fired too early"
+            "the ping deadline fired early, after {:?}",
+            start.elapsed()
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
@@ -1268,17 +1299,23 @@ mod tests {
     /// Exercises the other half of the liveness exchange: *we* ping *them*.
     ///
     /// The peer starts with nothing in flight and the remote goes quiet. After
-    /// `send_ping_timeout` the loop must send its own ping, and then, with no pong coming
-    /// back, give up after `ping_timeout`. Arriving at `PingTimeout` at all is what proves
-    /// the ping was sent: the test writer is a no-op sink and cannot be inspected.
+    /// `send_ping_timeout` the loop must put a ping on the wire, and then, with no pong
+    /// coming back, give up after `ping_timeout`.
+    ///
+    /// Decoding what the writer captured is what makes the first half real: `last_ping` is
+    /// stamped *before* the write, so reaching `PingTimeout` would still hold if the ping
+    /// were never actually sent. Only the bytes tell those two apart.
     #[tokio::test]
     async fn test_silent_peer_is_pinged_then_times_out() {
-        let SetupData {
-            mut peer,
-            mut actor_sender,
-            node_receiver,
-            node_sender,
-        } = create_peer_with(PeerTimeouts {
+        let (
+            SetupData {
+                mut peer,
+                mut actor_sender,
+                node_receiver,
+                node_sender,
+            },
+            sent,
+        ) = create_recording_peer_with(PeerTimeouts {
             send_ping_timeout: Duration::from_millis(100),
             ping_timeout: Duration::from_millis(200),
             ..fast_timeouts()
@@ -1288,7 +1325,8 @@ mod tests {
         // Nothing in flight: the loop itself has to decide to send a ping.
         peer.last_ping = None;
 
-        // Re-stamp the deadline after setup, so the deadline floor can never predate this instant.
+        // Re-stamped after `start` so the assertion below is sound; see
+        // `test_unanswered_ping_disconnects`.
         let start = Instant::now();
         peer.last_message = Instant::now();
 
@@ -1307,7 +1345,23 @@ mod tests {
         );
         assert!(
             start.elapsed() >= Duration::from_millis(300),
-            "deadline fired too early"
+            "the ping went out or timed out early, after {:?}",
+            start.elapsed()
+        );
+
+        // Clone the bytes out before awaiting: holding a std `MutexGuard` across an await
+        // is exactly what `clippy::await_holding_lock` is there to catch.
+        let bytes = sent
+            .lock()
+            .expect("the recording sink is never held across a panic")
+            .clone();
+        let messages = decode_sent_messages(bytes).await;
+
+        assert!(
+            messages
+                .iter()
+                .any(|message| matches!(message, NetworkMessage::Ping(_))),
+            "the peer never put a ping on the wire; it sent {messages:?}"
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
@@ -1333,7 +1387,6 @@ mod tests {
         peer.last_ping = None;
 
         let start = Instant::now();
-
         let fut = tokio::spawn(peer.read_loop());
 
         // Never reply to the `version` we send out; the peer stays in `State::SentVersion`.
@@ -1349,7 +1402,8 @@ mod tests {
         );
         assert!(
             start.elapsed() >= Duration::from_millis(200),
-            "deadline fired too early"
+            "the handshake deadline fired early, after {:?}",
+            start.elapsed()
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
@@ -1374,27 +1428,26 @@ mod tests {
             node_receiver,
             node_sender,
         } = create_peer_with(PeerTimeouts {
-            handshake_timeout: Duration::from_millis(300),
-            send_ping_timeout: Duration::from_millis(100),
-            ping_timeout: Duration::from_millis(500),
+            // Quiet well before the handshake deadline, so a ping goes out while we are
+            // still in `SentVersion` and stays unanswered from then on.
+            send_ping_timeout: Duration::from_millis(50),
+            handshake_timeout: Duration::from_millis(200),
+            // Only the handshake deadline may fire.
+            ping_timeout: NEVER,
             ..fast_timeouts()
         });
 
-        // Start with no ping in flight, so the loop itself sends one after send_ping_timeout.
         peer.last_ping = None;
 
         let start = Instant::now();
+        peer.last_message = Instant::now();
 
         let fut = tokio::spawn(peer.read_loop());
 
         // Never reply to the `version` we send out; the peer stays in `State::SentVersion`.
-        // After send_ping_timeout (~100ms), the loop sends a ping and sets last_ping.
-        // Before the fix, the bare `continue` would skip all deadline checks after that point.
-        // With the fix, the loop continues to check the handshake_timeout (~300ms), which
-        // fires before ping_timeout (~500ms).
         let err = tokio::time::timeout(Duration::from_secs(5), fut)
             .await
-            .expect("peer never gave up on the unfinished handshake even with a ping in flight")
+            .expect("the handshake deadline was never re-checked once a ping went out")
             .unwrap()
             .unwrap_err();
 
@@ -1403,12 +1456,9 @@ mod tests {
             "expected the handshake deadline to fire, got {err:?}"
         );
         assert!(
-            start.elapsed() >= Duration::from_millis(300),
-            "deadline fired too early"
-        );
-        assert!(
-            start.elapsed() < Duration::from_millis(500),
-            "deadline fired too late; ping_timeout, not handshake_timeout, was checked"
+            start.elapsed() >= Duration::from_millis(200),
+            "the handshake deadline fired early, after {:?}",
+            start.elapsed()
         );
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
@@ -1439,8 +1489,9 @@ mod tests {
         assert!(defaults.request_poll_interval < defaults.ping_timeout);
         assert!(defaults.request_poll_interval < defaults.send_ping_timeout);
 
-        // The loop only pings when nothing is in flight, so the two deadlines compose
-        // independently and the ordering is a policy choice, not a correctness invariant.
+        // Policy sanity check rather than a correctness invariant: the two deadlines compose
+        // independently, but waiting longer for a pong than we wait before pinging at all
+        // would mean a silent peer takes over two minutes to be noticed.
         assert!(defaults.ping_timeout < defaults.send_ping_timeout);
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -521,6 +521,7 @@ pub(crate) mod test_transport {
     use std::collections::VecDeque;
     use std::io;
     use std::io::ErrorKind;
+    use std::num::NonZeroUsize;
     use std::pin::Pin;
     use std::task::Context;
     use std::task::Poll;
@@ -571,29 +572,55 @@ pub(crate) mod test_transport {
         #[default]
         All,
 
-        /// Hand over at most `n` bytes per poll.
+        /// Hand over at most `n` bytes per poll. Build with [`ChunkPolicy::fixed`].
         ///
-        /// `Fixed(1)` is the harshest setting and the most useful one: it forces the
+        /// One byte is the harshest setting and the most useful one: it forces the
         /// parser through a separate poll for every single byte.
-        Fixed(usize),
+        Fixed(NonZeroUsize),
 
-        /// Walk a scripted sequence of chunk sizes, one entry per poll.
+        /// Walk a scripted sequence of per-poll size limits, one entry per poll. Build
+        /// with [`ChunkPolicy::scripted`].
         ///
         /// Use this to cut at specific offsets, e.g. in the middle of the 24-byte V1
         /// header. Once the script runs out, the reader falls back to [`ChunkPolicy::All`].
-        Scripted(VecDeque<usize>),
+        ///
+        /// Each entry is an upper bound, not an exact size: the caller's `ReadBuf` and any
+        /// pending fault can cut a poll shorter than its scripted entry, and the entry is
+        /// consumed either way.
+        Scripted(VecDeque<NonZeroUsize>),
     }
 
     impl ChunkPolicy {
-        /// Returns the size limit for the next poll, consuming one scripted entry.
+        /// Hand over at most `n` bytes per poll.
         ///
-        /// Sizes are clamped to at least 1: a zero-byte read means EOF in the
-        /// [`AsyncRead`] contract, and that is expressed by [`EndBehavior`] instead.
+        /// # Panics
+        ///
+        /// If `n` is zero. A poll that delivers zero bytes means end of stream in the
+        /// [`AsyncRead`] contract, so a zero-sized chunk cannot mean "a very short read";
+        /// end of stream is expressed by [`EndBehavior`] instead.
+        pub fn fixed(n: usize) -> Self {
+            Self::Fixed(Self::non_zero(n))
+        }
+
+        /// Walk `sizes` as per-poll upper bounds, one entry per poll.
+        ///
+        /// # Panics
+        ///
+        /// If any entry is zero; see [`ChunkPolicy::fixed`].
+        pub fn scripted(sizes: impl IntoIterator<Item = usize>) -> Self {
+            Self::Scripted(sizes.into_iter().map(Self::non_zero).collect())
+        }
+
+        fn non_zero(n: usize) -> NonZeroUsize {
+            NonZeroUsize::new(n).expect("a chunk size of zero would signal EOF, not a short read")
+        }
+
+        /// Returns the size limit for the next poll, consuming one scripted entry.
         fn next_limit(&mut self) -> usize {
             match self {
                 Self::All => usize::MAX,
-                Self::Fixed(n) => (*n).max(1),
-                Self::Scripted(script) => script.pop_front().unwrap_or(usize::MAX).max(1),
+                Self::Fixed(n) => n.get(),
+                Self::Scripted(script) => script.pop_front().map_or(usize::MAX, NonZeroUsize::get),
             }
         }
     }
@@ -635,7 +662,7 @@ pub(crate) mod test_transport {
     /// ```ignore
     /// // Feed a message one byte at a time, then close cleanly.
     /// let reader = Reader::new(bytes)
-    ///     .with_chunking(ChunkPolicy::Fixed(1))
+    ///     .with_chunking(ChunkPolicy::fixed(1))
     ///     .with_end_behavior(EndBehavior::CleanEof);
     /// ```
     #[derive(Debug, Default)]
@@ -792,7 +819,6 @@ pub(crate) mod test_transport {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
     use std::io::ErrorKind;
     use std::time::Duration;
 
@@ -908,7 +934,7 @@ mod tests {
     #[tokio::test]
     async fn test_valid_message_one_byte_per_poll() {
         let data = valid_ping_bytes();
-        let reader = Reader::new(data).with_chunking(ChunkPolicy::Fixed(1));
+        let reader = Reader::new(data).with_chunking(ChunkPolicy::fixed(1));
         let mut transport_reader = create_reader_v1_with(reader);
 
         let res = transport_reader
@@ -928,8 +954,7 @@ mod tests {
     #[tokio::test]
     async fn test_valid_message_scripted_chunks_split_header() {
         let data = valid_ping_bytes();
-        let script = VecDeque::from(vec![5, 3, 20, 1, 3]);
-        let reader = Reader::new(data).with_chunking(ChunkPolicy::Scripted(script));
+        let reader = Reader::new(data).with_chunking(ChunkPolicy::scripted([5, 3, 20, 1, 3]));
         let mut transport_reader = create_reader_v1_with(reader);
 
         let res = transport_reader
@@ -948,7 +973,7 @@ mod tests {
         data.truncate(20); // cut inside the 24-byte header
 
         let reader = Reader::new(data)
-            .with_chunking(ChunkPolicy::Fixed(8))
+            .with_chunking(ChunkPolicy::fixed(8))
             .with_end_behavior(EndBehavior::CleanEof);
         let mut transport_reader = create_reader_v1_with(reader);
 
@@ -1004,6 +1029,18 @@ mod tests {
         }
     }
 
+    #[test]
+    #[should_panic(expected = "chunk size of zero")]
+    fn test_chunk_policy_rejects_zero_fixed() {
+        let _ = ChunkPolicy::fixed(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "chunk size of zero")]
+    fn test_chunk_policy_rejects_zero_in_script() {
+        let _ = ChunkPolicy::scripted([4, 0, 2]);
+    }
+
     #[tokio::test]
     async fn test_reader_chunk_policy_all_delivers_everything() {
         let mut reader = Reader::new(vec![1, 2, 3, 4, 5]);
@@ -1015,7 +1052,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_reader_chunk_policy_fixed_caps_each_poll() {
-        let mut reader = Reader::new(vec![1, 2, 3, 4, 5]).with_chunking(ChunkPolicy::Fixed(2));
+        let mut reader = Reader::new(vec![1, 2, 3, 4, 5]).with_chunking(ChunkPolicy::fixed(2));
         let mut buf = [0_u8; 8];
 
         assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
@@ -1031,9 +1068,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reader_chunk_policy_scripted_then_falls_back_to_all() {
-        let script = VecDeque::from(vec![1, 3]);
         let mut reader =
-            Reader::new(vec![1, 2, 3, 4, 5, 6]).with_chunking(ChunkPolicy::Scripted(script));
+            Reader::new(vec![1, 2, 3, 4, 5, 6]).with_chunking(ChunkPolicy::scripted([1, 3]));
         let mut buf = [0_u8; 8];
 
         assert_eq!(reader.read(&mut buf).await.unwrap(), 1);
@@ -1127,7 +1163,7 @@ mod tests {
     /// bytes into 2 bytes of space, which would panic inside `put_slice`.
     #[tokio::test]
     async fn test_reader_respects_remaining_not_capacity() {
-        let mut reader = Reader::new((0..100).collect()).with_chunking(ChunkPolicy::Fixed(8));
+        let mut reader = Reader::new((0..100).collect()).with_chunking(ChunkPolicy::fixed(8));
         let mut buf = [0_u8; 10];
 
         reader

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -523,6 +523,8 @@ pub(crate) mod test_transport {
     use std::io::ErrorKind;
     use std::num::NonZeroUsize;
     use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::Mutex;
     use std::task::Context;
     use std::task::Poll;
 
@@ -781,7 +783,40 @@ pub(crate) mod test_transport {
         ReadTransport::V1(reader, Network::Regtest)
     }
 
-    pub struct Writer;
+    /// An [`AsyncWrite`] that swallows everything, optionally keeping a copy of the bytes.
+    ///
+    /// A no-op sink is enough for most peer tests. A test that needs to prove *what* went
+    /// out on the wire — rather than only that some code path was taken — needs the bytes
+    /// back, which is what [`Writer::recording`] is for.
+    #[derive(Debug, Default)]
+    pub struct Writer {
+        sink: Option<Arc<Mutex<Vec<u8>>>>,
+    }
+
+    impl Writer {
+        /// A writer that discards everything.
+        pub fn new() -> Self {
+            Self { sink: None }
+        }
+
+        /// A writer that discards everything but keeps a copy, returning the shared buffer.
+        pub fn recording() -> (Self, Arc<Mutex<Vec<u8>>>) {
+            let sink = Arc::new(Mutex::new(Vec::new()));
+            let writer = Self {
+                sink: Some(Arc::clone(&sink)),
+            };
+
+            (writer, sink)
+        }
+
+        fn record(&self, bytes: &[u8]) {
+            if let Some(sink) = &self.sink {
+                sink.lock()
+                    .expect("the recording sink is never held across a panic")
+                    .extend_from_slice(bytes);
+            }
+        }
+    }
 
     impl AsyncWrite for Writer {
         fn poll_write(
@@ -789,7 +824,9 @@ pub(crate) mod test_transport {
             _cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
-            // No-op writer
+            // Discarded, but recorded first if this writer is a recording one.
+            self.record(buf);
+
             Poll::Ready(Ok(buf.len()))
         }
 
@@ -811,7 +848,14 @@ pub(crate) mod test_transport {
             bufs: &[io::IoSlice<'_>],
         ) -> Poll<io::Result<usize>> {
             let len = bufs.iter().map(|buf| buf.len()).sum();
-            // No-op writer
+
+            // Discarded, but recorded first if this writer is a recording one. Every slice
+            // is accepted, so every slice has to be recorded to keep the capture in step
+            // with the byte count we report back.
+            for buf in bufs {
+                self.record(buf);
+            }
+
             Poll::Ready(Ok(len))
         }
     }

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -518,6 +518,7 @@ pub(crate) mod test_transport {
     use core::fmt;
     use core::fmt::Display;
     use core::fmt::Formatter;
+    use std::collections::VecDeque;
     use std::io;
     use std::io::ErrorKind;
     use std::pin::Pin;
@@ -542,9 +543,154 @@ pub(crate) mod test_transport {
 
     impl error::Error for UnexpectedEofError {}
 
+    /// The I/O error returned when an injected fault fires.
+    #[derive(Debug, Clone, Copy)]
+    pub struct InjectedFaultError {
+        /// The absolute byte offset the reader had delivered when the fault fired.
+        pub offset: usize,
+    }
+
+    impl Display for InjectedFaultError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write!(f, "injected fault at byte offset {}", self.offset)
+        }
+    }
+
+    impl error::Error for InjectedFaultError {}
+
+    /// How many bytes a [`Reader`] hands over on each `poll_read`.
+    ///
+    /// A real socket splits a message across an arbitrary number of reads, so parsing code
+    /// must reassemble it. Picking a policy other than [`ChunkPolicy::All`] is what lets a
+    /// test exercise that reassembly path.
+    #[derive(Debug, Default, Clone, PartialEq, Eq)]
+    pub enum ChunkPolicy {
+        /// Hand over as much as the caller asked for, capped by what is left.
+        ///
+        /// This is the well-behaved case where a whole message shows up at once.
+        #[default]
+        All,
+
+        /// Hand over at most `n` bytes per poll.
+        ///
+        /// `Fixed(1)` is the harshest setting and the most useful one: it forces the
+        /// parser through a separate poll for every single byte.
+        Fixed(usize),
+
+        /// Walk a scripted sequence of chunk sizes, one entry per poll.
+        ///
+        /// Use this to cut at specific offsets, e.g. in the middle of the 24-byte V1
+        /// header. Once the script runs out, the reader falls back to [`ChunkPolicy::All`].
+        Scripted(VecDeque<usize>),
+    }
+
+    impl ChunkPolicy {
+        /// Returns the size limit for the next poll, consuming one scripted entry.
+        ///
+        /// Sizes are clamped to at least 1: a zero-byte read means EOF in the
+        /// [`AsyncRead`] contract, and that is expressed by [`EndBehavior`] instead.
+        fn next_limit(&mut self) -> usize {
+            match self {
+                Self::All => usize::MAX,
+                Self::Fixed(n) => (*n).max(1),
+                Self::Scripted(script) => script.pop_front().unwrap_or(usize::MAX).max(1),
+            }
+        }
+    }
+
+    /// What a [`Reader`] does once it has handed over all of its data.
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    pub enum EndBehavior {
+        /// Fail with [`ErrorKind::UnexpectedEof`].
+        ///
+        /// This is the default, and it models a connection that is torn down mid-message.
+        #[default]
+        ErrorUnexpectedEof,
+
+        /// Report a clean end of stream: `Poll::Ready(Ok(()))` with zero bytes written.
+        ///
+        /// This is how a real socket signals an orderly close. It is distinct from an I/O
+        /// error, and a reader hitting this in the middle of a message should surface a
+        /// well-formed error rather than panicking.
+        CleanEof,
+
+        /// Never make progress again, modelling a peer that holds the socket open but
+        /// stops sending.
+        ///
+        /// This returns `Poll::Pending` *without* registering a waker, so the task parks
+        /// forever. Any test using it must impose its own deadline, e.g.
+        /// [`tokio::time::timeout`] under a paused clock.
+        Stall,
+    }
+
+    /// An [`AsyncRead`] that replays a fixed byte buffer under a configurable delivery
+    /// schedule, so tests can reproduce socket behaviour that a plain `Vec<u8>` cannot.
+    ///
+    /// By default it behaves like a cooperative peer that delivers everything at once and
+    /// then errors out ([`ChunkPolicy::All`] + [`EndBehavior::ErrorUnexpectedEof`]). The
+    /// builder methods turn it into a hostile one.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Feed a message one byte at a time, then close cleanly.
+    /// let reader = Reader::new(bytes)
+    ///     .with_chunking(ChunkPolicy::Fixed(1))
+    ///     .with_end_behavior(EndBehavior::CleanEof);
+    /// ```
     #[derive(Debug, Default)]
     pub struct Reader {
+        /// Bytes not yet handed over.
         data: Vec<u8>,
+
+        /// How many bytes have been handed over so far, used to locate the fault offset.
+        position: usize,
+
+        /// Delivery schedule.
+        chunks: ChunkPolicy,
+
+        /// What to do once `data` is empty.
+        end_behavior: EndBehavior,
+
+        /// Optional `(absolute offset, kind)` fault.
+        fault: Option<(usize, ErrorKind)>,
+    }
+
+    impl Reader {
+        /// Creates a reader that replays `data` all at once, then errors with
+        /// [`ErrorKind::UnexpectedEof`].
+        pub fn new(data: Vec<u8>) -> Self {
+            Self {
+                data,
+                position: 0,
+                chunks: ChunkPolicy::All,
+                end_behavior: EndBehavior::ErrorUnexpectedEof,
+                fault: None,
+            }
+        }
+
+        /// Sets how many bytes each `poll_read` may deliver. See [`ChunkPolicy`].
+        pub fn with_chunking(mut self, chunks: ChunkPolicy) -> Self {
+            self.chunks = chunks;
+            self
+        }
+
+        /// Sets what happens once the data runs out. See [`EndBehavior`].
+        pub fn with_end_behavior(mut self, end_behavior: EndBehavior) -> Self {
+            self.end_behavior = end_behavior;
+            self
+        }
+
+        /// Makes the reader fail with `kind` once it has delivered exactly `offset` bytes.
+        ///
+        /// Delivery is clamped so a poll never steps past `offset`; the *following* poll
+        /// returns the error. This mirrors a socket that hands over whatever already
+        /// arrived and only then reports the failure. An `offset` beyond the length of the
+        /// data is never reached, so the [`EndBehavior`] applies instead.
+        pub fn with_fault_at(mut self, offset: usize, kind: ErrorKind) -> Self {
+            self.fault = Some((offset, kind));
+            self
+        }
     }
 
     impl AsyncRead for Reader {
@@ -553,22 +699,59 @@ pub(crate) mod test_transport {
             _cx: &mut Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<io::Result<()>> {
-            let size = buf.capacity();
-            if size > self.data.len() {
-                return Poll::Ready(Err(io::Error::new(
-                    ErrorKind::UnexpectedEof,
-                    UnexpectedEofError,
-                )));
+            // An injected fault takes priority: once we are sitting on the offset, every
+            // further poll fails.
+            if let Some((offset, kind)) = self.fault {
+                if self.position >= offset {
+                    return Poll::Ready(Err(io::Error::new(kind, InjectedFaultError { offset })));
+                }
             }
 
-            buf.put_slice(&self.data.drain(0..size).collect::<Vec<_>>());
+            // `remaining()`, not `capacity()`: across the repeated polls of a partial read
+            // the buffer is already partly filled, and capacity would overcount.
+            let want = buf.remaining();
+            if want == 0 {
+                return Poll::Ready(Ok(()));
+            }
+
+            if self.data.is_empty() {
+                return match self.end_behavior {
+                    EndBehavior::ErrorUnexpectedEof => Poll::Ready(Err(io::Error::new(
+                        ErrorKind::UnexpectedEof,
+                        UnexpectedEofError,
+                    ))),
+                    EndBehavior::CleanEof => Poll::Ready(Ok(())),
+                    EndBehavior::Stall => Poll::Pending,
+                };
+            }
+
+            let mut size = self.chunks.next_limit().min(want).min(self.data.len());
+
+            // Never step past a pending fault, so it fires on a poll of its own.
+            if let Some((offset, _)) = self.fault {
+                size = size.min(offset - self.position);
+            }
+
+            let chunk = self.data.drain(0..size).collect::<Vec<_>>();
+            buf.put_slice(&chunk);
+            self.position += size;
 
             Poll::Ready(Ok(()))
         }
     }
 
+    /// Builds a V1 read transport over a cooperative reader that delivers everything at
+    /// once and then errors with [`ErrorKind::UnexpectedEof`].
     pub fn create_reader_v1(data: Vec<u8>) -> ReadTransport<Reader> {
-        ReadTransport::V1(Reader { data }, Network::Regtest)
+        ReadTransport::V1(Reader::new(data), Network::Regtest)
+    }
+
+    /// Builds a V1 read transport over a caller-configured [`Reader`].
+    ///
+    /// Use this when the point of the test is *how* the bytes arrive rather than what
+    /// they contain.
+    pub fn create_reader_v1_with(reader: Reader) -> ReadTransport<Reader> {
+        ReadTransport::V1(reader, Network::Regtest)
     }
 
     pub struct Writer;
@@ -609,17 +792,31 @@ pub(crate) mod test_transport {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::io::ErrorKind;
+    use std::time::Duration;
 
     use bitcoin::Network;
     use bitcoin::consensus::serialize;
     use bitcoin::p2p::message::NetworkMessage;
     use bitcoin::p2p::message::RawNetworkMessage;
+    use tokio::io::AsyncReadExt;
 
     use super::test_transport::*;
     use crate::p2p_wire::transport::P2PV1MessageChecksum;
     use crate::p2p_wire::transport::TransportError;
     use crate::p2p_wire::transport::V1MessageHeader;
+
+    /// Size of the V1 message header, in bytes.
+    const V1_HEADER_LEN: usize = 24;
+
+    /// A valid regtest `ping` message: 24 bytes of header plus an 8-byte nonce.
+    fn valid_ping_bytes() -> Vec<u8> {
+        let message = RawNetworkMessage::new(Network::Regtest.magic(), NetworkMessage::Ping(0));
+        let data = serialize(&message);
+        assert_eq!(data.len(), V1_HEADER_LEN + 8, "unexpected ping encoding");
+        data
+    }
 
     #[tokio::test]
     async fn test_oversized_message() {
@@ -701,5 +898,243 @@ mod tests {
             .expect("Message should be a valid ping");
 
         assert_eq!(res, NetworkMessage::Ping(0));
+    }
+
+    /// The same message as `test_valid_message`, but dripped in one byte at a time.
+    ///
+    /// A real socket never promises to hand over a whole message in a single read, so the
+    /// V1 parser has to reassemble it. This is the harshest possible schedule, and it was
+    /// impossible to express before the reader gained a chunking policy.
+    #[tokio::test]
+    async fn test_valid_message_one_byte_per_poll() {
+        let data = valid_ping_bytes();
+        let reader = Reader::new(data).with_chunking(ChunkPolicy::Fixed(1));
+        let mut transport_reader = create_reader_v1_with(reader);
+
+        let res = transport_reader
+            .read_message()
+            .await
+            .expect("a byte-by-byte ping must reassemble into the same message");
+
+        assert_eq!(res, NetworkMessage::Ping(0));
+    }
+
+    /// Delivers a message on a schedule whose boundaries fall inside the 24-byte header
+    /// and again inside the payload.
+    ///
+    /// The script is `[5, 3, 20, 1, 3]`, so the reads land at absolute offsets 5, 8 and 24
+    /// (splitting the header twice), then 25 and 28 inside the payload, and finally the
+    /// script runs out and the remainder arrives at once.
+    #[tokio::test]
+    async fn test_valid_message_scripted_chunks_split_header() {
+        let data = valid_ping_bytes();
+        let script = VecDeque::from(vec![5, 3, 20, 1, 3]);
+        let reader = Reader::new(data).with_chunking(ChunkPolicy::Scripted(script));
+        let mut transport_reader = create_reader_v1_with(reader);
+
+        let res = transport_reader
+            .read_message()
+            .await
+            .expect("a message split across the header boundary must still parse");
+
+        assert_eq!(res, NetworkMessage::Ping(0));
+    }
+
+    /// A peer that closes the connection cleanly in the middle of the header must produce
+    /// an error, not a panic.
+    #[tokio::test]
+    async fn test_clean_eof_mid_header() {
+        let mut data = valid_ping_bytes();
+        data.truncate(20); // cut inside the 24-byte header
+
+        let reader = Reader::new(data)
+            .with_chunking(ChunkPolicy::Fixed(8))
+            .with_end_behavior(EndBehavior::CleanEof);
+        let mut transport_reader = create_reader_v1_with(reader);
+
+        let error = transport_reader.read_message().await.unwrap_err();
+
+        match error {
+            TransportError::Io(e) => assert_eq!(e.kind(), ErrorKind::UnexpectedEof),
+            other => panic!("expected an IO error, got {other:?}"),
+        }
+    }
+
+    /// Same as above, but the clean close lands after a complete header, partway through
+    /// the payload the header promised.
+    #[tokio::test]
+    async fn test_clean_eof_mid_payload() {
+        let mut data = valid_ping_bytes();
+        data.truncate(V1_HEADER_LEN + 4); // full header, half a nonce
+
+        let reader = Reader::new(data).with_end_behavior(EndBehavior::CleanEof);
+        let mut transport_reader = create_reader_v1_with(reader);
+
+        let error = transport_reader.read_message().await.unwrap_err();
+
+        match error {
+            TransportError::Io(e) => assert_eq!(e.kind(), ErrorKind::UnexpectedEof),
+            other => panic!("expected an IO error, got {other:?}"),
+        }
+    }
+
+    /// An I/O failure partway through the payload must surface as `TransportError::Io`
+    /// carrying the original [`ErrorKind`].
+    #[tokio::test]
+    async fn test_injected_io_error_in_payload() {
+        const FAULT_OFFSET: usize = V1_HEADER_LEN + 4;
+
+        let data = valid_ping_bytes();
+        let reader = Reader::new(data).with_fault_at(FAULT_OFFSET, ErrorKind::ConnectionReset);
+        let mut transport_reader = create_reader_v1_with(reader);
+
+        let error = transport_reader.read_message().await.unwrap_err();
+
+        match error {
+            TransportError::Io(e) => {
+                assert_eq!(e.kind(), ErrorKind::ConnectionReset);
+
+                let fault = e
+                    .get_ref()
+                    .and_then(|inner| inner.downcast_ref::<InjectedFaultError>())
+                    .expect("the error should carry the injected fault payload");
+                assert_eq!(fault.offset, FAULT_OFFSET);
+            }
+            other => panic!("expected an IO error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reader_chunk_policy_all_delivers_everything() {
+        let mut reader = Reader::new(vec![1, 2, 3, 4, 5]);
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 5);
+        assert_eq!(&buf[..5], &[1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn test_reader_chunk_policy_fixed_caps_each_poll() {
+        let mut reader = Reader::new(vec![1, 2, 3, 4, 5]).with_chunking(ChunkPolicy::Fixed(2));
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+        assert_eq!(&buf[..2], &[1, 2]);
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+        assert_eq!(&buf[..2], &[3, 4]);
+
+        // Only one byte is left, so the cap is not the binding constraint.
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 1);
+        assert_eq!(&buf[..1], &[5]);
+    }
+
+    #[tokio::test]
+    async fn test_reader_chunk_policy_scripted_then_falls_back_to_all() {
+        let script = VecDeque::from(vec![1, 3]);
+        let mut reader =
+            Reader::new(vec![1, 2, 3, 4, 5, 6]).with_chunking(ChunkPolicy::Scripted(script));
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 1);
+        assert_eq!(&buf[..1], &[1]);
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 3);
+        assert_eq!(&buf[..3], &[2, 3, 4]);
+
+        // Script exhausted: the rest arrives in one go.
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+        assert_eq!(&buf[..2], &[5, 6]);
+    }
+
+    #[tokio::test]
+    async fn test_reader_end_behavior_error_unexpected_eof() {
+        let mut reader = Reader::new(vec![1, 2]);
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+
+        let error = reader.read(&mut buf).await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn test_reader_end_behavior_clean_eof() {
+        let mut reader = Reader::new(vec![1, 2]).with_end_behavior(EndBehavior::CleanEof);
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+
+        // A clean close reports zero bytes read, and keeps doing so.
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
+    }
+
+    /// A stalled peer holds the socket open and never sends again, so the read future
+    /// simply never resolves.
+    ///
+    /// The paused clock keeps this honest: the one-hour deadline below costs no real time,
+    /// and the runtime auto-advances to it precisely because nothing else can make
+    /// progress.
+    #[tokio::test(start_paused = true)]
+    async fn test_reader_end_behavior_stall_never_completes() {
+        let mut reader = Reader::new(vec![1, 2]).with_end_behavior(EndBehavior::Stall);
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+
+        let outcome = tokio::time::timeout(Duration::from_secs(3600), reader.read(&mut buf)).await;
+        assert!(outcome.is_err(), "a stalled reader must never resolve");
+    }
+
+    #[tokio::test]
+    async fn test_reader_fault_clamps_delivery_then_fires() {
+        let mut reader =
+            Reader::new(vec![1, 2, 3, 4, 5, 6]).with_fault_at(4, ErrorKind::ConnectionAborted);
+        let mut buf = [0_u8; 8];
+
+        // The poll is clamped so it stops exactly on the fault offset instead of
+        // overshooting it.
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 4);
+        assert_eq!(&buf[..4], &[1, 2, 3, 4]);
+
+        let error = reader.read(&mut buf).await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
+
+        // The fault is sticky: it keeps failing rather than resuming.
+        let error = reader.read(&mut buf).await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
+    }
+
+    /// A fault offset past the end of the data is never reached, so the end behavior wins.
+    #[tokio::test]
+    async fn test_reader_fault_beyond_data_never_fires() {
+        let mut reader = Reader::new(vec![1, 2])
+            .with_fault_at(100, ErrorKind::ConnectionAborted)
+            .with_end_behavior(EndBehavior::CleanEof);
+        let mut buf = [0_u8; 8];
+
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 2);
+        assert_eq!(reader.read(&mut buf).await.unwrap(), 0);
+    }
+
+    /// Regression test for the reader consulting `ReadBuf::capacity` instead of
+    /// `ReadBuf::remaining`.
+    ///
+    /// `read_exact` reuses one `ReadBuf` across polls, so after the first chunk the buffer
+    /// is partly filled and `capacity` overstates how much room is left. Asking for 10
+    /// bytes in chunks of 8 from a larger source makes the second poll try to write 8 more
+    /// bytes into 2 bytes of space, which would panic inside `put_slice`.
+    #[tokio::test]
+    async fn test_reader_respects_remaining_not_capacity() {
+        let mut reader = Reader::new((0..100).collect()).with_chunking(ChunkPolicy::Fixed(8));
+        let mut buf = [0_u8; 10];
+
+        reader
+            .read_exact(&mut buf)
+            .await
+            .expect("a partial read must not overrun the caller's buffer");
+
+        assert_eq!(buf, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 }


### PR DESCRIPTION
### Description and Notes

Rebased on top of #1268 as requested in review: this PR is now test-only. The behaviour fix in `peer.rs`, and the `PeerTimeouts` refactor its regression test depends on, moved there. **The diff below carries #1268's two commits until that one merges.**

Two things in `floresta-wire` had no coverage because no test could reach them.

**The V1 read path.** `test_transport::Reader` handed over the whole buffer on every `poll_read`, or failed outright. A real socket delivers a message across an arbitrary number of reads, so nothing about *how* bytes arrive could be expressed — and that is where parsing bugs against untrusted peers live. The reader gains a delivery schedule (`ChunkPolicy`), a configurable termination (`EndBehavior`: orderly close, error, or stall) and fault injection at a byte offset.

That also fixes a latent bug in the mock itself: it consulted `ReadBuf::capacity` instead of `remaining`. Across the repeated polls of a partial read the buffer is already partly filled, so capacity overstates the room left and `put_slice` would overrun it — invisible while every read delivered everything at once.

The new tests deliver a ping one byte per poll, land chunk boundaries inside the 24-byte header, close cleanly mid-header and mid-payload, and inject a `ConnectionReset` inside the payload. The last three assert that the transport surfaces an error rather than panicking, which is the invariant #1245 asks for on this path.

**The peer liveness deadlines.** Four tests on top of #1268's `PeerTimeouts`: an unanswered ping, a pong that clears the pending ping, a silent peer that gets pinged and then times out, and a handshake that is never answered. The pong case had no coverage at all — dropping `self.last_ping = None` from the `Pong` arm was completely invisible, even though it would disconnect a perfectly healthy peer every 30 seconds.

Two further commits strengthen what those tests actually observe:

- They asserted *which* `PeerError` came out, never *when*. A deadline that fires immediately — an inverted comparison, or `> Duration::ZERO` — left every one of them green. They now assert a lower bound on elapsed time. The bound is a floor, so scheduling delay can only push it further from the edge.
- `Writer` was a no-op sink, so "we sent a ping" could only be inferred from the timeout that followed. It can now record what was written, and the silent-peer test decodes those bytes and asserts a `Ping` actually went out.

`ChunkPolicy` carries `NonZeroUsize` rather than `usize`: a chunk size of zero would signal EOF, not a short read, so the invalid state is unrepresentable instead of silently clamped.

Relates to #1245. Deliberately out of scope: the V2/BIP-324 transport, `UtreexoNode`, and fuzz or property targets. These tests deform the *delivery* of a valid message, not the *content* of a hostile one.

### How to verify the changes you have done?

```
cargo test -p floresta-wire
```

70 tests, all green.

The assertions are strong enough to catch the mutations they exist for. Two checked by hand:

- Replace the handshake deadline comparison with `> Duration::ZERO`. Before this PR every timeout test still passed; now they fail with `the handshake deadline fired early, after 12.5ms`.
- Delete the `self.write(NetworkMessage::Ping(nonce))` call in `peer_loop_inner`. Before the recording writer the test still passed, because the loop stamps `last_ping` before it writes; now `test_silent_peer_is_pinged_then_times_out` fails and prints the messages that were actually sent.

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
