### PR TITLE
fix: new lints

### DIFF
--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -489,7 +489,7 @@ pub mod jsonrpc_interface {
 
     impl From<Infallible> for JsonRpcError {
         fn from(e: Infallible) -> Self {
-            Self::ConversionOverflow(e.to_string())
+            match e {}
         }
     }
 

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -327,11 +327,7 @@ impl LocalAddress {
                 let octets = address.octets();
                 // CJDNS addresses use a special range for local addresses (FC00::/8)
                 // See: https://github.com/cjdelisle/cjdns/tree/master/doc#what-is-notable-about-cjdns-why-should-i-use-it
-                if octets[0] == 0xFC {
-                    return true;
-                }
-
-                false
+                octets[0] == 0xFC
             }
             _ => true,
         }


### PR DESCRIPTION
fix(wire): reduce bool-literal if to expression in is_routable

Clippy's needless_bool lint flags the if/return-true/false pattern in the Cjdns arm of LocalAddress::is_routable; return the comparison directly instead.

And

fix(node): use empty match in From<Infallible> for JsonRpcError

Infallible has no values, so calling e.to_string() is unreachable code,
which rustc rejects under -D warnings. An empty match expresses the
impossibility directly.