### PR TITLE
chore(deps): replace sha2 and sha3 with bitcoin_hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,15 +404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -654,15 +645,6 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -775,16 +757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,16 +822,6 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dircpy"
@@ -1014,7 +976,6 @@ dependencies = [
  "rustreexo",
  "serde",
  "serde_json",
- "sha2",
  "spin",
  "tempfile",
  "tracing",
@@ -1040,7 +1001,6 @@ version = "0.5.0"
 dependencies = [
  "bitcoin",
  "hashbrown 0.17.1",
- "sha2",
  "spin",
  "tracing",
 ]
@@ -1178,6 +1138,7 @@ version = "0.5.0"
 dependencies = [
  "bip324",
  "bitcoin",
+ "bitcoin_hashes 0.20.0",
  "derive_more",
  "dns-lookup",
  "floresta-chain",
@@ -1191,7 +1152,6 @@ dependencies = [
  "rustreexo",
  "serde",
  "serde_json",
- "sha3",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -1307,16 +1267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1799,15 +1749,6 @@ checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
 dependencies = [
  "crossbeam",
  "rayon",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2709,27 +2650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,12 +3243,6 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs"
 rustreexo = { version = "=0.6.0" }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = { version = "=1.0.150" }
-sha2 = { version = "=0.10.9", default-features = false }
 spin = { version = "=0.10.1", default-features = false, features = ["spin_mutex", "rwlock"] }
 tempfile = { version = "=3.27.0" }
 tokio = { version = "=1.52.3", features = ["net", "time", "rt-multi-thread", "signal", "macros"] }

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -26,7 +26,6 @@ lru = { version = "=0.18.2", optional = true }
 memmap2 = { version = "=0.9.11", optional = true }
 rustreexo = { workspace = true }
 serde = { workspace = true, optional = true }
-sha2 = { workspace = true, features = ["std"] }
 spin = { workspace = true }
 tracing = { workspace = true }
 twox-hash = { version = "=2.1.2", default-features = false, features = ["xxhash3_64", "std"], optional = true }

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -10,9 +10,9 @@ use bitcoin::consensus;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::Encodable;
 use bitcoin::hashes::Hash;
+use bitcoin::hashes::HashEngine;
 use bitcoin::hashes::sha256;
-use sha2::Digest;
-use sha2::Sha512_256;
+use bitcoin::hashes::sha512_256;
 
 use crate::prelude::Box;
 use crate::prelude::Vec;
@@ -48,17 +48,19 @@ impl LeafData {
             .consensus_encode(&mut ser_utxo)
             .expect("serializing TxOut never fails: Vec<u8>::Write always returns Ok");
 
-        let leaf_hash = Sha512_256::new()
-            .chain_update(UTREEXO_TAG_V1)
-            .chain_update(UTREEXO_TAG_V1)
-            .chain_update(self.block_hash)
-            .chain_update(self.prevout.txid)
-            .chain_update(self.prevout.vout.to_le_bytes())
-            .chain_update(self.header_code.to_le_bytes())
-            .chain_update(ser_utxo)
-            .finalize();
+        let mut engine = sha512_256::Hash::engine();
 
-        sha256::Hash::from_byte_array(leaf_hash.into())
+        engine.input(&UTREEXO_TAG_V1);
+        engine.input(&UTREEXO_TAG_V1);
+        engine.input(&self.block_hash[..]);
+        engine.input(&self.prevout.txid[..]);
+        engine.input(&self.prevout.vout.to_le_bytes());
+        engine.input(&self.header_code.to_le_bytes());
+        engine.input(&ser_utxo);
+
+        let leaf_hash = sha512_256::Hash::from_engine(engine);
+
+        sha256::Hash::from_byte_array(leaf_hash.to_byte_array())
     }
 }
 
@@ -202,11 +204,11 @@ pub mod proof_util {
     use bitcoin::blockdata::script::Instruction;
     use bitcoin::consensus::Encodable;
     use bitcoin::hashes::Hash;
+    use bitcoin::hashes::HashEngine;
     use bitcoin::hashes::sha256;
+    use bitcoin::hashes::sha512_256;
     use floresta_common::impl_error_from;
     use rustreexo::node_hash::BitcoinNodeHash;
-    use sha2::Digest;
-    use sha2::Sha512_256;
 
     use super::LeafData;
     use crate::BlockchainError;
@@ -335,17 +337,19 @@ pub mod proof_util {
             height << 1
         };
 
-        let leaf_hash = Sha512_256::new()
-            .chain_update(UTREEXO_TAG_V1)
-            .chain_update(UTREEXO_TAG_V1)
-            .chain_update(block_hash)
-            .chain_update(txid)
-            .chain_update(vout.to_le_bytes())
-            .chain_update(header_code.to_le_bytes())
-            .chain_update(ser_utxo)
-            .finalize();
+        let mut engine = sha512_256::Hash::engine();
 
-        sha256::Hash::from_byte_array(leaf_hash.into())
+        engine.input(&UTREEXO_TAG_V1);
+        engine.input(&UTREEXO_TAG_V1);
+        engine.input(&block_hash[..]);
+        engine.input(&txid[..]);
+        engine.input(&vout.to_le_bytes());
+        engine.input(&header_code.to_le_bytes());
+        engine.input(&ser_utxo);
+
+        let leaf_hash = sha512_256::Hash::from_engine(engine);
+
+        sha256::Hash::from_byte_array(leaf_hash.to_byte_array())
     }
 
     /// From a block, gets the roots that will be included on the acc, certifying
@@ -732,5 +736,38 @@ mod test {
         )
         .unwrap();
         assert_eq!(leaf, reconstructed);
+    }
+    #[test]
+    fn test_leaf_hash_known_vector() {
+        use bitcoin::BlockHash;
+        use bitcoin::OutPoint;
+        use bitcoin::ScriptBuf;
+        use bitcoin::TxOut;
+        use bitcoin::amount::Amount;
+        use bitcoin::hashes::Hash;
+        use bitcoin::hashes::sha256;
+
+        let block_hash = BlockHash::from_byte_array([0xAA; 32]);
+        let txid = bitcoin::Txid::from_byte_array([0xBB; 32]);
+        let outpoint = OutPoint::new(txid, 42);
+        let header_code = 0xDEADBEEF;
+        let utxo = TxOut {
+            value: Amount::from_sat(100_000_000),
+            script_pubkey: ScriptBuf::new(),
+        };
+        let leaf = LeafData {
+            block_hash,
+            prevout: outpoint,
+            header_code,
+            utxo,
+        };
+
+        let hash = leaf._get_leaf_hashes();
+        let expected: sha256::Hash =
+            "faa30cef15141c86d3066850efdbc4c67690c513c465fb97c67a0ed56f4b05ec"
+                .parse()
+                .unwrap();
+
+        assert_eq!(hash, expected, "Leaf hash changed unexpectedly!");
     }
 }

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -13,13 +13,12 @@ readme.workspace = true # Floresta/README.md
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 hashbrown = { version = "=0.17.1" }
-sha2 = { workspace = true }
 spin = { workspace = true }
 tracing = { workspace = true }
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "sha2/std"]
+std = ["bitcoin/std"]
 
 [lints]
 workspace = true

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -26,8 +26,6 @@ use bitcoin::consensus::encode;
 use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256;
 use bitcoin::p2p::ServiceFlags;
