### PR TITLE
fix(chain): remove dangerous numeric casts

### DIFF
--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -303,7 +303,7 @@ fn chainstore_checksum_benchmark(c: &mut Criterion) {
         let mut chainstore = FlatChainStore::new(config).unwrap();
 
         headers.iter().enumerate().for_each(|(i, header)| {
-            let height = i as u32;
+            let height = u32::try_from(i).expect("test header index must fit in a u32");
             let disk_header = DiskBlockHeader::HeadersOnly(*header, height);
 
             chainstore.save_header(&disk_header).unwrap();

--- a/crates/floresta-chain/src/extensions.rs
+++ b/crates/floresta-chain/src/extensions.rs
@@ -222,7 +222,7 @@ impl HeaderExt for Header {
     }
 
     fn get_version_hex(&self) -> String {
-        serialize_hex(&(self.version.to_consensus() as u32).to_be())
+        serialize_hex(&self.version.to_consensus().to_be())
     }
 }
 
@@ -286,7 +286,7 @@ impl WorkExt for Work {
             // Result is built in big-endian order, so calculate the index accordingly
             let byte_index = by_chunks.len() - word_index;
             result_bytes[(byte_index - 1) * word_size..byte_index * word_size]
-                .copy_from_slice(&(product as u32).to_be_bytes());
+                .copy_from_slice(&product.to_be_bytes()[4..]);
         }
 
         if carry_high > 0 {
@@ -649,7 +649,10 @@ mod tests {
 
         let expected_confirmations = headers.len() - 2;
 
-        assert_eq!(confirmations, expected_confirmations as u32);
+        assert_eq!(
+            confirmations,
+            u32::try_from(expected_confirmations).expect("test confirmation count must fit in u32")
+        );
     }
 
     #[test]
@@ -669,7 +672,10 @@ mod tests {
             .get_height(&mock_chain)
             .expect("Failed to get block height");
 
-        assert_eq!(height, height_expected as u32);
+        assert_eq!(
+            height,
+            u32::try_from(height_expected).expect("test height must fit in u32")
+        );
 
         let mut header_missing = headers[0];
         header_missing.nonce = 0;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -65,6 +65,7 @@ use super::partial_chain::PartialChainState;
 use super::partial_chain::PartialChainStateInner;
 use crate::BestChain;
 use crate::ChainStore;
+use crate::extensions::ChainWorkOverflow;
 use crate::extensions::HeaderExt;
 use crate::extensions::WorkExt;
 use crate::prelude::*;
@@ -193,7 +194,9 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         height: u32,
     ) -> Result<(), BlockchainError> {
         for (offset, &header) in headers.iter().enumerate() {
-            let disk_height = height + offset as u32;
+            let offset = u32::try_from(offset)
+                .map_err(|_| BlockchainError::OperationOverflow(ChainWorkOverflow))?;
+            let disk_height = height + offset;
             let disk_header = DiskBlockHeader::FullyValid(header, disk_height);
             let hash = disk_header.block_hash();
 
@@ -969,7 +972,8 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         // Special testnet rule, if a block takes more than 20 minutes to mine, we can
         // mine a block with diff 1
         if params.params.allow_min_difficulty_blocks
-            && last_block.time + params.params.pow_target_spacing as u32 * 2 < next_header.time
+            && u64::from(last_block.time) + params.params.pow_target_spacing * 2
+                < u64::from(next_header.time)
         {
             return Ok(params.params.max_attainable_target);
         }
@@ -2061,7 +2065,7 @@ mod test {
             ChainParams::from(Network::Signet),
         );
 
-        assert!((first_block.time as i32 - last_block.time as i32) < 0);
+        assert!(first_block.time < last_block.time);
 
         assert_eq!(0x1e00ddeb, next_target.to_compact_lossy().to_consensus());
 
@@ -2313,7 +2317,10 @@ mod test {
             .invalidate_block(headers[random_height].prev_blockhash)
             .unwrap();
 
-        assert_eq!(chain.get_height().unwrap() as usize, random_height - 1);
+        assert_eq!(
+            usize::try_from(chain.get_height().unwrap()).expect("test height must fit in usize"),
+            random_height - 1
+        );
 
         // update_tip
         chain.update_tip(headers[1].prev_blockhash, 1);

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -312,7 +312,8 @@ impl Consensus {
                 if hinted_unspent {
                     unspent_amount += out.value;
                 } else {
-                    spent_vouts.push(vout as u32);
+                    spent_vouts
+                        .push(u32::try_from(vout).map_err(|_| BlockValidationErrors::BlockTooBig)?);
                 }
                 output_index += 1;
             }
@@ -733,13 +734,13 @@ impl Consensus {
         match push {
             Ok(script::Instruction::PushBytes(b)) => {
                 let h = script::read_scriptint(b.as_bytes()).ok()?;
-                Some(h as u32)
+                Some(u32::try_from(h).ok()?)
             }
 
             Ok(script::Instruction::Op(opcode)) => {
                 let opcode = opcode.to_u8();
                 if (0x51..=0x60).contains(&opcode) {
-                    Some(opcode as u32 - 0x50)
+                    Some(u32::from(opcode) - 0x50)
                 } else {
                     None
                 }
@@ -1836,7 +1837,12 @@ mod tests {
                 i => {
                     let unspent_indexes = default_unspent_idx.clone();
                     let (agg_i, amount) = consensus
-                        .process_block_swiftsync(block, i as u32, unspent_indexes, &salt)
+                        .process_block_swiftsync(
+                            block,
+                            u32::try_from(i).expect("test block height must fit in u32"),
+                            unspent_indexes,
+                            &salt,
+                        )
                         .unwrap();
 
                     assert!(agg_i.is_zero());

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1000,7 +1000,9 @@ impl FlatChainStore {
         let mut parent_hashes = HashSet::with_capacity(fork_count);
 
         for i in 0..fork_count {
-            let index = Index::new_fork(i as u32)?;
+            let index = Index::new_fork(
+                u32::try_from(i).map_err(|_| FlatChainstoreError::OversizedIndex)?,
+            )?;
             let hdr = unsafe { self.get_disk_header(index)? };
             match hdr.header {
                 DiskBlockHeader::InFork(..)
@@ -1251,8 +1253,9 @@ impl ChainStore for FlatChainStore {
             return Err(FlatChainstoreError::HeaderNotFound);
         }
 
-        header.acc_pos = pos as u32;
-        header.acc_len = size as u32;
+        header.acc_pos = u32::try_from(pos).map_err(|_| FlatChainstoreError::OversizedIndex)?;
+        header.acc_len =
+            u32::try_from(size).map_err(|_| FlatChainstoreError::OversizedAccumulator)?;
 
         self.accumulator_file.write_all(&roots)?;
         self.accumulator_file.flush()?;
@@ -1694,12 +1697,18 @@ mod tests {
             let block: Block = deserialize(&block).unwrap();
 
             store
-                .save_header(&DiskBlockHeader::FullyValid(block.header, i as u32))
+                .save_header(&DiskBlockHeader::FullyValid(
+                    block.header,
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                ))
                 .unwrap();
             // Map hashes to block indices such that we can later fetch headers from hashes
             // (hash -> index -> header)
             store
-                .update_block_index(i as u32, block.block_hash())
+                .update_block_index(
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                    block.block_hash(),
+                )
                 .unwrap();
         }
 
@@ -1873,11 +1882,17 @@ mod tests {
             hashes.push(block.block_hash());
 
             store
-                .save_header(&DiskBlockHeader::FullyValid(block.header, i as u32))
+                .save_header(&DiskBlockHeader::FullyValid(
+                    block.header,
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                ))
                 .unwrap();
 
             store
-                .update_block_index(i as u32, block.block_hash())
+                .update_block_index(
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                    block.block_hash(),
+                )
                 .unwrap();
         }
 
@@ -1933,11 +1948,17 @@ mod tests {
             let block: Block = deserialize(block).unwrap();
 
             store
-                .save_header(&DiskBlockHeader::FullyValid(block.header, i as u32))
+                .save_header(&DiskBlockHeader::FullyValid(
+                    block.header,
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                ))
                 .unwrap();
 
             store
-                .update_block_index(i as u32, block.block_hash())
+                .update_block_index(
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                    block.block_hash(),
+                )
                 .unwrap();
         }
 
@@ -1948,7 +1969,10 @@ mod tests {
             hashes.push(block.block_hash());
 
             store
-                .save_header(&DiskBlockHeader::InFork(block.header, i as u32))
+                .save_header(&DiskBlockHeader::InFork(
+                    block.header,
+                    u32::try_from(i).expect("test block index must fit in a u32"),
+                ))
                 .unwrap();
         }
 

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -100,11 +100,8 @@ impl PartialChainStateInner {
     }
 
     pub fn get_block(&self, height: u32) -> Option<&BlockHeader> {
-        if height >= self.blocks.len() as u32 {
-            return None;
-        }
-
-        self.blocks.get(height as usize)
+        let height = usize::try_from(height).ok()?;
+        self.blocks.get(height)
     }
 
     #[inline]
@@ -276,7 +273,10 @@ impl PartialChainState {
         self.inner()
             .blocks
             .iter()
-            .take(self.inner().current_height as usize)
+            .take(
+                usize::try_from(self.inner().current_height)
+                    .expect("current height must fit in a usize"),
+            )
             .collect()
     }
 
@@ -380,9 +380,10 @@ impl BlockchainInterface for PartialChainState {
     }
 
     fn get_block_hash(&self, height: u32) -> Result<bitcoin::BlockHash, BlockchainError> {
+        let height = usize::try_from(height).map_err(|_| BlockchainError::BlockNotPresent)?;
         self.inner()
             .blocks
-            .get(height as usize)
+            .get(height)
             .map(|b| b.block_hash())
             .ok_or(BlockchainError::BlockNotPresent)
     }
@@ -596,7 +597,8 @@ mod tests {
             consensus: Consensus::from(Network::Regtest),
             current_height: 0,
             current_acc: Stump::default(),
-            final_height: times.len().saturating_sub(1) as u32,
+            final_height: u32::try_from(times.len().saturating_sub(1))
+                .expect("test chain height must fit in u32"),
             blocks,
             error: None,
         }

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -381,15 +381,15 @@ pub mod proof_util {
             let is_cb = tx.is_coinbase();
 
             for (vout, output) in tx.output.iter().enumerate() {
-                let utxo_id = (txid, vout as u32);
+                let vout = u32::try_from(vout).expect("block output index must fit in an OutPoint");
+                let utxo_id = (txid, vout);
 
                 if Consensus::is_unspendable(&output.script_pubkey) || spent.contains(&utxo_id) {
                     // Do not add unspendable nor already spent utxos
                     continue;
                 }
 
-                let leaf_hash =
-                    get_leaf_hashes(txid, is_cb, vout as u32, output, height, block_hash);
+                let leaf_hash = get_leaf_hashes(txid, is_cb, vout, output, height, block_hash);
                 adds.push(BitcoinNodeHash::Some(leaf_hash.to_byte_array()));
             }
         }
@@ -434,7 +434,11 @@ pub mod proof_util {
             // Collect new UTXOs, which may be spent by later transactions in the block
             for (vout, out) in tx.output.iter().enumerate() {
                 utxos.insert(
-                    OutPoint::new(txid, vout as u32),
+                    OutPoint::new(
+                        txid,
+                        u32::try_from(vout)
+                            .expect("transaction output index must fit in an OutPoint"),
+                    ),
                     UtxoData {
                         txout: out.clone(),
                         is_coinbase: tx.is_coinbase(),

--- a/crates/floresta-chain/tests/transaction_tests.rs
+++ b/crates/floresta-chain/tests/transaction_tests.rs
@@ -61,7 +61,9 @@ mod parse {
 
             let vout = match is_coinbase {
                 true => u32::MAX,
-                false => prev.vout as u32,
+                false => {
+                    u32::try_from(prev.vout).expect("non-coinbase vout must fit in an OutPoint")
+                }
             };
 
             let utxo_data = UtxoData {


### PR DESCRIPTION
## Summary

Remove potentially lossy numeric casts from `floresta-chain` as part of #1014.

The changes replace narrowing integer casts with checked conversions or equivalent operations while preserving the existing behavior.

## Changes

* Replace unnecessary integer casts in `extensions.rs`.
* Replace narrowing conversions in chain-state and consensus code with checked conversions.
* Handle `usize` to `u32` conversions explicitly in Utreexo-related code.
* Update affected tests and benchmark code.
* Preserve the existing low-32-bit behavior in work multiplication.

## Testing

* `cargo check -p floresta-chain` — passed
* `cargo test -p floresta-chain` — **49 passed, 0 failed**
* Doc-tests — **1 passed, 1 ignored**
* Targeted Clippy checks for:
  * `cast_possible_truncation`
  * `cast_possible_wrap`
  * `cast_sign_loss`
  * No warnings from `floresta-chain`

<img width="949" height="847" alt="2026-09-01-121923_hyprshot" src="https://github.com/user-attachments/assets/4b7cb30d-be48-4c58-82a4-5690af915fb2" />


Part of #1014 