### PR TITLE
update Mempool documentation to match the current implementation

### DIFF
--- a/crates/floresta-domain/src/mempool/mempool_base.rs
+++ b/crates/floresta-domain/src/mempool/mempool_base.rs
@@ -41,18 +41,23 @@ pub trait MempoolBase: Send {
     /// Consume a block and remove all transactions that were included in it.
     fn consume_block(&mut self, block: &Block) -> Vec<Txid>;
 
-    /// Accepts a transaction to mempool
+    /// Accepts a transaction into the mempool.
     ///
-    /// This method will perform some context-less validations on a transaction,
-    /// and then accept to our mempool. It assumes that we have validated this transaction's
-    /// proof.
+    /// Only context-free, structural checks are performed: non-empty input and
+    /// output lists, no duplicate inputs within the transaction, script size limits, and
+    /// output amounts within the valid range. The transaction is also rejected if it
+    /// conflicts with (spends an input already spent by) a transaction already held.
+    ///
+    /// This is *not* full validation: Utreexo proofs, input scripts, and signatures
+    /// are not verified, and there is no check that the spent outputs exist or are
+    /// unspent. Callers must not treat acceptance as a guarantee that the
+    /// transaction is valid or that the network will accept it.
     ///
     /// # Errors
     ///  - If we don't have space left in our mempool
     ///  - If the transaction conflicts with another mempool transaction
-    ///  - If it sepends the same input twice
-    ///  - If any amount check fails: if input amounts are less than output amounts or if it spends more than
-    ///    the theoretical maximum amount of Bitcoins
+    ///  - If it spends the same input twice
+    ///  - If any output amount exceeds the theoretical maximum amount of Bitcoin
     ///  - If either vIn or vOut are empty
     ///  - If any script is larger than the maximum allowed size
     fn accept_to_mempool(&mut self, transaction: Transaction) -> Result<(), MempoolError>;

--- a/crates/floresta-mempool/Cargo.toml
+++ b/crates/floresta-mempool/Cargo.toml
@@ -5,9 +5,8 @@ rust-version.workspace = true
 edition.workspace = true
 authors = ["Floresta Developers <contact@getfloresta.org>"]
 description = """
-    A policy-driven, stateful transaction mempool for Floresta,
-    responsible for transaction relay decisions, fee estimation, and
-    block template construction.
+    An in-memory transaction mempool for Floresta, with dependency
+    tracking and block template construction.
 """
 repository = "https://github.com/getfloresta/Floresta"
 license.workspace = true

--- a/crates/floresta-mempool/src/lib.rs
+++ b/crates/floresta-mempool/src/lib.rs
@@ -1,21 +1,25 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! A Utreexo-based Bitcoin transaction mempool.
+//! A Bitcoin transaction mempool for Floresta.
 //!
-//! This crate provides a transaction mempool implementation specifically designed for
-//! [Utreexo](https://eprint.iacr.org/2019/611.pdf) nodes. Unlike traditional Bitcoin nodes
-//! that maintain a complete UTXO set, Utreexo nodes use a compact cryptographic accumulator
-//! to verify transaction validity, significantly reducing storage requirements.
+//! This crate provides an in-memory holding area for unconfirmed transactions.
+//! Today, transactions enter the mempool only when submitted locally — through the
+//! `sendrawtransaction` RPC or an Electrum broadcast. Transactions announced by
+//! peers are not accepted yet.
 //!
 //! # Overview
 //!
-//! The mempool serves as a holding area for unconfirmed transactions, performing several
-//! critical functions:
+//! The mempool currently performs the following functions:
 //!
-//! - **Transaction validation**: Verifies Utreexo inclusion proofs for transaction inputs
-//! - **Proof management**: Maintains a local accumulator to generate proofs for relay and mining
-//! - **Block template construction**: Assembles candidate blocks for miners
-//! - **Transaction relay**: Tracks which transactions to broadcast to peers
+//! - **Acceptance**: applies context-free structural checks (non-empty inputs and
+//!   outputs, script size limits, no duplicate inputs, output amounts in range)
+//!   and rejects transactions that conflict with ones already held. It does *not*
+//!   verify Utreexo proofs, scripts, or signatures, nor check that inputs exist
+//!   or are unspent.
+//! - **Dependency tracking**: records parent/child relationships between held
+//!   transactions, used for conflict handling and block assembly.
+//! - **Block template construction**: assembles candidate (unsolved) blocks from
+//!   held transactions, parents before children, up to a weight limit.
 
 // cargo docs customization
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! A simple mempool that keeps our transactions in memory. It try to rebroadcast
-//! our transactions every 1 hour.
-//! Once our transaction is included in a block, we remove it from the mempool.
+//! A simple mempool that keeps transactions we submitted in memory, along with
+//! the dependency relationships between them.
+//!
+//! Transactions that sit in the mempool for more than one hour can be listed with
+//! `get_stale` (e.g. for rebroadcast), and transactions included in a block can be
+//! removed with `consume_block`. Calling those is the node's responsibility; this
+//! module only provides the bookkeeping.
 
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -169,18 +173,23 @@ impl MempoolBase for Mempool {
             .collect()
     }
 
-    /// Accepts a transaction to mempool
+    /// Accepts a transaction into the mempool.
     ///
-    /// This method will perform some context-less validations on a transaction,
-    /// and then accept to our mempool. It assumes that we have validated this transaction's
-    /// proof.
+    /// Only context-free, structural checks are performed: non-empty input and
+    /// output lists, no duplicate inputs within the transaction, script size limits, and
+    /// output amounts within the valid range. The transaction is also rejected if it
+    /// conflicts with (spends an input already spent by) a transaction already held.
+    ///
+    /// This is *not* full validation: Utreexo proofs, input scripts, and signatures
+    /// are not verified, and there is no check that the spent outputs exist or are
+    /// unspent. Callers must not treat acceptance as a guarantee that the
+    /// transaction is valid or that the network will accept it.
     ///
     /// # Errors
     ///  - If we don't have space left in our mempool
     ///  - If the transaction conflicts with another mempool transaction
-    ///  - If it sepends the same input twice
-    ///  - If any amount check fails: if input amounts are less than output amounts or if it spends more than
-    ///    the theoretical maximum amount of Bitcoins
+    ///  - If it spends the same input twice
+    ///  - If any output amount exceeds the theoretical maximum amount of Bitcoin
     ///  - If either vIn or vOut are empty
     ///  - If any script is larger than the maximum allowed size
     fn accept_to_mempool(&mut self, transaction: Transaction) -> Result<(), MempoolError> {

--- a/crates/floresta-node/src/json_rpc/network.rs
+++ b/crates/floresta-node/src/json_rpc/network.rs
@@ -220,7 +220,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             connections_out,
             network_active: true,
             networks,
-            // Since Floresta has no mempool, relay_fee and incremental_fee are hardcoded to 0.
+            // Floresta's mempool has no fee policy yet, so relay_fee and incremental_fee are hardcoded to 0.
             relay_fee: 0.0,
             incremental_fee: 0.0,
             local_addresses: Vec::new(), // Floresta doesn't track local addresses since it does not accept inbound connections

--- a/crates/floresta-rpc/src/lib.rs
+++ b/crates/floresta-rpc/src/lib.rs
@@ -264,7 +264,7 @@ mod tests {
         // P2P networking is enabled by default.
         assert!(info.network_active);
 
-        // Floresta has no mempool, so relay-related fields are hardcoded.
+        // Floresta's mempool has no inbound relay or fee policy yet, so relay-related fields are hardcoded.
         assert!(!info.local_relay);
         assert_eq!(info.relay_fee, 0.0);
         assert_eq!(info.incremental_fee, 0.0);

--- a/crates/floresta-wire/README.md
+++ b/crates/floresta-wire/README.md
@@ -1,6 +1,6 @@
 # floresta-wire
 
-`floresta-wire` is the P2P layer for the Floresta project: a lightweight, Utreexo-powered Bitcoin node. It supports Bitcoin P2P transport v1 and v2/BIP324, with peer discovery via DNS seeds, hardcoded addresses, and user-provided peers. It learns about new blocks and transactions, selects the best header chain, performs IBD, maintains a mempool, and stays in sync with the network.
+`floresta-wire` is the P2P layer for the Floresta project: a lightweight, Utreexo-powered Bitcoin node. It supports Bitcoin P2P transport v1 and v2/BIP324, with peer discovery via DNS seeds, hardcoded addresses, and user-provided peers. It learns about new blocks, selects the best header chain, performs IBD, announces locally-submitted transactions to peers, and stays in sync with the network.
 
 It also supports compact block filters, which are particularly helpful for rescans because Floresta is fully pruned, and an optional SOCKS5 proxy to route all P2P traffic and DNS seed queries.
 
@@ -23,7 +23,8 @@ let node = UtreexoNode::<_, RunningNode>::new(
 
 Where:
 
-- `UtreexoNodeConfig`, `Mempool`, and `AddressMan` are defined in this crate.
+- `UtreexoNodeConfig` and `AddressMan` are defined in this crate.
+- The mempool can be any implementation of `MempoolBase` from `floresta-domain` — for example `Mempool` from `floresta-mempool`.
 - `ChainState` is provided by `floresta-chain` (implements the `ChainBackend` trait).
 - Optional compact filters use `NetworkFilters` from `floresta-compact-filters`.
 - The kill signal is an `Arc<tokio::sync::RwLock<bool>>`. Set it to `true` to stop the node.

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -57,9 +57,9 @@ async fn main() {
     );
 
     // Create a new node. It will connect to the Bitcoin network and start downloading the blockchain.
-    // It will also start a mempool, which will keep track of the current mempool state, this
-    // particular mempool doesn't store other's transactions, it just keeps track of our own, to
-    // perform broadcast. We always rebroadcast our own transactions every hour.
+    // It will also start a mempool, which keeps track of the transactions we submit through the
+    // node (this particular mempool doesn't store other people's transactions) so they can be
+    // announced to our peers.
     // Note that we are using the RunningNode context, which is a state optimized for a node that
     // already has the blockchain synced. You don't need to worry about this, because internally
     // the node will automatically switch to the IBD context and back once it's finished.
@@ -83,7 +83,8 @@ async fn main() {
     let (sender, _receiver) = tokio::sync::oneshot::channel();
 
     // Start the node. This will start the IBD process, and will return once the node is synced.
-    // It will also start the mempool, which will start rebroadcasting our transactions every hour.
+    // It will also start the mempool, keeping the transactions we submit ready to be announced
+    // to our peers.
     // The node will keep running until the process is killed, by setting kill_signal to true. In
     // this example, we don't kill the node, so it will keep running forever.
     p2p.run(sender).await;

--- a/doc/rpc/getnetworkinfo.md
+++ b/doc/rpc/getnetworkinfo.md
@@ -37,7 +37,7 @@ Returns a JSON object with the following fields:
 
 - `localservicesnames` - (array of strings) Human-readable names of the advertised services (e.g., `NETWORK`, `WITNESS`, `UTREEXO`).
 
-- `localrelay` - (boolean) Whether the node requests transaction relay from peers. Always `false` in Floresta, since Floresta has no mempool.
+- `localrelay` - (boolean) Whether the node requests transaction relay from peers. Always `false` in Floresta, since Floresta's mempool only holds locally-submitted transactions.
 
 - `timeoffset` - (numeric) The time offset, in seconds. Always `0` in Floresta, since Floresta does not track peer time offsets.
 
@@ -56,9 +56,9 @@ Returns a JSON object with the following fields:
     * `proxy` - (string) The proxy used for this network in `host:port` form, or empty if none.
     * `proxy_randomize_credentials` - (boolean) Whether randomized credentials are used for the proxy.
 
-- `relayfee` - (numeric) The minimum relay fee rate, in BTC/kB. Always `0.0` in Floresta, since Floresta has no mempool.
+- `relayfee` - (numeric) The minimum relay fee rate, in BTC/kB. Always `0.0` in Floresta, since Floresta's mempool only holds locally-submitted transactions.
 
-- `incrementalfee` - (numeric) The minimum fee rate increment for mempool limiting or replacement, in BTC/kB. Always `0.0` in Floresta, since Floresta has no mempool.
+- `incrementalfee` - (numeric) The minimum fee rate increment for mempool limiting or replacement, in BTC/kB. Always `0.0` in Floresta, since Floresta's mempool only holds locally-submitted transactions.
 
 - `localaddresses` - (array of objects) Local addresses the node is listening on. Always empty in Floresta, since the node does not accept inbound connections.
 
@@ -70,5 +70,5 @@ Returns a JSON object with the following fields:
 
 ## Notes
 
-- This RPC mirrors Bitcoin Core's `getnetworkinfo` and reuses Bitcoin Core's response schema for compatibility. Several fields are hardcoded because Floresta is a lightweight, outbound-only node: it does not accept inbound connections (`connections_in`, `localaddresses`), does not maintain a mempool (`localrelay`, `relayfee`, `incrementalfee`), does not track peer time offsets (`timeoffset`), cannot toggle networking at runtime (`networkactive`), and does not emit network or blockchain warnings (`warnings`).
+- This RPC mirrors Bitcoin Core's `getnetworkinfo` and reuses Bitcoin Core's response schema for compatibility. Several fields are hardcoded because Floresta is a lightweight, outbound-only node: it does not accept inbound connections (`connections_in`, `localaddresses`), has a mempool that only holds locally-submitted transactions with no inbound relay or fee policy (`localrelay`, `relayfee`, `incrementalfee`), does not track peer time offsets (`timeoffset`), cannot toggle networking at runtime (`networkactive`), and does not emit network or blockchain warnings (`warnings`).
 - For per-peer details rather than node-wide networking state, see [`getpeerinfo`](getpeerinfo.md). For just the connection count, see [`getconnectioncount`](getconnectioncount.md).

--- a/doc/rpc/getpeerinfo.md
+++ b/doc/rpc/getpeerinfo.md
@@ -31,7 +31,7 @@ Returns a JSON array of objects, each representing a connected peer with the fol
 - `address` - (string) The network address and port for this peer (e.g., "192.168.1.5:8333"). This helps identify where the connection is established.
 - `services` - (string) A 16-character hexadecimal bitfield with the services this peer advertises (e.g., "0000000000000c09"). This indicates what capabilities the peer supports and what data we can request from them.
 - `servicesnames` - (array of strings) Human-readable names for the recognized services this peer advertises (e.g., "NETWORK", "WITNESS", "P2P_V2"). Unknown service bits are still represented in `services`.
-- `relaytxes` - (boolean) Whether mempool transaction relay is enabled with this peer. Always `false` in Floresta, since Floresta does not implement mempool transaction relay.
+- `relaytxes` - (boolean) Whether mempool transaction relay is enabled with this peer. Always `false` in Floresta, since Floresta does not track per-peer transaction relay preferences.
 - `user_agent` - (string) The User Agent string representing the client software and version being used by the peer (e.g., `/Satoshi-26.0/`). Useful for identifying the software distribution on the network.
 - `inbound` - (boolean) Whether this peer connection is inbound. Always `false` in Floresta, since Floresta does not accept inbound P2P connections.
 - `bip152_hb_to` - (boolean) Whether we selected this peer as a BIP152 high-bandwidth compact block relay peer. Always `false` in Floresta, since this relay mode is not implemented.

--- a/doc/rpc/gettxout.md
+++ b/doc/rpc/gettxout.md
@@ -48,6 +48,6 @@ floresta-cli gettxout aa5f3068b53941915d82be382f2b35711305ec7d454a34ca69f8897510
 
 ## Notes
 
-* This `rpc` isn't fully implemented mostly because we need to implement a mempool. For more information see [RPC Saga](https://github.com/orgs/getfloresta/projects/5):
+* This `rpc` isn't fully implemented mostly because the mempool isn't integrated with `gettxout` yet. For more information see [RPC Saga](https://github.com/orgs/getfloresta/projects/5):
 
 * The API accept the `include_mempool` argument but, for now, it does nothing.


### PR DESCRIPTION
The mempool documentation throughout the codebase describes features that no longer exist (or perhaps never did), mostly as leftovers from previous work.

This PR contains **documentation only changes**. No behavior is modified. Beyond keeping the documentation accurate, explicitly stating what transaction acceptance does and does not, that should help prevent misguided contributions (particularly LLM-generated PRs) that scrape the documentation, assume nonexistent features are implemented and build on top of those assumptions.

Closes #1304 