-use sha2::Digest;
-
 #[cfg(feature = "std")]
 mod ema;
 pub mod macros;
@@ -41,8 +39,7 @@ pub use spsc::Channel;
 ///
 /// [Hash]: https://docs.rs/bitcoin_hashes/latest/bitcoin_hashes/sha256/struct.Hash.html
 pub fn get_hash_from_u8(data: &[u8]) -> sha256::Hash {
-    let hash = sha2::Sha256::new().chain_update(data).finalize();
-    sha256::Hash::from_byte_array(hash.into())
+    sha256::Hash::hash(data)
 }
 
 /// Computes the SHA-256 digest of a script, reverses its bytes, and returns a [Hash] from
@@ -55,11 +52,10 @@ pub fn get_hash_from_u8(data: &[u8]) -> sha256::Hash {
 /// [Hash]: https://docs.rs/bitcoin_hashes/latest/bitcoin_hashes/sha256/struct.Hash.html
 pub fn get_spk_hash(spk: &ScriptBuf) -> sha256::Hash {
     let data = spk.as_bytes();
-    let mut hash = sha2::Sha256::new().chain_update(data).finalize();
-    hash.reverse();
-    sha256::Hash::from_byte_array(hash.into())
+    let mut bytes = sha256::Hash::hash(data).to_byte_array();
+    bytes.reverse();
+    sha256::Hash::from_byte_array(bytes)
 }
-
 /// Reads a VarInt from the given reader and ensures it is less than or equal to `max`.
 ///
 /// Returns an error if the VarInt is larger than `max`.

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -25,7 +25,7 @@ rustls = { version = "=0.23.40", default-features = false, features = ["ring", "
 rustreexo = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha3 = { version = "=0.10.9", default-features = false, features = ["asm"] }
+bitcoin_hashes = { version = "=0.20.0" }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 ureq = { version = "=3.3.0", features = ["socks-proxy", "json", "rustls-no-provider"], default-features = false }

--- a/crates/floresta-wire/src/p2p_wire/onion.rs
+++ b/crates/floresta-wire/src/p2p_wire/onion.rs
@@ -6,9 +6,8 @@ use std::io::Write;
 use std::str::FromStr;
 
 use bitcoin::p2p::address::AddrV2;
+use bitcoin_hashes::sha3_256;
 use floresta_common::impl_error_from;
-use sha3::Digest;
-use sha3::Sha3_256;
 
 /// The base32 alphabet.
 ///
@@ -270,25 +269,14 @@ impl OnionV3Addr {
     /// These should be serialized as a byte-array and hashed. The checksum will be resulting
     /// hash's two lowest bytes.
     pub fn checksum(&self) -> OnionChecksum {
-        let mut hash = Sha3_256::new();
+        let mut data = Vec::with_capacity(14 + PUBKEY_LENGTH + VERSION_LENGTH);
+        data.extend_from_slice(".onion checksum".as_bytes());
+        data.extend_from_slice(&self.pubkey.0);
+        data.extend_from_slice(&self.version.0.to_be_bytes());
 
-        // to compute the checksum, we must write...
-
-        // ... ".onion checksum" as bytes...
-        hash.write_all(".onion checksum".as_bytes())
-            .expect("in-memory hashers don't err");
-
-        // ... the server pubkey bytes ...
-        hash.write_all(&self.pubkey.0)
-            .expect("in-memory hashers don't err");
-
-        // ... and finally, the protocol version as bytes ...
-        hash.write_all(&self.version.0.to_be_bytes())
-            .expect("in-memory hashers don't err");
-
-        let digest = hash.finalize();
+        let digest = sha3_256::Hash::hash(&data);
         let mut final_checksum = [0; CHECKSUM_LENGTH];
-        final_checksum.copy_from_slice(&digest[0..CHECKSUM_LENGTH]);
+        final_checksum.copy_from_slice(&digest.to_byte_array()[0..CHECKSUM_LENGTH]);
 
         final_checksum.into()
     }


### PR DESCRIPTION
### Description and Notes

Replaces external RustCrypto `sha2` and `sha3` dependencies with `bitcoin_hashes` from the rust-bitcoin ecosystem, keeping all hashing within a single dependency family.....

**Changes:**
- **Removed `sha2`** from workspace root, `floresta-chain`, and `floresta-common` — it was declared but never used correctly. All SHA-256 usage was already via `bitcoin_hashes::sha256`.
- **Replaced `sha2` with `bitcoin_hashes::sha512_256`** for Utreexo leaf hash computation in `floresta-chain`. Computes as `sha512_256` internally and converts output to `sha256::Hash` to match existing return types.
- **Replaced `sha3` with `bitcoin_hashes 0.20.0`** in `floresta-wire` for the Tor V3 onion address checksum. Version 0.20 is already in the tree via `rustreexo`, so no new crate is introduced.

Note: `bitcoin_hashes` 0.14 (pinned by `bitcoin 0.32.8`) does not include `sha3_256`, which is why a direct dep on 0.20 is needed.

Closes #1237

### How to verify the changes

- `cargo check --workspace` ==> compiles cleanly
- `cargo test -p floresta-wire -- onion` ==> all 12 onion tests pass
- `cargo clippy --workspace` ==> zero warnings

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/getfloresta/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above