### PR TITLE
deps: bump bitcoinkernel to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoinkernel"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af4fd16f643d5bc585073c8513a9fde0a72278a38d0957b78cfd8f2c21bbb36"
+checksum = "202e7d3409ef1457abbe72404cfb3f43a104980313cc685e45cfe0366048618d"
 dependencies = [
  "libbitcoinkernel-sys",
 ]
@@ -1878,9 +1878,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbitcoinkernel-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2906bc31f02dff7af9611fe9129c9eae021bd359f9d8e79824026fe1aaf28ab1"
+checksum = "ccee819dc48af6ce3fb213e6f93bae7a7231cd0689b0435afd86ab167cad5321"
 dependencies = [
  "cc",
 ]

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 # All dependencies MUST be pinned precisely with `X.Y.z`
 bitcoin = { workspace = true }
 bitcoin_hashes = { workspace = true }
-bitcoinkernel = { version = "=0.2.1", optional = true }
+bitcoinkernel = { version = "=0.3.0", optional = true }
 lru = { version = "=0.18.2", optional = true }
 memmap2 = { version = "=0.9.11", optional = true }
 rustreexo = { workspace = true }

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -14,7 +14,6 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use core::ffi::c_uint;
 
 use bitcoin::Block;
 use bitcoin::BlockHash;
@@ -23,6 +22,8 @@ use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::constants::SUBSIDY_HALVING_INTERVAL;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::params::Params;
+#[cfg(feature = "bitcoinkernel")]
+use bitcoinkernel::ScriptVerificationFlags;
 use floresta_common::acchashes;
 use floresta_common::bhash;
 use floresta_common::service_flags;
@@ -76,7 +77,7 @@ pub struct ChainParams {
 
     /// A list of exceptions to the rules, where the key is the block hash and the value is the
     /// verification flags
-    pub exceptions: HashMap<BlockHash, c_uint>,
+    pub exceptions: HashMap<BlockHash, u32>,
 
     /// The network this chain params is for
     pub network: Network,
@@ -245,7 +246,7 @@ impl ChainParams {
 
     #[cfg(feature = "bitcoinkernel")]
     /// Returns the validation flags for a given block hash and height
-    pub fn get_validation_flags(&self, height: u32, hash: BlockHash) -> c_uint {
+    pub fn get_validation_flags(&self, height: u32, hash: BlockHash) -> ScriptVerificationFlags {
         if let Some(flag) = self.exceptions.get(&hash) {
             return *flag;
         }
@@ -285,7 +286,7 @@ impl ChainParams {
 /// "looks like segwit but are not segwit". We pretend segwit
 /// was enabled since genesis, and only skip this for blocks
 /// that have such transactions using hardcoded values.
-fn get_exceptions() -> HashMap<BlockHash, c_uint> {
+fn get_exceptions() -> HashMap<BlockHash, ScriptVerificationFlags> {
     use bitcoinkernel::VERIFY_NONE;
     use bitcoinkernel::VERIFY_P2SH;
     use bitcoinkernel::VERIFY_WITNESS;
@@ -307,7 +308,7 @@ fn get_exceptions() -> HashMap<BlockHash, c_uint> {
 }
 
 #[cfg(not(feature = "bitcoinkernel"))]
-fn get_exceptions() -> HashMap<BlockHash, c_uint> {
+fn get_exceptions() -> HashMap<BlockHash, u32> {
     HashMap::new()
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -7,8 +7,6 @@
 
 extern crate alloc;
 
-use core::ffi::c_uint;
-
 use bitcoin::Amount;
 use bitcoin::Block;
 use bitcoin::CompactTarget;
@@ -29,6 +27,8 @@ use bitcoin::hashes::sha256;
 use bitcoin::script;
 #[cfg(feature = "bitcoinkernel")]
 use bitcoinkernel::PrecomputedTransactionData;
+#[cfg(feature = "bitcoinkernel")]
+use bitcoinkernel::ScriptVerificationFlags;
 use floresta_common::prelude::*;
 use rustreexo::node_hash::BitcoinNodeHash;
 use rustreexo::proof::Proof;
@@ -191,7 +191,7 @@ impl Consensus {
         transactions: &[Transaction],
         subsidy: Amount,
         verify_script: bool,
-        flags: c_uint,
+        flags: u32,
     ) -> Result<(), BlockchainError> {
         // Blocks must contain at least one transaction (i.e., the coinbase)
         if transactions.is_empty() {
@@ -383,7 +383,7 @@ impl Consensus {
         utxos: &mut HashMap<OutPoint, UtxoData>,
         height: u32,
         _verify_script: bool,
-        _flags: c_uint,
+        _flags: u32,
     ) -> Result<(Amount, Amount), BlockchainError> {
         let txid = || transaction.compute_txid();
 
@@ -437,7 +437,7 @@ impl Consensus {
     fn verify_input_scripts(
         transaction: &Transaction,
         spent_utxos: &[UtxoData],
-        flags: c_uint,
+        flags: ScriptVerificationFlags,
     ) -> Result<(), BlockchainError> {
         let tx = serialize(&transaction);
         let txid = || transaction.compute_txid();


### PR DESCRIPTION
Updates to the latest release of bitcoinkernel which includes some new methods that we can use, one of the changes was Android build instructions that allows for floresta, now with the bitcoinkernel feature, to be compiled for android targets.

Also, verify now takes `flags: ScriptVerificationFlags` instead of a `flags: u32`, this did not raise a problem by itself because we were handling flags with `c_uint` which maps directly to `u32`. `ScriptVerificationFlags` is just a type alias of `u32` BTW.

Taking the chance to drop c_uint on flags typing to reduce the difference between the current APIs, putting u32s in common places and ScriptVerificationFlagson bitcoinkernel exclusive paths. Another point to drop c_uint, as official rust docs on it explain: "This type will almost always be  u32, but may differ on some esoteric systems. The C standard technically only requires that this type be an unsigned integer  with the same size as an int; some systems define it as a u16, for example." 
