### PR TITLE
fix(rpc): addnode should report failure, not always success

### DIFF
--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -63,12 +63,34 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         let address =
             BitcoinSocketAddr::parse_address(&address, Some(self.network), SystemResolver)?;
 
-        let _ = match command.as_str() {
-            "add" => self.node.add_peer(address, v2transport).await,
-            "remove" => self.node.remove_peer(address).await,
-            "onetry" => self.node.onetry_peer(address, v2transport).await,
+        let (succeeded, failure_message) = match command.as_str() {
+            "add" => (
+                self.node
+                    .add_peer(address, v2transport)
+                    .await
+                    .map_err(|e| JsonRpcError::Node(e.to_string()))?,
+                "Node already added",
+            ),
+            "remove" => (
+                self.node
+                    .remove_peer(address)
+                    .await
+                    .map_err(|e| JsonRpcError::Node(e.to_string()))?,
+                "Node has not been added",
+            ),
+            "onetry" => (
+                self.node
+                    .onetry_peer(address, v2transport)
+                    .await
+                    .map_err(|e| JsonRpcError::Node(e.to_string()))?,
+                "Failed to connect to node",
+            ),
             _ => return Err(JsonRpcError::InvalidAddnodeCommand),
         };
+
+        if !succeeded {
+            return Err(JsonRpcError::AddnodeFailed(failure_message.into()));
+        }
 
         Ok(json!(null))
     }

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -159,6 +159,7 @@ pub mod jsonrpc_interface {
     pub const NO_BLOCK_FILTERS: i16 = SERVER_ERROR_MIN + 7; // -32092
     pub const NODE_ERROR: i16 = SERVER_ERROR_MIN + 8; // -32091
     pub const CHAIN_ERROR: i16 = SERVER_ERROR_MIN + 9; // -32090
+    pub const ADDNODE_ERROR: i16 = SERVER_ERROR_MIN + 10; // -32089
     pub const FILTERS_ERROR: i16 = SERVER_ERROR_MAX; // -32000
 
     #[derive(Debug)]
@@ -241,6 +242,11 @@ pub mod jsonrpc_interface {
         /// Peer not found in the peer list.
         PeerNotFound,
 
+        /// An `addnode` command (`add`, `remove`, or `onetry`) did not perform the requested
+        /// operation, e.g. adding a peer that's already added, removing one that was never
+        /// added, or a one-time connection attempt that failed.
+        AddnodeFailed(String),
+
         /// Timestamp argument to `rescanblockchain` is before the genesis block
         /// (and not zero, which is the default).
         InvalidTimestamp,
@@ -287,6 +293,9 @@ pub mod jsonrpc_interface {
                 | Self::BlockNotFound
                 | Self::TxNotFound
                 | Self::PeerNotFound => StatusCode::NOT_FOUND,
+
+                // 409 Conflict - the requested operation doesn't match the peer's current state
+                Self::AddnodeFailed(_) => StatusCode::CONFLICT,
 
                 // 500 Internal Server Error - server messed up
                 Self::ChainWorkOverflow | Self::ConversionOverflow(_) => {
@@ -425,6 +434,11 @@ pub mod jsonrpc_interface {
                 Self::PeerNotFound => RpcError {
                     code: PEER_NOT_FOUND,
                     message: "Peer not found".into(),
+                    data: None,
+                },
+                Self::AddnodeFailed(msg) => RpcError {
+                    code: ADDNODE_ERROR,
+                    message: msg.clone(),
                     data: None,
                 },
                 Self::NoAddressesToRescan => RpcError {

--- a/tests/floresta-cli/addnode.py
+++ b/tests/floresta-cli/addnode.py
@@ -3,6 +3,7 @@
 """Tests for florestad addnode RPC behavior."""
 
 import pytest
+from requests.exceptions import HTTPError
 
 from test_framework.node import NodeType
 
@@ -101,18 +102,29 @@ class AddNodeTest:
         self.verify_peer_connection_state(is_connected=True)
 
         self.log.info(
-            "===== Verify Floresta does not add the same persistent peer twice"
+            "===== Verify Floresta rejects re-adding the same persistent peer"
         )
-        self.floresta_addnode_with_command("add")
-        # This function expects 1 peer connected to florestad
+        with pytest.raises(HTTPError):
+            self.floresta_addnode_with_command("add")
+        # The peer was already connected and stays that way; the RPC call itself failed.
         self.verify_peer_connection_state(is_connected=True)
 
-        self.floresta_addnode_with_command("onetry")
-        # This function expects 1 peer connected to florestad
+        self.log.info(
+            "===== Verify Floresta rejects a onetry to an already-connected peer"
+        )
+        with pytest.raises(HTTPError):
+            self.floresta_addnode_with_command("onetry")
         self.verify_peer_connection_state(is_connected=True)
 
         self.log.info("===== Remove bitcoind from Floresta's persistent peer list")
         self.floresta_addnode_with_command("remove")
+        self.verify_peer_connection_state(is_connected=True)
+
+        self.log.info(
+            "===== Verify Floresta rejects removing a peer that was not added"
+        )
+        with pytest.raises(HTTPError):
+            self.floresta_addnode_with_command("remove")
         self.verify_peer_connection_state(is_connected=True)
 
         self.stop_bitcoind()


### PR DESCRIPTION
Closes #1239

`addnode` (add/remove/onetry) was throwing away the bool that `add_peer`/`remove_peer`/`onetry_peer` return and always answering with success, even when the peer was already added, wasn't in the list, or the one-time connection failed. This makes it check that result and return an error instead, the same way `disconnect_node` already does right below it.

Also updated the addnode test, since it was actually depending on this bug (calling `add` and `onetry` a second time and expecting silent success). Added a case for calling `remove` on a peer that was never added too.