### PR TITLE
fix(wire): keep checking the handshake deadline while a ping is in flight

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -373,12 +373,11 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                 }
             }
 
-            // Send a ping to check if this peer is still good
+            // Send a ping to check if this peer is still good.
+            // Only ping if nothing is in flight; otherwise, let the ping-timeout loop
+            // recycle and check the handshake deadline while we wait.
             let last_message = self.last_message.elapsed();
-            if last_message > self.timeouts.send_ping_timeout {
-                if self.last_ping.is_some() {
-                    continue;
-                }
+            if last_message > self.timeouts.send_ping_timeout && self.last_ping.is_none() {
                 let nonce = rand::random();
                 self.last_ping = Some(Instant::now());
                 self.write(NetworkMessage::Ping(nonce)).await?;
@@ -1141,13 +1140,82 @@ mod tests {
         drop(node_receiver);
     }
 
+    #[tokio::test]
+    /// A peer that never answers our `version` but goes quiet long enough to earn a ping must
+    /// still be dropped once `handshake_timeout` elapses.
+    ///
+    /// Before the fix, the bare `continue` skipped the rest of the loop body, so once a ping
+    /// was in flight the handshake deadline was never re-checked and only `ping_timeout` could
+    /// end the connection. Note that the production defaults hide this: a ping needs 60s of
+    /// silence (`send_ping_timeout`), by which point the 10s handshake deadline has long since
+    /// fired. Only configurable deadlines make the skipped check observable.
+    async fn test_handshake_timeout_fires_with_ping_in_flight() {
+        // The deadlines are ordered so that only the handshake deadline can end this
+        // connection: the ping goes out first, the handshake deadline fires next, and
+        // ping_timeout sits far enough behind it to tell the two apart. The assertions
+        // below read these same bindings, so changing one here carries them along.
+        let send_ping_timeout = Duration::from_millis(100);
+        let handshake_timeout = Duration::from_millis(300);
+        let ping_timeout = Duration::from_millis(500);
+
+        let SetupData {
+            mut peer,
+            actor_sender,
+            node_receiver,
+            node_sender,
+        } = create_peer_with(PeerTimeouts {
+            handshake_timeout,
+            send_ping_timeout,
+            ping_timeout,
+            // A deadline is only observed when the loop wakes up, so the effective timeout is
+            // the deadline rounded up to the next multiple of the poll interval. Keeping the
+            // poll interval well under the deadlines above keeps that rounding negligible.
+            request_poll_interval: Duration::from_millis(10),
+        });
+
+        // Start with no ping in flight, so the loop itself sends one after send_ping_timeout.
+        peer.last_ping = None;
+
+        let start = Instant::now();
+
+        let fut = tokio::spawn(peer.read_loop());
+
+        // Never reply to the `version` we send out; the peer stays in `State::SentVersion`.
+        // After send_ping_timeout, the loop sends a ping and sets last_ping. Before the fix,
+        // the bare `continue` would skip all deadline checks after that point. With the fix,
+        // the loop keeps checking handshake_timeout, which fires before ping_timeout.
+        let err = tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("peer never gave up on the unfinished handshake even with a ping in flight")
+            .unwrap()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, PeerError::UnexpectedMessage),
+            "expected the handshake deadline to fire, got {err:?}"
+        );
+        assert!(
+            start.elapsed() >= handshake_timeout,
+            "gave up before handshake_timeout ({handshake_timeout:?}) could have elapsed"
+        );
+        assert!(
+            start.elapsed() < ping_timeout,
+            "gave up only at ping_timeout ({ping_timeout:?}); handshake_timeout was not re-checked"
+        );
+
+        // Prevents those channels from being dropped, so we don't get a `Channel` error
+        drop(actor_sender);
+        drop(node_receiver);
+        drop(node_sender);
+    }
+
+    #[test]
     /// The relations the production deadlines must satisfy, whatever values they are set to.
     ///
     /// [`PeerTimeouts`] exists so that behavioural tests can dial these down to milliseconds,
     /// which means no such test says anything about what a real peer does. The individual
     /// values are a policy choice and belong to the constants; what is asserted here is how
     /// they have to relate to each other for the peer loop to behave as intended.
