### PR TITLE
add signet.seed.utreexo.net to signet DNS seeds

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -418,6 +418,7 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
         Network::Signet => {
             seeds.push(DnsSeed::new("signet.seed.dlsouza.lol", x1000));
             seeds.push(DnsSeed::new("seed.signet.bitcoin.sprovoost.nl", x49));
+            seeds.push(DnsSeed::new("signet.seed.utreexo.net", x1009));
         }
         Network::Testnet => {
             seeds.push(DnsSeed::new("testnet-seed.bitcoin.jonasschnelli.ch", x49));


### PR DESCRIPTION
The network needs another option for initial peer discovery. This PR adds a second Utreexo-filtered DNS seed for Signet only.

Validation:

`$ dig +short x1009.signet.seed.utreexo.net A`


