### PR TITLE
fix: reject creation_height = 0 on leaf data

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -217,6 +217,9 @@ pub mod proof_util {
     use crate::pruned_utreexo::consensus::UTREEXO_TAG_V1;
     use crate::pruned_utreexo::utxo_data::UtxoData;
 
+    /// A leaf can never legitimately claim creation at the genesis block.
+    pub const GENESIS_HEIGHT: u32 = 0;
+
     #[derive(Debug)]
     /// Errors that may occur while reconstructing a leaf's scriptPubKey.
     pub enum LeafErrorKind {
@@ -228,6 +231,10 @@ pub mod proof_util {
 
         /// The last instruction in the scriptsig was not an `OP_PUSHBYTES`.
         NotPushBytes,
+
+        /// The leaf claims the spent UTXO was created by the genesis block (height 0); that can
+        /// never happen, as the genesis coinbase is not part of the UTXO set.
+        GenesisCreationHeight,
     }
 
     impl Display for LeafErrorKind {
@@ -236,6 +243,9 @@ pub mod proof_util {
                 Self::EmptyStack => write!(f, "Empty stack"),
                 Self::InvalidInstruction(e) => write!(f, "Invalid instruction: {e}"),
                 Self::NotPushBytes => write!(f, "Not push bytes"),
+                Self::GenesisCreationHeight => {
+                    write!(f, "Leaf claims creation at the genesis block")
+                }
             }
         }
     }
@@ -440,14 +450,25 @@ pub mod proof_util {
                 if utxos.contains_key(&input.previous_output) {
                     continue;
                 }
-                let leaf = match leaves_iter.next() {
-                    Some(leaf) => leaf,
-                    None => continue,
+                let Some(leaf) = leaves_iter.next() else {
+                    continue;
                 };
 
                 let creation_height = leaf.header_code >> 1;
                 // The coinbase flag is the LSB
                 let is_coinbase = (leaf.header_code & 1) != 0;
+
+                // A leaf can never legitimately claim creation at the
+                // genesis block, so reject height 0 up front.
+                if creation_height == GENESIS_HEIGHT {
+                    return Err(UtreexoLeafError {
+                        leaf,
+                        txid,
+                        vin,
+                        kind: LeafErrorKind::GenesisCreationHeight,
+                    }
+                    .into());
+                }
 
                 let hash = get_block_hash(creation_height)?;
                 let leaf =
@@ -558,18 +579,26 @@ pub mod proof_util {
 mod test {
     use bitcoin::Amount;
     use bitcoin::BlockHash;
+    use bitcoin::OutPoint;
     use bitcoin::ScriptBuf;
+    use bitcoin::Sequence;
     use bitcoin::Transaction;
     use bitcoin::TxIn;
+    use bitcoin::TxOut;
+    use bitcoin::Witness;
+    use bitcoin::absolute::LockTime;
     use bitcoin::blockdata::script;
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::opcodes::all::OP_NOP;
     use bitcoin::opcodes::all::OP_PUSHBYTES_1;
+    use bitcoin::transaction::Version;
     use floresta_common::bhash;
 
     use super::CompactLeafData;
     use super::LeafData;
     use super::ScriptPubKeyKind;
+    use super::proof_util::UtreexoLeafError;
+    use super::proof_util::process_proof;
     use super::proof_util::reconstruct_leaf_data;
     use crate::proof_util::LeafErrorKind;
     use crate::proof_util::reconstruct_script_pubkey;
@@ -732,5 +761,69 @@ mod test {
         )
         .unwrap();
         assert_eq!(leaf, reconstructed);
+    }
+
+    #[test]
+    fn test_process_proof_rejects_genesis_creation_height() {
+        #[derive(Debug)]
+        // Any `E: From<UtreexoLeafError>` works; a local type keeps the test self-contained.
+        enum TestErr {
+            Leaf(UtreexoLeafError),
+        }
+
+        impl From<UtreexoLeafError> for TestErr {
+            fn from(e: UtreexoLeafError) -> Self {
+                Self::Leaf(e)
+            }
+        }
+
+        let coinbase = Transaction {
+            version: Version::ONE,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::from_sat(50),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        // A tx spending a prior-block UTXO, so `process_proof` pulls a leaf for it.
+        let spending_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: coinbase.compute_txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(10),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        let txdata = [coinbase, spending_tx];
+
+        let leaves = [CompactLeafData {
+            header_code: 1, // height = 0, coinbase = true.
+            amount: 1,
+            spk_ty: ScriptPubKeyKind::Other(Box::new([0x51])),
+        }];
+
+        // The leaf must be rejected before any block-hash lookup happens.
+        let get_block_hash = |_height| -> Result<BlockHash, TestErr> {
+            panic!("get_block_hash must not be called for a rejected genesis leaf")
+        };
+
+        let TestErr::Leaf(err) =
+            process_proof(&leaves, &txdata, 100, get_block_hash).expect_err("must be rejected");
+
+        assert!(
+            matches!(err.kind, LeafErrorKind::GenesisCreationHeight),
+            "expected GenesisCreationHeight, got {:?}",
+            err.kind
+        );
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/node/blocks.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/blocks.rs
@@ -280,47 +280,76 @@ where
         let (leaf_data, proof, utreexo_peer) =
             inflight.aux_data.ok_or(WireError::BlockProofNotFound)?;
 
+        // The leaf data supplied by the utreexo peer is consumed here, before it is
+        // authenticated, so errors must go through the same handling as `connect_block` ones;
+        // otherwise a misbehaving peer would go unpunished and the block would silently stall.
         let (del_hashes, inputs) =
-            proof_util::process_proof(&leaf_data, &block.txdata, block_height, |h| {
+            match proof_util::process_proof(&leaf_data, &block.txdata, block_height, |h| {
                 self.chain.get_block_hash(h)
-            })?;
-
-        if let Err(chain_err) = self.chain.connect_block(&block, proof, inputs, del_hashes) {
-            error!(
-                "Validation failed for block with {:?}, received by peer {peer}. Reason: {chain_err}",
-                block.header,
-            );
-
-            // Return early if the error is not from block validation (e.g., a database error)
-            let Some(e) = Self::block_validation_err(chain_err) else {
-                return Ok(());
-            };
-
-            return match self.handle_validation_errors(e, block, peer, utreexo_peer) {
-                // Disconnect the responsible peer and ban it.
-                Some(blamed_peer) => {
-                    self.disconnect_and_ban(blamed_peer)?;
-                    Err(WireError::PeerMisbehaving)
+            }) {
+                Ok(processed) => processed,
+                Err(err) => {
+                    return self.handle_process_block_error(err.into(), block, peer, utreexo_peer);
                 }
-                None => Ok(()),
             };
+
+        if let Err(err) = self.chain.connect_block(&block, proof, inputs, del_hashes) {
+            return self.handle_process_block_error(
+                WireError::Blockchain(err),
+                block,
+                peer,
+                utreexo_peer,
+            );
         }
 
         self.last_tip_update = Instant::now();
         Ok(())
     }
 
-    /// Returns the inner [`BlockValidationErrors`] of this chain error, if any.
-    fn block_validation_err(e: BlockchainError) -> Option<BlockValidationErrors> {
-        match e {
-            BlockchainError::TransactionError(tx_err) => Some(tx_err.error),
-            BlockchainError::BlockValidation(block_err) => Some(block_err),
+    /// Handles an error raised while processing a block, either by [`proof_util::process_proof`]
+    /// or [`UpdatableChainstate::connect_block`], banning the responsible peer if any.
+    ///
+    /// Only chain errors caused by peer-supplied data lead to a ban; any other error is our own
+    /// fault (e.g. a database failure) and never punishes a peer: non-chain errors are propagated
+    /// unchanged, and chain errors that aren't validation failures are only logged.
+    ///
+    /// [`UpdatableChainstate::connect_block`]: floresta_chain::pruned_utreexo::UpdatableChainstate::connect_block
+    fn handle_process_block_error(
+        &mut self,
+        err: WireError,
+        block: Block,
+        block_peer: PeerId,
+        utreexo_peer: PeerId,
+    ) -> Result<(), WireError> {
+        let WireError::Blockchain(chain_err) = err else {
+            Err(err)?
+        };
+
+        // Return early if the error is not from block validation (e.g., a database error)
+        let e = match chain_err {
+            BlockchainError::TransactionError(tx_err) => tx_err.error,
+            BlockchainError::BlockValidation(block_err) => block_err,
             // TODO: we need clearer error definitions for utreexo failures
-            BlockchainError::AccumulatorError(_) | BlockchainError::InvalidUtreexoProof => {
-                Some(BlockValidationErrors::InvalidUtreexoProof)
-            }
-            _ => None,
-        }
+            BlockchainError::AccumulatorError(_)
+            | BlockchainError::InvalidUtreexoProof
+            | BlockchainError::UtreexoLeaf(_) => BlockValidationErrors::InvalidUtreexoProof,
+            _ => return Ok(()),
+        };
+
+        let block_hash = block.block_hash();
+
+        let Some(blamed_peer) = self.handle_validation_errors(&e, block, block_peer, utreexo_peer)
+        else {
+            return Ok(());
+        };
+
+        error!(
+            "Validation failed for block {block_hash}, received by peer {blamed_peer}. Reason: {e}"
+        );
+
+        // Disconnect the responsible peer and ban it.
+        self.disconnect_and_ban(blamed_peer)?;
+        Err(WireError::PeerMisbehaving)
     }
 
     /// Handles the different block validation errors that can happen when connecting a block.
@@ -328,7 +357,7 @@ where
     /// Returns the peer id that caused this error, since it could be block or utreexo-related.
     fn handle_validation_errors(
         &mut self,
-        e: BlockValidationErrors,
+        e: &BlockValidationErrors,
         block: Block,
         block_peer: PeerId,
         utreexo_peer: PeerId,


### PR DESCRIPTION
### Description and Notes

While reviewing #1246, I noticed an possible underflow being introduced; [code](https://github.com/getfloresta/Floresta/pull/1246/changes#diff-d1e827190ce70c3c7a1b68a448fe56f843dcf1d3b06366f56e6c89dcf4c85d8dR425))
```Rust

        // Every output created in this block shares the same creation MTP, so compute it once
        // instead of on every output.
        let block_mtp = get_mtp(height - 1)?;
```

We need to subtract one from height to correctly get the Median Time Past, but the given height here is externally provided (we extract it from leaf_data in `process_proof`) and does not have its bounds checked before being used. An malicious peer could send `height = 0` to provoke an underflow, panic on debug but on release its catastrophic.

I added new `LeafErrorKind::GenesisCreationHeight` thats returned on
```Rust
// A leaf can never legitimately claim creation at the
// genesis block, so reject height 0 up front.
if creation_height == 0 {
    return Err(UtreexoLeafError {
        leaf,
        txid,
        vin,
        kind: LeafErrorKind::GenesisCreationHeight,
    }
    .into());
}
``` 
right inside process proof.

Also modified the error handling portion of `process_block` into a new `handle_process_block_error` that can be called both by `process_proof` and `connect_block`, since `process_proof` can now return an error that should punish a peer.

`handle_process_block_error` absorbed the `block_validation_err` helper and only log the peer-blaming `"Validation failed for block {block_hash}, received by peer {blamed_peer}. Reason: {e}"` after we 1. identified which of both relevant peers `(block_peer, utreexo_peer)` and 2. identified an error that should punish the peer.

### How to verify the changes you have done?

`test_process_proof_rejects_genesis_creation_height` exercises this precise case on floresta-chain side, please take a look.