### PR TITLE
Change dependabot's interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     - package-ecosystem: "cargo"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
           time: "00:00"
       cooldown:
           default-days: 60
@@ -17,7 +17,7 @@ updates:
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
           time: "00:00"
       cooldown:
           default-days: 60
@@ -28,7 +28,7 @@ updates:
     - package-ecosystem: "nix"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
           time: "00:00"
       cooldown:
           default-days: 60
@@ -39,7 +39,7 @@ updates:
     - package-ecosystem: "uv"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
           time: "00:00"
       cooldown:
           default-days: 60


### PR DESCRIPTION
Makes dependabot's PRs less spammy by moving the interval to `monthly`.