-    #[test]
     fn test_default_timeouts_are_internally_consistent() {
         let defaults = PeerTimeouts::default();
 
@@ -1157,7 +1225,8 @@ mod tests {
         assert!(defaults.request_poll_interval < defaults.ping_timeout);
         assert!(defaults.request_poll_interval < defaults.send_ping_timeout);
 
-        // We must give the remote a chance to answer before we hang up on it.
+        // The loop only pings when nothing is in flight, so the two deadlines compose
+        // independently and the ordering is a policy choice, not a correctness invariant.
         assert!(defaults.ping_timeout < defaults.send_ping_timeout);
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -64,6 +64,17 @@ const PING_TIMEOUT: Duration = Duration::from_secs(30);
 /// If the last message we've got was more than 60, send out a ping
 const SEND_PING_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// How long a peer has to answer our `version` before we give up on the handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long the peer loop blocks waiting for a node request before waking up to
+/// re-check the liveness deadlines.
+///
+/// This is the resolution of every deadline below: a deadline can only be noticed
+/// on a loop iteration, so the *effective* timeout is the deadline rounded up to the
+/// next multiple of this interval.
+const REQUEST_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
 /// The command string for the "utreexo proof" message
 const UTREEXO_PROOF_CMD_STRING: &str = "uproof";
 
@@ -98,6 +109,39 @@ enum State {
     SentVersion(Instant),
     SentVerack,
     Connected,
+}
+
+/// The liveness deadlines that govern a peer connection.
+///
+/// Production always uses [`PeerTimeouts::default`], which is wired to the module
+/// constants ([`PING_TIMEOUT`], [`SEND_PING_TIMEOUT`], [`HANDSHAKE_TIMEOUT`] and
+/// [`REQUEST_POLL_INTERVAL`]). Making them per-[`Peer`] data rather than hardcoded
+/// constants is what lets tests drive the very same code paths at millisecond scale,
+/// against the real clock, instead of needing a mockable clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerTimeouts {
+    /// If we send a ping and the peer takes longer than this to reply, disconnect.
+    pub ping_timeout: Duration,
+
+    /// If we haven't heard anything from the peer for this long, send it a ping.
+    pub send_ping_timeout: Duration,
+
+    /// How long the peer has to answer our `version` before we drop the connection.
+    pub handshake_timeout: Duration,
+
+    /// How often the peer loop wakes up to re-check the deadlines above.
+    pub request_poll_interval: Duration,
+}
+
+impl Default for PeerTimeouts {
+    fn default() -> Self {
+        Self {
+            ping_timeout: PING_TIMEOUT,
+            send_ping_timeout: SEND_PING_TIMEOUT,
+            handshake_timeout: HANDSHAKE_TIMEOUT,
+            request_poll_interval: REQUEST_POLL_INTERVAL,
+        }
+    }
 }
 
 pub struct MessageActor<R: AsyncRead + Unpin + Send> {
@@ -162,6 +206,7 @@ pub struct Peer<T: AsyncWrite + Unpin + Send + Sync> {
     // This is kept as an option to avoid the need to keep the other half around during tests.
     cancellation_sender: Option<oneshot::Sender<()>>,
     transport_protocol: TransportProtocol,
+    timeouts: PeerTimeouts,
 }
 
 #[derive(Debug)]
@@ -289,7 +334,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         self.state = State::SentVersion(Instant::now());
         loop {
             tokio::select! {
-                request = tokio::time::timeout(Duration::from_secs(2), self.node_requests.recv()) => {
+                request = tokio::time::timeout(self.timeouts.request_poll_interval, self.node_requests.recv()) => {
                     match request {
                         Ok(None) => {
                             return Err(PeerError::Channel);
@@ -323,14 +368,14 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
 
             // If we send a ping and our peer doesn't respond in time, disconnect
             if let Some(when) = self.last_ping {
-                if when.elapsed() > PING_TIMEOUT {
+                if when.elapsed() > self.timeouts.ping_timeout {
                     return Err(PeerError::PingTimeout);
                 }
             }
 
             // Send a ping to check if this peer is still good
             let last_message = self.last_message.elapsed();
-            if last_message > SEND_PING_TIMEOUT {
+            if last_message > self.timeouts.send_ping_timeout {
                 if self.last_ping.is_some() {
                     continue;
                 }
@@ -356,7 +401,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             }
 
             if let State::SentVersion(when) = self.state {
-                if Instant::now().duration_since(when) > Duration::from_secs(10) {
+                if Instant::now().duration_since(when) > self.timeouts.handshake_timeout {
                     return Err(PeerError::UnexpectedMessage);
                 }
             }
@@ -749,6 +794,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             our_best_block,
             cancellation_sender: Some(cancellation_sender),
             transport_protocol,
+            timeouts: PeerTimeouts::default(),
         };
 
         spawn(peer.read_loop());
@@ -938,6 +984,7 @@ mod tests {
     use crate::node::NodeRequest;
     use crate::p2p_wire::peer::Peer;
     use crate::p2p_wire::peer::PeerError;
+    use crate::p2p_wire::peer::PeerTimeouts;
     use crate::p2p_wire::peer::ReaderMessage;
     use crate::p2p_wire::peer::State;
     use crate::p2p_wire::peer::peer_utils;
@@ -962,6 +1009,15 @@ mod tests {
     }
 
     fn create_peer() -> SetupData {
+        create_peer_with(PeerTimeouts::default())
+    }
+
+    /// Same as [`create_peer`], but with the liveness deadlines dialled down to whatever
+    /// the caller needs.
+    ///
+    /// Tests use millisecond-scale deadlines so the real code paths run against the real
+    /// clock in well under a second.
+    fn create_peer_with(timeouts: PeerTimeouts) -> SetupData {
         let (node_tx, node_receiver) = unbounded_channel();
         let (node_sender, node_requests) = unbounded_channel();
         let (actor_sender, actor_receiver) = unbounded_channel();
@@ -1003,6 +1059,7 @@ mod tests {
             current_best_block: 0,
             transport_protocol: TransportProtocol::V1,
             cancellation_sender: Some(cancellation_sender),
+            timeouts,
         };
 
         SetupData {
@@ -1082,5 +1139,25 @@ mod tests {
 
         // Prevents those channels from being dropped, so we don't get a `Channel` error
         drop(node_receiver);
+    }
+
+    /// The relations the production deadlines must satisfy, whatever values they are set to.
+    ///
+    /// [`PeerTimeouts`] exists so that behavioural tests can dial these down to milliseconds,
+    /// which means no such test says anything about what a real peer does. The individual
+    /// values are a policy choice and belong to the constants; what is asserted here is how
+    /// they have to relate to each other for the peer loop to behave as intended.
+    #[test]
+    fn test_default_timeouts_are_internally_consistent() {
+        let defaults = PeerTimeouts::default();
+
+        // A deadline is only noticed on a loop wake-up, so a poll interval coarser than a
+        // deadline would silently stretch that deadline out to the poll interval.
+        assert!(defaults.request_poll_interval < defaults.handshake_timeout);
+        assert!(defaults.request_poll_interval < defaults.ping_timeout);
+        assert!(defaults.request_poll_interval < defaults.send_ping_timeout);
+
+        // We must give the remote a chance to answer before we hang up on it.
+        assert!(defaults.ping_timeout < defaults.send_ping_timeout);
     }
 }


### PR DESCRIPTION
### Description and Notes

Split out of #1267 as requested in review: this is the behaviour fix on its own.

`peer_loop_inner` used a bare `continue` to avoid sending a second ping while one was already in flight. It also skipped every check below it — the message-rate limit and, more importantly, the handshake deadline. A peer that never answered our `version` but stayed quiet long enough to earn a ping was therefore never re-checked against `handshake_timeout`, and only fell out much later, on `ping_timeout`. The fix folds the guard into the condition so the loop body always runs to the end.

**Why this is two commits and not one.** The bug is unreachable with the shipped deadlines: sending a ping needs 60s of silence (`SEND_PING_TIMEOUT`), and the 10s handshake deadline always fires long before that. No regression test can exist while the deadlines are hardcoded constants — not a fast one, not a slow one. So the first commit moves the four deadlines into a `PeerTimeouts` struct owned by `Peer`, built in production from `PeerTimeouts::default()` and wired to the same constants as before, leaving behaviour unchanged. The second commit carries the fix and the test that pins it.

Everything else from #1267 — the reader/writer test doubles and the coverage built on them — stays there.

Relates to #1245.

### How to verify the changes you have done?

The suite is green:

```
cargo test -p floresta-wire
```

To see the regression test earn its place, revert just the production hunk in `peer_loop_inner`:

```rust
// from
if last_message > self.timeouts.send_ping_timeout && self.last_ping.is_none() {
    let nonce = rand::random();

// back to
if last_message > self.timeouts.send_ping_timeout {
    if self.last_ping.is_some() {
        continue;
    }
    let nonce = rand::random();
```

then run:

```
cargo test -p floresta-wire test_handshake_timeout_fires_with_ping_in_flight
```

It fails with `expected the handshake deadline to fire, got PingTimeout` — the loop gave up on the ping deadline instead of the handshake deadline, exactly the bug.

`test_default_timeouts_are_internally_consistent` asserts the relations the deadlines have to satisfy — the poll interval sits below every deadline it is meant to observe, and `ping_timeout` below `send_ping_timeout` — rather than their literal values, which are a policy choice that belongs to the constants.

One gap worth naming: nothing asserts that the production construction path is still wired to `PeerTimeouts::default()`, because `Peer::create_peer` spawns the loop instead of returning the `Peer`. That wiring is the only thing the first commit could quietly get wrong, and today it is guarded by reading the code rather than by a test.

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

