### PR TITLE
chore(deps): bump the all group with 3 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,9 +1904,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2282,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+checksum = "ba70bf887030e45213b4a95c9b08d5a450b157f87c1d63661ed0847a12fa2aad"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3212,13 +3212,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "http",
+ "percent-encoding",
  "pin-project-lite",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2020,7 +2020,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2537,7 +2537,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2795,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2904,7 +2904,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3581,7 +3581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 bitcoinkernel = { version = "=0.2.1", optional = true }
-lru = { version = "=0.18.0", optional = true }
+lru = { version = "=0.18.2", optional = true }
 memmap2 = { version = "=0.9.11", optional = true }
 rustreexo = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/crates/floresta-node/Cargo.toml
+++ b/crates/floresta-node/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 toml = { workspace = true }
-tower-http = { version = "=0.6.11", optional = true, features = ["cors"] }
+tower-http = { version = "=0.7.0", optional = true, features = ["cors"] }
 tracing = { workspace = true }
 zmq = { version = "=0.10.0", optional = true, default-features = false }
 time = { workspace = true }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 axum = { workspace = true }
-prometheus-client = { version = "=0.24.1" }
+prometheus-client = { version = "=0.25.0" }
 sysinfo = { version = "=0.36.1", default-features = false, features = ["system"] }
 tokio = { workspace = true }
 


### PR DESCRIPTION
This PR overwrites PR #1273. 
PR #1273 bumps dependencies that require a Rust version greater than 1.85. For more information, see PR #1265.

**Closing issue #1278. The lru dependency has been bumped to version 0.18.2.**

Fixes the vulnerability reported by `cargo audit` in the `h2` dependency. `h2` is not a direct dependency, but is pulled in indirectly by `tonic` and `axum`. Neither currently has a version that uses a non-vulnerable `h2` release, so the update had to be forced with `cargo update -p h2 --precise 0.4.16`.


Bumps the all group with 3 updates:

| Package | From | To |
| --- | --- | --- |
| [tower-http](https://github.com/tower-rs/tower-http) | `0.6.11` | `0.7.0` | 
| [prometheus-client](https://github.com/prometheus/client_rust) | `0.24.1` | `0.25.0` | 
| [lru](https://github.com/jeromefroe/lru-rs) | `0.18.0` | `0.18.2` |
| [h2](https://github.com/hyperium/h2) | `0.4.14` | `0.4.16` |



Updates `tower-http` from 0.6.11 to 0.7.0
- [Release notes](https://github.com/tower-rs/tower-http/releases)
- [Commits](https://github.com/tower-rs/tower-http/compare/tower-http-0.6.11...tower-http-0.7.0)

Updates `prometheus-client` from 0.24.1 to 0.25.0
- [Release notes](https://github.com/prometheus/client_rust/releases)
- [Changelog](https://github.com/prometheus/client_rust/blob/master/CHANGELOG.md)
- [Commits](https://github.com/prometheus/client_rust/compare/v0.24.1...v0.25.0)

Updates `lru` from 0.18.0 to 0.18.2
- [Changelog](https://github.com/jeromefroe/lru-rs/blob/0.18.2/CHANGELOG.md)
- [Commits](https://github.com/jeromefroe/lru-rs/compare/0.18.0...0.18.2)

Updates `h2` from 0.4.14 to 0.4.16
- [Changelog](https://github.com/hyperium/h2/blob/master/CHANGELOG.md#0416-august-17-2026)
- [Commits](https://github.com/hyperium/h2/compare/v0.4.14...v0.4.16)

---
updated-dependencies:
- dependency-name: tower-http
  dependency-version: 0.7.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all
- dependency-name: prometheus-client
  dependency-version: 0.25.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all
- dependency-name: lru
  dependency-version: 0.18.2
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all

