### PR TITLE
[WIP] chain: acceptance test for block validation parity and ordering (fail-intended)

### DIFF
--- a/crates/floresta-chain/src/bitcoinkernelbackend.rs
+++ b/crates/floresta-chain/src/bitcoinkernelbackend.rs
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bitcoin Core as a chain backend, so that our tests can ask it what it would have said.
+//!
+//! # This is an oracle, not a backend anyone should run
+//!
+//! Nothing here is meant for production, and none of it is written as if it were. It exists so
+//! that a test can drive Bitcoin Core through the same trait it drives us through, and compare
+//! the two answers. It panics where a real backend would return, it holds Core's chain state
+//! on disk in whatever directory it's handed, and most of
+//! [`UpdatableChainstate`](crate::pruned_utreexo::UpdatableChainstate) is left
+//! unimplemented, because an oracle is asked exactly two things: take this header, take this
+//! block.
+//!
+//! # Reading Core's answer
+//!
+//! Core says two things about a block it turns down, and they arrive separately:
+//!
+//! - the **reject reason**, the string its checks are named after, which only reaches us
+//!   through the validation log, so the logger is turned up to debug and read back;
+//! - the **validation result**, the coarse enum, which comes back with the block itself.
+//!   Three checks log something other than their reject reason (`duplicate-invalid`,
+//!   `prev-blk-not-found` and `bad-prevblk`), and the result is the only thing that names
+//!   them, so it's the fallback.
+//!
+//! `from_core_reason` turns the reason into one of ours, and is the inverse of the
+//! `Bitcoin Core:` lines on [`BlockValidationErrors`](crate::BlockValidationErrors). A reason
+//! it doesn't know is a variant there that doesn't name it yet, and it says so.
+//!
+//! # What Core here can't answer
+//!
+//! - It is consensus only. `IsBlockMutated` lives in Core's networking layer, so the checks
+//!   that are only there never fire and a later consensus check answers in their place.
+//! - It holds the whole UTXO set and looks the spent outputs up for itself, so the proof and
+//!   the UTXOs that `connect_block` carries are dropped on the floor.
+//! - It has no way of being *told* a block is invalid. Hand it one that is, and it finds out.
+
+// This is test scaffolding: it fails by panicking, on purpose and loudly.
+#![allow(clippy::unwrap_used)]
+
+extern crate std;
+
+use std::string::String;
+use std::string::ToString;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::vec::Vec;
+
+use bitcoin::Block;
+use bitcoin::BlockHash;
+use bitcoin::Network;
+use bitcoin::OutPoint;
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::consensus::serialize;
+use bitcoin::hashes::sha256;
+use bitcoinkernel::BlockValidationResult;
+use bitcoinkernel::BlockValidationStateRef;
+use bitcoinkernel::ChainType;
+use bitcoinkernel::ChainstateManager;
+use bitcoinkernel::ChainstateManagerBuilder;
+use bitcoinkernel::Context;
+use bitcoinkernel::ContextBuilder;
+use bitcoinkernel::Log;
+use bitcoinkernel::LogCategory;
+use bitcoinkernel::LogLevel;
+use bitcoinkernel::Logger;
+use bitcoinkernel::ProcessBlockHeaderResult;
+use bitcoinkernel::ProcessBlockResult;
+use bitcoinkernel::ValidationMode;
+use bitcoinkernel::prelude::BlockValidationStateExt;
+use rustreexo::node_hash::BitcoinNodeHash;
+use rustreexo::proof::Proof;
+use rustreexo::stump::Stump;
+
+use crate::BlockValidationErrors;
+use crate::BlockchainError;
+use crate::prelude::HashMap;
+use crate::pruned_utreexo::IBDState;
+use crate::pruned_utreexo::UpdatableChainstate;
+use crate::pruned_utreexo::partial_chain::PartialChainState;
+use crate::pruned_utreexo::utxo_data::UtxoData;
+
+/// Bitcoin Core, behind [`UpdatableChainstate`].
+pub struct KernelBackend {
+    // Declared before what it borrows from, so that it's dropped first
+    chainman: ChainstateManager,
+    _context: Context,
+    _logger: Logger,
+    log: Arc<Mutex<Vec<String>>>,
+    rejection: Arc<Mutex<Option<BlockValidationResult>>>,
+}
+
+impl KernelBackend {
+    /// Bitcoin Core with an empty chain of its own, under `data_dir`.
+    ///
+    /// # Panics
+    ///
+    /// If Core won't start: there's nothing an oracle can do about that.
+    pub fn new(network: Network, data_dir: &str) -> Self {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let rejection = Arc::new(Mutex::new(None));
+
+        let logger = Logger::new(LogSink(log.clone())).expect("the log connects");
+        // Both of these: the reject reasons of the header checks are logged at debug level,
+        // under a category that is off by default
+        logger.enable_category(LogCategory::Validation);
+        logger.set_level_category(LogCategory::Validation, LogLevel::Debug);
+
+        let seen = rejection.clone();
+        let context = ContextBuilder::new()
+            .chain_type(chain_type(network))
+            .with_block_checked_validation(move |_block, state: BlockValidationStateRef<'_>| {
+                // Core signals this for every block it connects, so only the ones that didn't
+                // are worth keeping
+                if state.mode() != ValidationMode::Valid {
+                    *seen.lock().unwrap() = Some(state.result());
+                }
+            })
+            .build()
+            .expect("the context builds");
+
+        let blocks_dir = std::format!("{data_dir}/blocks");
+        std::fs::create_dir_all(&blocks_dir).expect("the data directory is ours to make");
+
+        let chainman = ChainstateManagerBuilder::new(&context, data_dir, &blocks_dir)
+            .expect("the chainstate options build")
+            .build()
+            .expect("the chainstate builds");
+
+        Self {
+            chainman,
+            _context: context,
+            _logger: logger,
+            log,
+            rejection,
+        }
+    }
+
+    /// The height of the chain Core considers best.
+    pub fn height(&self) -> u32 {
+        self.chainman
+            .active_chain()
+            .height()
+            .try_into()
+            .expect("the chain is at the genesis or past it")
+    }
+
+    /// A block as Core takes them, or the reason it can't be handed this one at all.
+    ///
+    /// A transaction with no inputs has a zero where the input count goes, and that zero is the
+    /// SegWit marker, so a block carrying one doesn't decode. No peer can send one either.
+    fn to_kernel(block: &Block) -> Result<bitcoinkernel::Block, BlockchainError> {
+        bitcoinkernel::Block::try_from(serialize(block).as_slice()).map_err(|_| {
+            BlockchainError::InvalidTip("core can't be handed this block: it doesn't decode".into())
+        })
+    }
+
+    /// What we would have said for the check that turned the last block or header down.
+    fn last_rejection(&self) -> BlockchainError {
+        // Copied out, so that nothing below panics holding a lock that Core's own threads are
+        // going to take
+        let log = self.log.lock().unwrap().clone();
+        let rejection = self.rejection.lock().unwrap().take();
+
+        if let Some(reason) = first_reject_reason(&log) {
+            return BlockchainError::BlockValidation(from_core_reason(reason));
+        }
+
+        // The checks that log something other than their reject reason
+        let error = match rejection {
+            Some(BlockValidationResult::CachedInvalid) => {
+                BlockValidationErrors::DuplicateInvalidBlock
+            }
+            Some(BlockValidationResult::MissingPrev) => BlockValidationErrors::PrevBlockNotFound,
+            Some(BlockValidationResult::InvalidPrev) => BlockValidationErrors::BadPrevBlock,
+            Some(BlockValidationResult::TimeFuture) => BlockValidationErrors::TimeTooNew,
+            other => panic!("core turned a block down without saying why: {other:?}\n{log:#?}"),
+        };
+
+        BlockchainError::BlockValidation(error)
+    }
+}
+
+impl UpdatableChainstate for KernelBackend {
+    /// The proof, the UTXOs and the deletion hashes are ours, not Core's: it holds the whole
+    /// UTXO set and looks the spent outputs up for itself.
+    fn connect_block(
+        &self,
+        block: &Block,
+        _proof: Proof,
+        _inputs: HashMap<OutPoint, UtxoData>,
+        _del_hashes: Vec<sha256::Hash>,
+    ) -> Result<u32, BlockchainError> {
+        self.log.lock().unwrap().clear();
+        *self.rejection.lock().unwrap() = None;
+
+        let processed = self.chainman.process_block(&Self::to_kernel(block)?);
+
+        // A block that fails to connect is processed all the same: Core marks it invalid, keeps
+        // the tip it had, and says so through the validation state rather than the outcome
+        let connected = self.rejection.lock().unwrap().is_none();
+
+        match processed {
+            ProcessBlockResult::NewBlock | ProcessBlockResult::Duplicate if connected => {
+                Ok(self.height())
+            }
+            _ => Err(self.last_rejection()),
+        }
+    }
+
+    fn accept_header(&self, header: BlockHeader) -> Result<(), BlockchainError> {
+        self.log.lock().unwrap().clear();
+
+        let header = bitcoinkernel::BlockHeader::try_from(serialize(&header).as_slice())
+            .expect("a header is 80 bytes, whatever is in it");
+
+        match self.chainman.process_block_header(&header) {
+            Ok(ProcessBlockHeaderResult::Valid) => Ok(()),
+            Ok(ProcessBlockHeaderResult::Invalid(state)) => {
+                *self.rejection.lock().unwrap() = Some(state.result());
+                Err(self.last_rejection())
+            }
+            Err(e) => panic!("the kernel failed to process a header: {e:?}"),
+        }
+    }
+
+    fn flush(&self) -> Result<(), BlockchainError> {
+        // Core writes as it goes
+        Ok(())
+    }
+
+    fn update_ibd(&self, _ibd_state: IBDState) {
+        // Core keeps its own idea of whether it's caught up
+    }
+
+    fn invalidate_block(&self, _block: BlockHash) -> Result<(), BlockchainError> {
+        unimplemented!("core can't be told a block is invalid: hand it one that is")
+    }
+
+    fn get_acc(&self) -> Stump {
+        unimplemented!("core holds the UTXO set itself, there's no accumulator to speak of")
+    }
+
+    fn get_root_hashes(&self) -> Vec<BitcoinNodeHash> {
+        unimplemented!("core holds the UTXO set itself, there's no accumulator to speak of")
+    }
+
+    fn switch_chain(&self, _new_tip: BlockHash) -> Result<(), BlockchainError> {
+        unimplemented!("core reorgs on its own, as blocks arrive")
+    }
+
+    fn mark_block_as_valid(&self, _block: BlockHash) -> Result<(), BlockchainError> {
+        unimplemented!("core makes up its own mind about a block")
+    }
+
+    fn mark_chain_as_assumed(&self, _acc: Stump, _tip: BlockHash) -> Result<bool, BlockchainError> {
+        unimplemented!("core makes up its own mind about a chain")
+    }
+
+    fn get_partial_chain(
+        &self,
+        _initial_height: u32,
+        _final_height: u32,
+        _acc: Stump,
+    ) -> Result<PartialChainState, BlockchainError> {
+        unimplemented!("a partial chain is ours, core has no such thing")
+    }
+
+    fn handle_transaction(&self) -> Result<(), BlockchainError> {
+        unimplemented!("this oracle is asked about blocks")
+    }
+}
+
+/// Collects everything Core logs, so that the reject reasons can be read back.
+struct LogSink(Arc<Mutex<Vec<String>>>);
+
+impl Log for LogSink {
+    fn log(&self, message: &str) {
+        // Core calls this from its own threads, across an `extern "C"` boundary that a panic
+        // would abort the process on, so a lock that a panicking test left poisoned has to be
+        // taken all the same
+        let mut log = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        log.push(message.to_string());
+    }
+}
+
+fn chain_type(network: Network) -> ChainType {
+    match network {
+        Network::Bitcoin => ChainType::Mainnet,
+        Network::Testnet => ChainType::Testnet,
+        Network::Testnet4 => ChainType::Testnet4,
+        Network::Signet => ChainType::Signet,
+        Network::Regtest => ChainType::Regtest,
+    }
+}
+
+/// What we would have said for a check Bitcoin Core names `reason`.
+///
+/// The inverse of the `Bitcoin Core:` lines on [`BlockValidationErrors`], so a reason missing
+/// here is a variant there that doesn't name it yet.
+///
+/// # Panics
+///
+/// On a reason no variant names.
+fn from_core_reason(reason: &str) -> BlockValidationErrors {
+    match reason {
+        "high-hash" => BlockValidationErrors::NotEnoughPow,
+        "bad-diffbits" => BlockValidationErrors::BadDifficultyBits,
+        "time-too-old" => BlockValidationErrors::TimeTooOld,
+        "time-too-new" => BlockValidationErrors::TimeTooNew,
+        "time-timewarp-attack" => BlockValidationErrors::BIP94TimeWarp,
+        "bad-version" => BlockValidationErrors::BadBlockVersion,
+        "prev-blk-not-found" => BlockValidationErrors::PrevBlockNotFound,
+        "bad-prevblk" => BlockValidationErrors::BadPrevBlock,
+        "duplicate-invalid" => BlockValidationErrors::DuplicateInvalidBlock,
+        "bad-signet-blksig" => BlockValidationErrors::BadSignetBlockSignature,
+        "bad-txnmrklroot" => BlockValidationErrors::BadMerkleRoot,
+        "bad-txns-duplicate" => BlockValidationErrors::DuplicateTransactions,
+        "bad-witness-nonce-size" => BlockValidationErrors::BadWitnessNonceSize,
+        "bad-witness-merkle-match" => BlockValidationErrors::BadWitnessCommitment,
+        "unexpected-witness" => BlockValidationErrors::UnexpectedWitness,
+        // Core says this for a payload with no transactions and for one that's over the size
+        // limits alike. We split the two, so one of them can't line up.
+        "bad-blk-length" => BlockValidationErrors::EmptyBlock,
+        "bad-blk-weight" => BlockValidationErrors::BlockTooBig,
+        "bad-cb-missing" => BlockValidationErrors::FirstTxIsNotCoinbase,
+        "bad-cb-multiple" => BlockValidationErrors::MultipleCoinbase,
+        // Core names the check, we name what's wrong with the coinbase, and the only thing this
+        // check turns down is a scriptsig of the wrong size
+        "bad-cb-length" => BlockValidationErrors::InvalidCoinbase("Invalid ScriptSig size".into()),
+        "bad-cb-amount" => BlockValidationErrors::BadCoinbaseOutValue,
+        "bad-cb-height" => BlockValidationErrors::BadBip34,
+        "bad-txns-vin-empty" => BlockValidationErrors::EmptyInputs,
+        "bad-txns-vout-empty" => BlockValidationErrors::EmptyOutputs,
+        "bad-txns-vout-negative"
+        | "bad-txns-vout-toolarge"
+        | "bad-txns-txouttotal-toolarge"
+        | "bad-txns-inputvalues-outofrange"
+        | "bad-txns-fee-outofrange"
+        | "bad-txns-accumulated-fee-outofrange" => BlockValidationErrors::TooManyCoins,
+        "bad-txns-inputs-duplicate" => BlockValidationErrors::DuplicateInput,
+        "bad-txns-prevout-null" => BlockValidationErrors::NullPrevOut,
+        // Core says this for an unsatisfied absolute lock time and for an unsatisfied relative
+        // one alike, which we tell apart
+        "bad-txns-nonfinal" => BlockValidationErrors::NonFinalTransaction,
+        // Core names the transaction, not the output, so the outpoint we'd name is one it never
+        // tells us
+        "bad-txns-inputs-missingorspent" => BlockValidationErrors::UtxoNotFound(OutPoint::null()),
+        "bad-txns-premature-spend-of-coinbase" => BlockValidationErrors::CoinbaseNotMatured,
+        "bad-txns-in-belowout" => BlockValidationErrors::NotEnoughMoney,
+        "bad-txns-BIP30" => BlockValidationErrors::UnspendableUTXO,
+        "bad-blk-sigops" => BlockValidationErrors::TooManySigOps,
+        "bad-txns-too-many-sigops" => BlockValidationErrors::ScriptError,
+        "mandatory-script-verify-flag-failed" | "block-script-verify-flag-failed" => {
+            BlockValidationErrors::ScriptValidationError(reason.into())
+        }
+        other => panic!("no variant of BlockValidationErrors names `{other}` yet"),
+    }
+}
+
+/// Every reason [`from_core_reason`] knows, longest first so that one containing another is
+/// matched whole.
+fn core_reject_reasons() -> Vec<&'static str> {
+    let mut reasons = std::vec![
+        "high-hash",
+        "bad-diffbits",
+        "time-too-old",
+        "time-too-new",
+        "time-timewarp-attack",
+        "bad-version",
+        "prev-blk-not-found",
+        "bad-prevblk",
+        "duplicate-invalid",
+        "bad-signet-blksig",
+        "bad-txnmrklroot",
+        "bad-txns-duplicate",
+        "bad-witness-nonce-size",
+        "bad-witness-merkle-match",
+        "unexpected-witness",
+        "bad-blk-length",
+        "bad-blk-weight",
+        "bad-cb-missing",
+        "bad-cb-multiple",
+        "bad-cb-length",
+        "bad-cb-amount",
+        "bad-cb-height",
+        "bad-txns-vin-empty",
+        "bad-txns-vout-empty",
+        "bad-txns-vout-negative",
+        "bad-txns-vout-toolarge",
+        "bad-txns-txouttotal-toolarge",
+        "bad-txns-inputvalues-outofrange",
+        "bad-txns-fee-outofrange",
+        "bad-txns-accumulated-fee-outofrange",
+        "bad-txns-inputs-duplicate",
+        "bad-txns-prevout-null",
+        "bad-txns-nonfinal",
+        "bad-txns-inputs-missingorspent",
+        "bad-txns-premature-spend-of-coinbase",
+        "bad-txns-in-belowout",
+        "bad-txns-BIP30",
+        "bad-blk-sigops",
+        "bad-txns-too-many-sigops",
+        "mandatory-script-verify-flag-failed",
+        "block-script-verify-flag-failed",
+    ];
+    reasons.sort_by_key(|reason| core::cmp::Reverse(reason.len()));
+
+    reasons
+}
+
+/// The reason of the first check that turned the block down, which is the earliest one Core
+/// logged.
+fn first_reject_reason(log: &[String]) -> Option<&'static str> {
+    let reasons = core_reject_reasons();
+
+    log.iter().find_map(|line| {
+        reasons
+            .iter()
+            .filter_map(|reason| line.find(reason).map(|at| (at, *reason)))
+            .min_by_key(|(at, reason)| (*at, core::cmp::Reverse(reason.len())))
+            .map(|(_, reason)| reason)
+    })
+}

--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -21,6 +21,9 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
+/// Bitcoin Core as a chain backend, for tests to compare ourselves against. Not for use.
+#[cfg(feature = "bitcoinkernel")]
+pub mod bitcoinkernelbackend;
 pub mod extensions;
 
 pub mod pruned_utreexo;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1550,7 +1550,7 @@ macro_rules! write_lock {
 }
 
 #[cfg(all(test, feature = "flat-chainstore"))]
-mod test {
+pub(crate) mod test {
     use std::format;
     use std::fs::File;
     use std::io::Cursor;
@@ -1603,8 +1603,8 @@ mod test {
 
     const DEFAULT_TEST_CHAINSTORE_SIZE: usize = 32_768;
     const TEST_FORK_FILE_SIZE: usize = 10_000;
-    const EASIEST_REGTEST_TARGET_BITS: u32 = 0x207f_ffff;
-    fn setup_test_chain(
+    pub(crate) const EASIEST_REGTEST_TARGET_BITS: u32 = 0x207f_ffff;
+    pub(crate) fn setup_test_chain(
         network: Network,
         assume_valid_arg: AssumeValidArg,
         header_capacity: Option<usize>,
@@ -1630,7 +1630,11 @@ mod test {
         script
     }
 
-    fn test_coinbase(height: u32, sequence: Sequence, lock_time: LockTime) -> Transaction {
+    pub(crate) fn test_coinbase(
+        height: u32,
+        sequence: Sequence,
+        lock_time: LockTime,
+    ) -> Transaction {
         let script_sig = Builder::new()
             .push_int(i64::from(height))
             .push_int(0)
@@ -1644,7 +1648,7 @@ mod test {
         }
     }
 
-    fn block_with_transactions(height: u32, txdata: Vec<Transaction>) -> Block {
+    pub(crate) fn block_with_transactions(height: u32, txdata: Vec<Transaction>) -> Block {
         let mut block = Block {
             header: BlockHeader {
                 version: HeaderVersion::TWO,
@@ -1664,7 +1668,25 @@ mod test {
         block_with_transactions(height, vec![coinbase])
     }
 
-    fn test_outpoint(vout: u32) -> OutPoint {
+    /// Grinds the header nonce until the block satisfies its own target. On regtest,
+    /// virtually every nonce works, so this returns almost immediately.
+    pub(crate) fn mine(mut block: Block) -> Block {
+        block.header = mine_header(block.header);
+
+        block
+    }
+
+    /// Grinds the nonce until the header satisfies the target it claims.
+    pub(crate) fn mine_header(mut header: BlockHeader) -> BlockHeader {
+        let target = header.target();
+        while header.validate_pow(target).is_err() {
+            header.nonce += 1;
+        }
+
+        header
+    }
+
+    pub(crate) fn test_outpoint(vout: u32) -> OutPoint {
         OutPoint {
             txid: genesis_block(Network::Regtest).txdata[0].compute_txid(),
             vout,
@@ -1673,7 +1695,7 @@ mod test {
 
     /// Builds a two-input test transaction with the given lock time and sequences,
     /// plus its referenced input UTXOs.
-    fn test_spend(
+    pub(crate) fn test_spend(
         lock_time: LockTime,
         first_sequence: Sequence,
         second_sequence: Sequence,

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -121,32 +121,287 @@ pub struct TransactionError {
 
 #[derive(Clone, Debug, PartialEq)]
 /// Represents errors encountered during block validation.
+///
+/// Every variant names the Bitcoin Core reject reason it stands for, so that the two
+/// implementations can be compared check by check. Bitcoin Core splits these checks between
+/// the networking layer (`net_processing`) and consensus (`validation.cpp`); we don't have
+/// that split, so all of them are raised by `floresta-chain` and bubble up to the caller.
+///
+/// The variants marked **not raised yet** name something we don't report yet: mostly checks
+/// that Bitcoin Core performs and we don't, plus the odd case where we want to tell the caller
+/// more than Core does. Nothing constructs them today: they exist so that the gap is written
+/// down, and so that the validation-pipeline acceptance test can state the error each of them
+/// is expected to produce once it's implemented.
 pub enum BlockValidationErrors {
+    /// This block is not the next one we have to validate. It says nothing about the block:
+    /// it's the caller handing us one we can't do anything with yet.
+    ///
+    /// Bitcoin Core has no equivalent, and this is a **known divergence**: we only ever connect
+    /// the block right after our validation index, on the chain we consider active. A block on
+    /// a fork can't be handed to us at all — we take its *header*, keep that branch as headers
+    /// alone, and only validate its blocks if the branch wins and we switch to it.
+    ///
+    /// Core takes any block whose parent it has and writes it to disk, whatever branch it sits
+    /// on. We keep no blocks: we validate the transaction data the main chain needs and then
+    /// discard it, holding one accumulator, the one at our validation index. Validating a fork
+    /// block would leave us nothing to keep, so a fork is worth headers to us and nothing more.
     BlockDoesntExtendTip,
+
+    /// The coinbase transaction is malformed.
+    ///
+    /// Bitcoin Core: `bad-cb-length` and `bad-txns-prevout-null`.
     InvalidCoinbase(String),
+
+    /// A spent output isn't in the UTXOs we've been given for this block, either because it
+    /// doesn't exist or because it was already spent.
+    ///
+    /// Bitcoin Core: `bad-txns-inputs-missingorspent`.
     UtxoNotFound(OutPoint),
+
+    /// An input script didn't validate against the output it spends.
+    ///
+    /// Bitcoin Core: `mandatory-script-verify-flag-failed` and
+    /// `block-script-verify-flag-failed`.
     ScriptValidationError(String),
+
+    /// A non-coinbase transaction has a null PrevOut.
+    ///
+    /// Bitcoin Core: `bad-txns-prevout-null`.
     NullPrevOut,
+
+    /// A transaction has no inputs.
+    ///
+    /// Bitcoin Core: `bad-txns-vin-empty`.
     EmptyInputs,
+
+    /// A transaction has no outputs.
+    ///
+    /// Bitcoin Core: `bad-txns-vout-empty`.
     EmptyOutputs,
+
+    /// A script is unspendable or has too many sigops.
+    ///
+    /// Bitcoin Core: `bad-txns-too-many-sigops`.
     ScriptError,
+
+    /// The block weight is above the 4,000,000 WU limit.
+    ///
+    /// Bitcoin Core: `bad-blk-weight` and `bad-blk-length`.
     BlockTooBig,
+
+    /// An amount is above the 21 million coin limit.
+    ///
+    /// Bitcoin Core: `bad-txns-vout-toolarge`, `bad-txns-txouttotal-toolarge`,
+    /// `bad-txns-inputvalues-outofrange`, `bad-txns-fee-outofrange` and
+    /// `bad-txns-accumulated-fee-outofrange`.
     TooManyCoins,
+
+    /// The header hash doesn't meet the target it claims.
+    ///
+    /// Bitcoin Core: `high-hash`.
     NotEnoughPow,
+
+    /// The header's merkle root doesn't commit to the transactions in this block.
+    ///
+    /// Bitcoin Core: `bad-txnmrklroot`. This describes the payload we've been given, not the
+    /// header, which may still have a valid payload that another peer can send us, so it must
+    /// not mark the header invalid.
     BadMerkleRoot,
+
+    /// The witness merkle root doesn't match the coinbase witness commitment.
+    ///
+    /// Bitcoin Core: `bad-witness-merkle-match`. Like [`BlockValidationErrors::BadMerkleRoot`],
+    /// this describes the payload and must not mark the header invalid.
     BadWitnessCommitment,
+
+    /// A transaction spends more than its inputs hold.
+    ///
+    /// Bitcoin Core: `bad-txns-in-belowout`.
     NotEnoughMoney,
+
+    /// The first transaction in the block isn't a coinbase.
+    ///
+    /// Bitcoin Core: `bad-cb-missing`.
     FirstTxIsNotCoinbase,
+
+    /// The coinbase claims more than the subsidy plus the block fees.
+    ///
+    /// Bitcoin Core: `bad-cb-amount`.
     BadCoinbaseOutValue,
+
+    /// The block has no transactions, so it has no coinbase either.
+    ///
+    /// Bitcoin Core: `bad-blk-length`.
     EmptyBlock,
+
+    /// This block extends a chain whose ancestors we don't have.
+    ///
+    /// Bitcoin Core has no equivalent: it doesn't validate a block before connecting its
+    /// parent. See [`BlockValidationErrors::PrevBlockNotFound`] for the missing-parent case.
     BlockExtendsAnOrphanChain,
+
+    /// The coinbase doesn't commit to the block height, as required after BIP34.
+    ///
+    /// Bitcoin Core: `bad-cb-height`.
     BadBip34,
+
+    /// The proof doesn't verify the spent UTXOs against our accumulator.
+    ///
+    /// Bitcoin Core has no equivalent: it holds the whole UTXO set, so it looks the spent
+    /// outputs up instead of having them proven.
+    ///
+    /// Today a proof failure reaches the caller in three shapes: this one, rustreexo's own
+    /// error let out as [`BlockchainError::AccumulatorError`], and
+    /// [`BlockchainError::InvalidUtreexoProof`], the top-level variant of the same name that a
+    /// partial chain answers with. `floresta-wire` has to fold all three back together before
+    /// it can decide whom to blame, which is the thing to fix: what went wrong with a proof
+    /// should be said here, once.
     InvalidUtreexoProof,
+
+    /// A transaction spends a coinbase output that isn't 100 blocks old yet.
+    ///
+    /// Bitcoin Core: `bad-txns-premature-spend-of-coinbase`.
     CoinbaseNotMatured,
+
+    /// A transaction's absolute lock time is not final for this block.
+    ///
+    /// Bitcoin Core: `bad-txns-nonfinal`.
     NonFinalTransaction,
+
+    /// A transaction spends an output that the historical BIP30 violation overwrote.
+    ///
+    /// Bitcoin Core: `bad-txns-BIP30`. For us it's the other way around: Utreexo commits to the
+    /// block hash in the leaf hash, so the output is still provable and we reject it here.
     UnspendableUTXO,
+
+    /// The header timestamp went backwards on a difficulty-adjustment block.
+    ///
+    /// Bitcoin Core: `time-timewarp-attack`.
     BIP94TimeWarp,
+
+    /// A transaction spends the same output more than once.
+    ///
+    /// Bitcoin Core: `bad-txns-inputs-duplicate`.
     DuplicateInput,
+
+    /// The proof doesn't line up with the deletions it comes with, claiming a different number
+    /// of targets than the leaf hashes handed over with it.
+    ///
+    /// Bitcoin Core has no equivalent, as with every proof failure. **Not raised yet**: with
+    /// nothing to delete, rustreexo returns before it so much as looks at the proof, so a proof
+    /// claiming targets that nothing accounts for goes through, and we don't check it either.
+    MalformedUtreexoProof,
+
+    /// We already have this header, and nothing is wrong with it as far as we know.
+    ///
+    /// Bitcoin Core has no equivalent: `AcceptBlockHeader` reports success for a header it
+    /// already has. **Not raised yet**: we do the same, so the caller can't tell a header that
+    /// advanced our chain from one we had already seen, and has to work that out on its own.
+    DuplicateBlock,
+
+    /// We already have this header, and we've already marked it invalid.
+    ///
+    /// Bitcoin Core: `duplicate-invalid`. **Not raised yet**: we short-circuit every header we
+    /// already have, whether we've marked it invalid or not, and report success.
+    DuplicateInvalidBlock,
+
+    /// We don't have this block's parent, so we can't validate the header.
+    ///
+    /// Bitcoin Core: `prev-blk-not-found`. **Not raised yet**: looking the parent up is the
+    /// first thing we do, and a miss surfaces as [`BlockchainError::BlockNotPresent`], which
+    /// says nothing about why we were looking it up.
+    PrevBlockNotFound,
+
+    /// This block's parent is one we've already marked invalid.
+    ///
+    /// Bitcoin Core: `bad-prevblk`. **Not raised yet**: we report it as
+    /// [`BlockValidationErrors::BlockExtendsAnOrphanChain`], which doesn't say that we know
+    /// the parent and know it to be invalid.
+    BadPrevBlock,
+
+    /// The header claims less work than the one we require for its height.
+    ///
+    /// Bitcoin Core: `bad-diffbits`. **Not raised yet**: we report it as
+    /// [`BlockValidationErrors::NotEnoughPow`], conflating it with Core's `high-hash`. Note
+    /// that Core compares the compact encoding for equality, while we only require the claimed
+    /// target to be at most the expected one, since the testnet minimum-difficulty rule makes
+    /// the expected `nBits` ambiguous.
+    BadDifficultyBits,
+
+    /// The header timestamp is not above the Median Time Past of its ancestors.
+    ///
+    /// Bitcoin Core: `time-too-old`. **Not raised yet**: we compute the MTP only to decide the
+    /// lock-time cutoff, and never compare the header timestamp against it.
+    TimeTooOld,
+
+    /// The header timestamp is more than 2 hours into the future.
+    ///
+    /// Bitcoin Core: `time-too-new`. **Not raised yet**. Note this isn't a consensus failure:
+    /// the block may become valid as time passes, so the header must not be marked invalid and
+    /// the peer must not be punished.
+    TimeTooNew,
+
+    /// The header version is below the minimum required at this height by BIP34, BIP66 or
+    /// BIP65.
+    ///
+    /// Bitcoin Core: `bad-version(0x...)`. **Not raised yet**.
+    BadBlockVersion,
+
+    /// The signet block solution doesn't sign this block with the network challenge.
+    ///
+    /// Bitcoin Core: `bad-signet-blksig`. **Not raised yet**: we don't validate the signet
+    /// block signature at all.
+    BadSignetBlockSignature,
+
+    /// The merkle tree has duplicated real siblings, so a different transaction list yields
+    /// the same root ([CVE-2012-2459]).
+    ///
+    /// Bitcoin Core: `bad-txns-duplicate`. **Not raised yet**: we do detect the mutation, but
+    /// report it as [`BlockValidationErrors::BadMerkleRoot`].
+    ///
+    /// [CVE-2012-2459]: https://www.cve.org/CVERecord?id=CVE-2012-2459
+    DuplicateTransactions,
+
+    /// A block without a coinbase carries a transaction that serializes to exactly 64 bytes,
+    /// which is indistinguishable from an inner merkle node ([CVE-2017-12842]).
+    ///
+    /// Bitcoin Core has no reject reason for this: such a block is already invalid, and is only
+    /// treated as mutated so that the header isn't marked invalid. **Not raised yet**.
+    ///
+    /// [CVE-2017-12842]: https://www.cve.org/CVERecord?id=CVE-2017-12842
+    SixtyFourByteTransaction,
+
+    /// The witness commitment is present, but the coinbase witness isn't a single 32-byte item.
+    ///
+    /// Bitcoin Core: `bad-witness-nonce-size`. **Not raised yet**: the
+    /// [`check_witness_commitment`](bitcoin::Block::check_witness_commitment) helper we use
+    /// folds this into [`BlockValidationErrors::BadWitnessCommitment`].
+    BadWitnessNonceSize,
+
+    /// The block has no witness commitment, but some transaction carries witness data.
+    ///
+    /// Bitcoin Core: `unexpected-witness`. **Not raised yet**: folded into
+    /// [`BlockValidationErrors::BadWitnessCommitment`] as well.
+    UnexpectedWitness,
+
+    /// A transaction other than the first one is a coinbase.
+    ///
+    /// Bitcoin Core: `bad-cb-multiple`. **Not raised yet**: such a transaction has a null
+    /// PrevOut, so we reject it with [`BlockValidationErrors::NullPrevOut`], which is Core's
+    /// `bad-txns-prevout-null`, instead of catching it as a second coinbase.
+    MultipleCoinbase,
+
+    /// The block's total sigop cost is above the 80,000 limit.
+    ///
+    /// Bitcoin Core: `bad-blk-sigops`. **Not raised yet**: we only bound the sigops of each
+    /// individual script, never their sum over the block.
+    TooManySigOps,
+
+    /// A transaction's BIP68 relative lock times are not satisfied at this height.
+    ///
+    /// Bitcoin Core reports this as `bad-txns-nonfinal` too, but it's a separate check.
+    /// **Not raised yet**: we don't evaluate sequence locks.
+    UnsatisfiedSequenceLocks,
 }
 
 // Helpful macro for generating a TransactionError
@@ -245,6 +500,57 @@ impl Display for BlockValidationErrors {
             }
             Self::DuplicateInput => {
                 write!(f, "This transaction has duplicate inputs")
+            }
+            Self::MalformedUtreexoProof => {
+                write!(f, "The proof doesn't match the deletions it comes with")
+            }
+            Self::DuplicateBlock => {
+                write!(f, "We already know this block")
+            }
+            Self::DuplicateInvalidBlock => {
+                write!(f, "We already know this block, and it's invalid")
+            }
+            Self::PrevBlockNotFound => {
+                write!(f, "We don't have this block's parent")
+            }
+            Self::BadPrevBlock => {
+                write!(f, "This block's parent is invalid")
+            }
+            Self::BadDifficultyBits => {
+                write!(f, "This block claims less work than we require")
+            }
+            Self::TimeTooOld => {
+                write!(f, "This block is older than the Median Time Past")
+            }
+            Self::TimeTooNew => {
+                write!(f, "This block is too far into the future")
+            }
+            Self::BadBlockVersion => {
+                write!(f, "This block's version is below the required one")
+            }
+            Self::BadSignetBlockSignature => {
+                write!(f, "This block's signet solution is invalid")
+            }
+            Self::DuplicateTransactions => {
+                write!(f, "This block's merkle tree has duplicate transactions")
+            }
+            Self::SixtyFourByteTransaction => {
+                write!(f, "This block has a transaction of exactly 64 bytes")
+            }
+            Self::BadWitnessNonceSize => {
+                write!(f, "The witness reserved value isn't a single 32-byte item")
+            }
+            Self::UnexpectedWitness => {
+                write!(f, "There's witness data but no witness commitment")
+            }
+            Self::MultipleCoinbase => {
+                write!(f, "This block has more than one coinbase transaction")
+            }
+            Self::TooManySigOps => {
+                write!(f, "This block has too many sigops")
+            }
+            Self::UnsatisfiedSequenceLocks => {
+                write!(f, "A transaction's relative lock times aren't satisfied")
             }
         }
     }

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -453,3 +453,1117 @@ impl<T: BlockchainInterface + UpdatableChainstate> ChainBackend for T {}
 pub trait ThreadSafeChain: ChainBackend + Sync + Send + 'static {}
 
 impl<T: ChainBackend + Sync + Send + 'static> ThreadSafeChain for T {}
+
+#[cfg(all(test, feature = "flat-chainstore"))]
+mod validation_pipeline_test {
+    use bitcoin::Amount;
+    use bitcoin::Block;
+    use bitcoin::BlockHash;
+    use bitcoin::CompactTarget;
+    use bitcoin::Network;
+    use bitcoin::ScriptBuf;
+    use bitcoin::Sequence;
+    use bitcoin::Transaction;
+    use bitcoin::TxMerkleNode;
+    use bitcoin::TxOut;
+    use bitcoin::Witness;
+    use bitcoin::absolute::LockTime;
+    use bitcoin::block::Header as BlockHeader;
+    use bitcoin::block::Version as HeaderVersion;
+    use bitcoin::constants::genesis_block;
+    use bitcoin::hashes::Hash;
+    use bitcoin::opcodes::OP_TRUE;
+    use bitcoin::opcodes::all::OP_CHECKSIG;
+    use bitcoin::transaction::Version as TransactionVersion;
+    use floresta_common::assert_ok;
+
+    use super::*;
+    use crate::AssumeValidArg;
+    use crate::ChainState;
+    use crate::FlatChainStore;
+    #[cfg(feature = "bitcoinkernel")]
+    use crate::bitcoinkernelbackend::KernelBackend;
+    use crate::extensions::HeaderExt;
+    use crate::pruned_utreexo::chain_state::test::EASIEST_REGTEST_TARGET_BITS;
+    use crate::pruned_utreexo::chain_state::test::block_with_transactions;
+    use crate::pruned_utreexo::chain_state::test::mine;
+    use crate::pruned_utreexo::chain_state::test::setup_test_chain;
+    use crate::pruned_utreexo::chain_state::test::test_coinbase;
+    use crate::pruned_utreexo::chain_state::test::test_outpoint;
+    use crate::pruned_utreexo::chainparams::ChainParams;
+    use crate::pruned_utreexo::consensus::Consensus;
+    use crate::pruned_utreexo::consensus::UNSPENDABLE_BIP30_UTXO_91722;
+    use crate::pruned_utreexo::error::BlockValidationErrors;
+    use crate::pruned_utreexo::partial_chain::PartialChainStateInner;
+    use crate::txin;
+    use crate::txout;
+
+    /// A target that a header we haven't mined won't meet: it asks for roughly 2^47 times the
+    /// work of the regtest limit, which is the easiest target there is.
+    ///
+    /// It is *harder* than the target we require at this height, so the difficulty comparison
+    /// lets it through and the header fails on its own hash against its own claimed target,
+    /// which is what Bitcoin Core reports as `high-hash`.
+    const UNMEETABLE_TARGET_BITS: u32 = 0x1b00_ffff;
+
+    /// A timestamp no clock will accept: the largest one a header can carry.
+    ///
+    /// A header may not be stamped more than two hours ahead of the clock of whoever is
+    /// validating it, and the largest timestamp there is sits decades past that, whatever that
+    /// clock says. Which also keeps the walk from depending on the clock of the machine
+    /// running it.
+    const FAR_FUTURE_TIME: u32 = u32::MAX;
+
+    /// The block version Bitcoin Core asks for once BIP34, BIP66 and BIP65 are in force, which
+    /// on regtest is from the first block on. We don't look at versions at all, so this is here
+    /// for the backend that does.
+    const REQUIRED_BLOCK_VERSION: HeaderVersion = HeaderVersion::from_consensus(4);
+
+    /// A coinbase value above the 50 BTC the regtest chain pays at the height we walk.
+    const EXCESSIVE_COINBASE_VALUE: u64 = 51 * 100_000_000;
+
+    /// More coins than there will ever be, one satoshi over the 21 million limit.
+    const MORE_THAN_EVERY_COIN: u64 = 21_000_000 * 100_000_000 + 1;
+
+    /// A script long enough to take a block past the 4,000,000 weight units it's allowed. Bytes
+    /// outside a witness weigh four units each, so a megabyte of script is more than enough.
+    const OVERSIZED_SCRIPT_LEN: usize = 1_000_001;
+
+    /// An absolute lock time no block of the height we walk can satisfy.
+    const LOCK_TIME_IN_THE_FUTURE: u32 = 1_000;
+
+    /// A sequence claiming a relative lock time of ten blocks, which also makes the input it
+    /// sits in non-final for an absolute lock time.
+    const RELATIVE_LOCK_SEQUENCE: u32 = 10;
+
+    /// The leaf our bogus proof claims to prove the deletion of, and the position it claims
+    /// for it. Any preimage and any position would do: what's hashed here was never in the
+    /// accumulator, which is the whole point.
+    const UNPROVEN_LEAF: &[u8] = b"not in the accumulator";
+    const UNPROVEN_LEAF_POSITION: u64 = 0;
+
+    /// The number of sigops that takes a block over its budget. Legacy sigops count four times
+    /// towards the limit of 80,000, so 20,000 of them is exactly the budget, and one more is
+    /// over it.
+    const SIGOPS_OVER_THE_BLOCK_LIMIT: usize = 20_001;
+
+    /// The size of a transaction that can be read as two concatenated merkle hashes instead,
+    /// which is what makes a block carrying one ambiguous ([CVE-2017-12842]).
+    ///
+    /// [CVE-2017-12842]: https://www.cve.org/CVERecord?id=CVE-2017-12842
+    const MERKLE_NODE_TX_SIZE: usize = 64;
+
+    /// The six bytes that mark a coinbase output as the SegWit commitment: `OP_RETURN`,
+    /// `OP_PUSHBYTES_36` and the `aa21a9ed` tag defined by [BIP141]. The 32 committed bytes
+    /// follow them.
+    ///
+    /// [BIP141]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure
+    const WITNESS_COMMITMENT_HEADER: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+
+    /// What the walk below needs from a backend.
+    ///
+    /// Deliberately as small as it can be: anything a backend gets to answer for itself is a
+    /// divergence the walk stops covering. So this only says how to drive it — never which
+    /// error a check reports, which is what the walk is there to pin down.
+    ///
+    /// It doesn't require [`UpdatableChainstate`], because one of the backends is Bitcoin Core
+    /// itself and Core is not a chain backend of ours. Our own backends forward every method
+    /// here to that trait, so the walk still goes through the API everyone else uses.
+    trait PipelineHarness: Sized {
+        /// A backend that knows the headers of `blocks` and hasn't validated any of them.
+        fn setup(blocks: &[Block]) -> Self;
+
+        /// Whether this backend validates headers. A [`PartialChainState`] is handed a range
+        /// of headers that the full chainstate has already accepted, so it skips step 1.
+        fn validates_headers() -> bool;
+
+        /// Hands a header to the backend on its own, without a block behind it.
+        fn accept_header(&self, header: BlockHeader) -> Result<(), BlockchainError>;
+
+        /// Makes this block, whose header the backend already knows, one it knows to be
+        /// invalid. The block is invalid on its own, so a backend that has no way of being
+        /// told can find out by validating it.
+        fn mark_invalid(&self, block: &Block);
+
+        /// Connects a block that the walk needs behind it, and isn't a step of its own.
+        fn connect(&self, block: &Block) -> Result<u32, BlockchainError>;
+
+        /// Feeds `block` to the backend and returns what the pipeline reports.
+        fn feed(
+            &self,
+            block: &Block,
+            proof: Proof,
+            inputs: HashMap<OutPoint, UtxoData>,
+            del_hashes: Vec<sha256::Hash>,
+        ) -> Result<u32, BlockchainError>;
+
+        /// The height of the chain the backend considers best.
+        fn height(&self) -> u32;
+    }
+
+    impl PipelineHarness for ChainState<FlatChainStore> {
+        fn setup(blocks: &[Block]) -> Self {
+            let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Disabled, None);
+
+            for block in blocks {
+                UpdatableChainstate::accept_header(&chain, block.header).unwrap();
+            }
+
+            chain
+        }
+
+        fn validates_headers() -> bool {
+            true
+        }
+
+        fn accept_header(&self, header: BlockHeader) -> Result<(), BlockchainError> {
+            UpdatableChainstate::accept_header(self, header)
+        }
+
+        fn mark_invalid(&self, block: &Block) {
+            UpdatableChainstate::invalidate_block(self, block.block_hash()).unwrap();
+        }
+
+        fn connect(&self, block: &Block) -> Result<u32, BlockchainError> {
+            UpdatableChainstate::connect_block(
+                self,
+                block,
+                Proof::default(),
+                HashMap::new(),
+                Vec::new(),
+            )
+        }
+
+        fn height(&self) -> u32 {
+            BlockchainInterface::get_height(self).unwrap()
+        }
+
+        /// Puts this block's header in the place of whatever we have at its height, and
+        /// connects the block.
+        ///
+        /// Replacing the header is what lets one walk carry a single block through the whole
+        /// pipeline: repairing the payload changes the merkle root, and with it the header
+        /// that commits to it.
+        fn feed(
+            &self,
+            block: &Block,
+            proof: Proof,
+            inputs: HashMap<OutPoint, UtxoData>,
+            del_hashes: Vec<sha256::Hash>,
+        ) -> Result<u32, BlockchainError> {
+            let parent_height = self
+                .get_block_height(&block.header.prev_blockhash)
+                .unwrap()
+                .expect("the parent is in our chain");
+
+            // Drop the variant we fed last time, so this one can extend the tip in its place
+            if let Ok(hash) = self.get_block_hash(parent_height + 1) {
+                let known = self.get_block_height(&hash);
+                let is_valid_tip = matches!(known, Ok(Some(_)));
+
+                if hash != block.block_hash() && is_valid_tip {
+                    self.invalidate_block(hash).unwrap();
+                }
+            }
+
+            UpdatableChainstate::accept_header(self, block.header)?;
+            UpdatableChainstate::connect_block(self, block, proof, inputs, del_hashes)
+        }
+    }
+
+    impl PipelineHarness for PartialChainState {
+        fn setup(blocks: &[Block]) -> Self {
+            // The headers at heights 0 to 11: the genesis, and the eleven blocks that the
+            // block we walk through the pipeline builds on
+            let headers = core::iter::once(genesis_block(Network::Regtest).header)
+                .chain(blocks.iter().take(11).map(|block| block.header))
+                .collect();
+
+            PartialChainStateInner {
+                assume_valid: true,
+                consensus: Consensus {
+                    parameters: ChainParams::from(Network::Regtest),
+                },
+                current_height: 0,
+                current_acc: Stump::default(),
+                final_height: 12,
+                blocks: headers,
+                error: None,
+            }
+            .into()
+        }
+
+        fn validates_headers() -> bool {
+            false
+        }
+
+        fn accept_header(&self, _header: BlockHeader) -> Result<(), BlockchainError> {
+            unimplemented!("a partial chain is handed headers that were accepted for it")
+        }
+
+        fn mark_invalid(&self, _block: &Block) {
+            unimplemented!("a partial chain has no headers of its own to mark")
+        }
+
+        fn connect(&self, block: &Block) -> Result<u32, BlockchainError> {
+            UpdatableChainstate::connect_block(
+                self,
+                block,
+                Proof::default(),
+                HashMap::new(),
+                Vec::new(),
+            )
+        }
+
+        fn height(&self) -> u32 {
+            BlockchainInterface::get_height(self).unwrap()
+        }
+
+        fn feed(
+            &self,
+            block: &Block,
+            proof: Proof,
+            inputs: HashMap<OutPoint, UtxoData>,
+            del_hashes: Vec<sha256::Hash>,
+        ) -> Result<u32, BlockchainError> {
+            // A partial chain holds no headers of its own to replace
+            self.connect_block(block, proof, inputs, del_hashes)
+        }
+    }
+
+    /// Bitcoin Core itself, as a backend for the walk, through [`KernelBackend`].
+    ///
+    /// This is the oracle: its list of gaps is the list of divergences between us and Core,
+    /// ordering and parity together. The steps that have no counterpart in Core, the tip check
+    /// and everything about the utreexo proof, come out as gaps here and are meant to. What
+    /// Core can and can't answer, and how its answers are read, is in
+    /// [`bitcoinkernelbackend`](crate::bitcoinkernelbackend).
+    #[cfg(feature = "bitcoinkernel")]
+    impl PipelineHarness for KernelBackend {
+        /// Core keeps no state between a header and its block, so the eleven blocks the walk
+        /// builds on are connected here, which is where the other backends are by the time the
+        /// walk is done with its tip check. Block 12 is left out: the walk hands it over
+        /// itself, to learn it's invalid.
+        fn setup(blocks: &[Block]) -> Self {
+            let data_dir = format!("./tmp-db/kernel-{}", rand::random::<u64>());
+            let chain = Self::new(Network::Regtest, &data_dir);
+
+            for block in blocks.iter().take(11) {
+                PipelineHarness::connect(&chain, block).expect("these blocks are valid");
+            }
+
+            chain
+        }
+
+        fn validates_headers() -> bool {
+            true
+        }
+
+        fn accept_header(&self, header: BlockHeader) -> Result<(), BlockchainError> {
+            UpdatableChainstate::accept_header(self, header)
+        }
+
+        /// Core has no way of being told a block is invalid, so it finds out: this one is
+        /// invalid on its own, and turning it down is what marks its header.
+        fn mark_invalid(&self, block: &Block) {
+            PipelineHarness::connect(self, block).expect_err("this block is invalid");
+        }
+
+        fn connect(&self, block: &Block) -> Result<u32, BlockchainError> {
+            UpdatableChainstate::connect_block(
+                self,
+                block,
+                Proof::default(),
+                HashMap::new(),
+                Vec::new(),
+            )
+        }
+
+        fn feed(
+            &self,
+            block: &Block,
+            proof: Proof,
+            inputs: HashMap<OutPoint, UtxoData>,
+            del_hashes: Vec<sha256::Hash>,
+        ) -> Result<u32, BlockchainError> {
+            UpdatableChainstate::connect_block(self, block, proof, inputs, del_hashes)
+        }
+
+        fn height(&self) -> u32 {
+            Self::height(self)
+        }
+    }
+
+    #[cfg(feature = "bitcoinkernel")]
+    #[test]
+    fn kernel_validation_pipeline() {
+        walk_the_validation_pipeline::<KernelBackend>();
+    }
+
+    #[test]
+    fn chain_state_validation_pipeline() {
+        walk_the_validation_pipeline::<ChainState<FlatChainStore>>();
+    }
+
+    #[test]
+    fn partial_chain_state_validation_pipeline() {
+        walk_the_validation_pipeline::<PartialChainState>();
+    }
+
+    /// Acceptance test for the whole validation pipeline: which check answers for a block, in
+    /// which order, and with which error.
+    ///
+    /// One chain, and one block that starts out broken at every level we know how to check.
+    /// Each step feeds it to the backend, asserts the error Bitcoin Core reports for the check
+    /// that has to come first, repairs *only* that one thing and feeds it back, so that the
+    /// next step sees the next check fire. A step can fail on two counts, and the walk covers
+    /// both:
+    ///
+    /// - **ordering**: a check that runs out of turn answers for a step that isn't its own,
+    ///   and a check that doesn't run at all lets a later one answer in its place
+    /// - **parity**: the check runs where it should, but reports something other than what
+    ///   Bitcoin Core reports for it, so whoever reads the error can't tell which check failed
+    ///
+    /// ```text
+    /// 1. accept_header  a header we already have ──────────────── DuplicateBlock
+    ///                   ↓ mark block 12 invalid
+    ///                   a header we know to be invalid ────────── DuplicateInvalidBlock
+    ///                   ↓ repair: nothing (the same header)
+    ///                   pow against its own claimed target ────── NotEnoughPow
+    ///                   ↓ repair: claim the regtest target, and meet it
+    ///                   unknown parent ────────────────────────── PrevBlockNotFound
+    ///                   ↓ repair: build on block 12 (invalid)
+    ///                   invalid parent ────────────────────────── BadPrevBlock
+    ///                   ↓ repair: build on block 6
+    ///                   timestamp at the MTP ──────────────────── TimeTooOld
+    ///                   ↓ repair: a timestamp above it
+    ///                   timestamp in the future ───────────────── TimeTooNew
+    ///                   ↓ repair: a sane timestamp
+    ///                   header accepted ───────────────────────── ok
+    /// 2. connect_block  not the next block to validate ────────── BlockDoesntExtendTip
+    ///                   ↓ repair: connect blocks 1 to 11
+    /// 3. block          no transactions at all ────────────────── EmptyBlock
+    ///                   ↓ repair: the transactions
+    ///                   over the weight limit ─────────────────── BlockTooBig
+    ///                   ↓ repair: drop the padding
+    /// 4. mutation       payload ≠ merkle root ─────────────────── BadMerkleRoot
+    ///                   ↓ repair: the committed payload, last transaction duplicated
+    ///                   [a,b,c] against [a,b,c,c] ─────────────── DuplicateTransactions
+    ///                   ↓ repair: drop the duplicate
+    ///                   64-byte transaction, no coinbase ──────── SixtyFourByteTransaction
+    ///                   ↓ repair: make it 65 bytes long
+    ///                   no coinbase ───────────────────────────── FirstTxIsNotCoinbase
+    ///                   ↓ repair: a coinbase, with a commitment and a 1-byte nonce
+    ///                   reserved value isn't 32 bytes ─────────── BadWitnessNonceSize
+    ///                   ↓ repair: a 32-byte reserved value
+    ///                   the commitment doesn't match ──────────── BadWitnessCommitment
+    ///                   ↓ repair: drop the commitment
+    ///                   witness data with no commitment ───────── UnexpectedWitness
+    /// 5. transactions   ↓ repair: drop the witness data
+    ///                   a second coinbase ─────────────────────── MultipleCoinbase
+    ///                   ↓ repair: drop the second coinbase
+    ///                   a coinbase scriptsig too short ────────── InvalidCoinbase
+    ///                   ↓ repair: a scriptsig of the size one has to be
+    ///                   no inputs ─────────────────────────────── EmptyInputs
+    ///                   ↓ repair: two inputs, the same one twice
+    ///                   no outputs ────────────────────────────── EmptyOutputs
+    ///                   ↓ repair: an output
+    ///                   more coins than there are ─────────────── TooManyCoins
+    ///                   ↓ repair: a value that exists
+    ///                   the same input twice ──────────────────── DuplicateInput
+    ///                   ↓ repair: a second input of its own
+    ///                   a null prevout ────────────────────────── NullPrevOut
+    ///                   ↓ repair: an output for it to spend
+    ///                   sigops over the block limit ───────────── TooManySigOps
+    ///                   ↓ repair: drop the sigop script
+    ///                   lock time in the future ───────────────── NonFinalTransaction
+    ///                   ↓ repair: no lock time
+    /// 6. proof          a proof with no deletion hash ─────────── MalformedUtreexoProof
+    ///                   ↓ repair: the hash of the deleted leaf
+    ///                   a leaf we never had ───────────────────── InvalidUtreexoProof
+    ///                   ↓ repair: the hash of a leaf we do hold
+    ///                   a leaf the BIP30 violation overwrote ──── UnspendableUTXO
+    ///                   ↓ repair: a proof of nothing, which verifies
+    /// 7. the UTXOs      the spent UTXOs are missing ───────────── UtxoNotFound(the first)
+    ///                   ↓ repair: hand the UTXOs over
+    ///                   an immature coinbase ──────────────────── CoinbaseNotMatured
+    ///                   ↓ repair: not a coinbase
+    ///                   an unspendable script ─────────────────── ScriptError
+    ///                   ↓ repair: a script anyone can spend
+    ///                   spending more than it holds ───────────── NotEnoughMoney
+    ///                   ↓ repair: enough value
+    ///                   a relative lock time ──────────────────── UnsatisfiedSequenceLocks
+    ///                   ↓ repair: final sequences
+    ///                   the coinbase claims too much ──────────── BadCoinbaseOutValue
+    ///                   ↓ repair: what the block pays it
+    ///                   BLOCK CONNECTED ───────────────────────── height 12
+    /// ```
+    ///
+    /// A backend that doesn't validate headers skips step 1, which is what [`PipelineHarness`]
+    /// describes. Nothing else about the walk is per-backend: it's one pipeline, so the errors
+    /// have to be the same too.
+    fn walk_the_validation_pipeline<T: PipelineHarness>() {
+        let mut gaps = Vec::new();
+
+        // Twelve blocks to work against. Block 11 is the parent of everything we feed below,
+        // and block 12 is the one every backend learns is invalid: its header is sound, and
+        // its coinbase claims more than the block pays it. A backend that can't be told to
+        // invalidate a block finds out by validating this one.
+        let mut blocks = mine_chain(12);
+        let mut coinbase = blocks[11].txdata[0].clone();
+        coinbase.output[0].value = Amount::from_sat(EXCESSIVE_COINBASE_VALUE);
+        blocks[11] = rebuild(&[coinbase], blocks[11].header);
+        let chain = T::setup(&blocks);
+        let parent = &blocks[10];
+
+        // The block we walk through the pipeline, broken at every level we know how to check.
+        // Its payload is, in this order: a transaction of exactly 64 bytes where the coinbase
+        // should be, a second coinbase padding the block past the weight limit, and the
+        // transaction the block spends with, which starts out with no inputs and no outputs.
+        let mut coinbase = test_coinbase(12, Sequence::MAX, LockTime::ZERO);
+        coinbase.input[0].script_sig = ScriptBuf::from_bytes(vec![OP_TRUE.to_u8()]);
+        coinbase.output = vec![txout!(EXCESSIVE_COINBASE_VALUE, ScriptBuf::new())];
+        coinbase.output.push(txout!(0, sigop_script()));
+        coinbase.output.push(witness_commitment_output([0u8; 32]));
+        coinbase.input[0].witness = Witness::from_slice(&[[0u8; 1]]);
+
+        let mut second_coinbase = test_coinbase(999, Sequence::MAX, LockTime::ZERO);
+        second_coinbase
+            .output
+            .push(txout!(0, anyone_can_spend_bytes(OVERSIZED_SCRIPT_LEN)));
+
+        let spend = Transaction {
+            version: TransactionVersion::TWO,
+            lock_time: LockTime::from_consensus(LOCK_TIME_IN_THE_FUTURE),
+            input: vec![
+                txin!(
+                    test_outpoint(0),
+                    ScriptBuf::new(),
+                    Sequence::from_consensus(RELATIVE_LOCK_SEQUENCE)
+                ),
+                txin!(
+                    test_outpoint(0),
+                    ScriptBuf::new(),
+                    Sequence::from_consensus(RELATIVE_LOCK_SEQUENCE)
+                ),
+            ],
+            output: Vec::new(),
+        };
+        let mut txdata = vec![sixty_four_byte_transaction(), second_coinbase, spend];
+        let mut block = rebuild(
+            &txdata,
+            BlockHeader {
+                version: REQUIRED_BLOCK_VERSION,
+                prev_blockhash: parent.block_hash(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: parent.header.time + 1,
+                bits: CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS),
+                nonce: 0,
+            },
+        );
+
+        // ---- 1. Header validation ----
+        if T::validates_headers() {
+            // A header we already have short-circuits every check below it, and we say so
+            // rather than quietly reporting success: it's the caller who knows what a header
+            // it has already given us means
+            gaps.extend(compare(
+                "known header",
+                BlockValidationErrors::DuplicateBlock,
+                chain.accept_header(blocks[11].header),
+            ));
+
+            // One we've marked invalid is rejected outright, still without being revalidated.
+            // This also leaves block 11 as our tip.
+            chain.mark_invalid(&blocks[11]);
+            gaps.extend(compare(
+                "known invalid header",
+                BlockValidationErrors::DuplicateInvalidBlock,
+                chain.accept_header(blocks[11].header),
+            ));
+
+            // Break the header: it claims a target it doesn't meet, builds on a parent we
+            // don't have, and is stamped at the Median Time Past of the chain we do have. The
+            // steps below build on block 6, so a header we wrongly accept lands on a fork and
+            // leaves our tip alone.
+            let fork_parent = &blocks[5];
+            block.header.prev_blockhash = BlockHash::all_zeros();
+            block.header.bits = CompactTarget::from_consensus(UNMEETABLE_TARGET_BITS);
+            block.header.time = median_time_past(&blocks[..6]);
+
+            // The proof of work is checked against the target the header itself claims, so it
+            // needs no context at all and is reported before we even look for the parent
+            gaps.extend(compare(
+                "header proof of work",
+                BlockValidationErrors::NotEnoughPow,
+                chain.accept_header(block.header),
+            ));
+
+            // Repair: claim the regtest target, and meet it
+            block.header.bits = CompactTarget::from_consensus(EASIEST_REGTEST_TARGET_BITS);
+            block = mine(block);
+
+            // Now the parent lookup, which is reported before any check against that parent
+            gaps.extend(compare(
+                "missing parent",
+                BlockValidationErrors::PrevBlockNotFound,
+                chain.accept_header(block.header),
+            ));
+
+            // Repair: build on a parent we do have. It's the one we've just marked invalid.
+            block.header.prev_blockhash = blocks[11].block_hash();
+            block = mine(block);
+
+            // Knowing the parent and knowing it to be invalid is a different answer from not
+            // having it at all, and it too comes before the checks against the parent
+            gaps.extend(compare(
+                "invalid parent",
+                BlockValidationErrors::BadPrevBlock,
+                chain.accept_header(block.header),
+            ));
+
+            // Repair: build on a valid parent
+            block.header.prev_blockhash = fork_parent.block_hash();
+            block = mine(block);
+
+            // Contextual: the timestamp has to be above the Median Time Past of the ancestors
+            gaps.extend(compare(
+                "timestamp at the median time past",
+                BlockValidationErrors::TimeTooOld,
+                chain.accept_header(block.header),
+            ));
+
+            // Repair: a timestamp above the Median Time Past ... and hours ahead of our clock
+            block.header.time = FAR_FUTURE_TIME;
+            block = mine(block);
+
+            // ... which can't be more than two hours
+            gaps.extend(compare(
+                "timestamp in the future",
+                BlockValidationErrors::TimeTooNew,
+                chain.accept_header(block.header),
+            ));
+
+            // Repair: a sane timestamp. There's nothing left to say about this header, and
+            // it's accepted, as a fork of the chain we're building on.
+            block.header.time = fork_parent.header.time + 1;
+            block = mine(block);
+            assert_ok!(chain.accept_header(block.header));
+
+            // Move the walk back to the tip. A fork is headers alone as far as we're
+            // concerned, so a block building on one can't be connected however valid it is,
+            // which is why the header steps above could afford to live on one and these can't.
+            block.header.prev_blockhash = parent.block_hash();
+            block.header.time = parent.header.time + 1;
+            block = mine(block);
+        }
+
+        // ---- 2. The tip check ----
+        // The emptiest payload there is, which is also where the block stage starts below. A
+        // header that gets replaced can't come back, so this step uses the one it goes on to
+        // use next.
+        let empty = rebuild(&[], block.header);
+
+        // A known divergence: Core takes any block whose parent it has, on whatever branch. We
+        // keep no blocks — only the transaction data the main chain needs, and only while we
+        // validate it — so a fork is worth headers to us and nothing more. See
+        // [`BlockValidationErrors::BlockDoesntExtendTip`].
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "tip check",
+            BlockValidationErrors::BlockDoesntExtendTip,
+            chain.feed(&empty, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: connect everything below this block, so that it's the next one to validate
+        for connected in blocks.iter().take(11) {
+            chain.connect(connected).unwrap();
+        }
+
+        // ---- 3. The block ----
+        // Nothing at all: no transactions, which the header commits to with the zero merkle
+        // root Bitcoin Core defines for an empty list. There isn't even a coinbase to look at.
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "empty block",
+            BlockValidationErrors::EmptyBlock,
+            chain.feed(&empty, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: the transactions this block carries. The second coinbase pads it past the
+        // four million weight units a block is allowed.
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "block weight",
+            BlockValidationErrors::BlockTooBig,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: drop the padding
+        txdata[1].output.pop();
+        block = rebuild(&txdata, block.header);
+
+        // ---- 4. Mutation detection ----
+        // The header commits to a payload, and this isn't it. Everything the payload is broken
+        // in below is still there, and none of it is reported instead.
+        let mut mutated = block.clone();
+        mutated.txdata = vec![test_coinbase(998, Sequence::MAX, LockTime::ZERO)];
+        assert_eq!(mutated.block_hash(), block.block_hash());
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "merkle root",
+            BlockValidationErrors::BadMerkleRoot,
+            chain.feed(&mutated, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: the payload the header commits to, with the last transaction duplicated.
+        // `[a, b, c]` and `[a, b, c, c]` have the same merkle root, so the header commits to
+        // this payload just as much.
+        let mut duplicated = block.clone();
+        duplicated.txdata.push(txdata[2].clone());
+        assert_eq!(duplicated.block_hash(), block.block_hash());
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "duplicate transactions",
+            BlockValidationErrors::DuplicateTransactions,
+            chain.feed(&duplicated, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: drop the duplicate. What's left starts with a 64-byte transaction, which can
+        // be read as a pair of merkle hashes instead.
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "64-byte transaction",
+            BlockValidationErrors::SixtyFourByteTransaction,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: one more byte of script, so the transaction can't be mistaken for a pair of
+        // hashes anymore. It still isn't a coinbase.
+        let padding = txdata[0].output[0].script_pubkey.len() + 1;
+        txdata[0].output[0].script_pubkey = anyone_can_spend_bytes(padding);
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "missing coinbase",
+            BlockValidationErrors::FirstTxIsNotCoinbase,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: a coinbase, which is what commits to the witness data of the whole block. It
+        // claims a commitment that doesn't match, and its reserved value isn't 32 bytes long.
+        txdata[0] = coinbase;
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "witness reserved value",
+            BlockValidationErrors::BadWitnessNonceSize,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: a 32-byte reserved value. Witness data doesn't change any txid, so the header
+        // still commits to this payload, and now the commitment itself is what's wrong.
+        block.txdata[0].input[0].witness = Witness::from_slice(&[[0u8; 32]]);
+        txdata[0] = block.txdata[0].clone();
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "witness commitment",
+            BlockValidationErrors::BadWitnessCommitment,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: drop the commitment. Now nothing commits to the witness data that's still in
+        // there, which is room for anything.
+        txdata[0].output.pop();
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "unexpected witness",
+            BlockValidationErrors::UnexpectedWitness,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // ---- 5. The transactions, on their own ----
+        // Repair: drop the witness data. The payload is committed to and unmutated now, so
+        // what's wrong with it is the block's own business: it has a second coinbase.
+        block.txdata[0].input[0].witness = Witness::default();
+        txdata[0] = block.txdata[0].clone();
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "second coinbase",
+            BlockValidationErrors::MultipleCoinbase,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: drop the second coinbase. The one that's left carries a scriptsig too short
+        // to be a coinbase's.
+        txdata.remove(1);
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "coinbase scriptsig",
+            BlockValidationErrors::InvalidCoinbase("Invalid ScriptSig size".into()),
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: a scriptsig of the size a coinbase's has to be. From here on it's the
+        // transaction the block spends with.
+        txdata[0].input[0].script_sig = test_coinbase(12, Sequence::MAX, LockTime::ZERO).input[0]
+            .script_sig
+            .clone();
+        block = rebuild(&txdata, block.header);
+
+        // A transaction with no inputs, which is a detour rather than a state the walk repairs
+        // out of: the zero where the input count goes is the SegWit marker, so a block that
+        // carries one doesn't decode and can only ever be built in memory.
+        let mut without_inputs = txdata.clone();
+        without_inputs[1].input.clear();
+        let without_inputs = rebuild(&without_inputs, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "transaction without inputs",
+            BlockValidationErrors::EmptyInputs,
+            chain.feed(&without_inputs, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Back to the transaction the block carries, whose two inputs spend the same output
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "transaction without outputs",
+            BlockValidationErrors::EmptyOutputs,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: an output, claiming more coins than there will ever be
+        txdata[1].output = vec![txout!(MORE_THAN_EVERY_COIN, anyone_can_spend_bytes(1))];
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "more coins than there are",
+            BlockValidationErrors::TooManyCoins,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: a value that exists. The two inputs still spend the same output twice.
+        txdata[1].output[0].value = Amount::ONE_SAT;
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "the same input twice",
+            BlockValidationErrors::DuplicateInput,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: a second input of its own, except it spends nothing at all, which only a
+        // coinbase may do
+        txdata[1].input[1].previous_output = OutPoint::null();
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "a null prevout",
+            BlockValidationErrors::NullPrevOut,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: an output for it to spend. What's left is the coinbase, which spends the
+        // block's whole sigop budget four times over.
+        txdata[1].input[1].previous_output = test_outpoint(1);
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "block sigops",
+            BlockValidationErrors::TooManySigOps,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: drop the sigop script. The spend still claims a lock time this block is too
+        // early for.
+        txdata[0].output.remove(1);
+        block = rebuild(&txdata, block.header);
+
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "lock time in the future",
+            BlockValidationErrors::NonFinalTransaction,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: no lock time at all
+        txdata[1].lock_time = LockTime::ZERO;
+        block = rebuild(&txdata, block.header);
+
+        // ---- 6. The utreexo proof ----
+        // Nothing is left to say about this block without looking at what it spends, and the
+        // proof is what ties those UTXOs to our accumulator, so it has to be verified before
+        // anything looks at them. Each way a proof can fail is its own answer: whoever gets it
+        // shouldn't have to guess which one it got.
+        //
+        // A proof that claims a deletion without carrying the hash of what it deletes. With
+        // nothing to delete, rustreexo returns before it so much as looks at the proof, so the
+        // targets it claims go unchecked unless we check them ourselves.
+        let (proof, _) = bogus_proof();
+        gaps.extend(compare(
+            "proof with no deletion hash",
+            BlockValidationErrors::MalformedUtreexoProof,
+            chain.feed(&block, proof, HashMap::new(), Vec::new()),
+        ));
+
+        // Repair: the hash of the leaf it deletes. The proof is well formed now, and proves the
+        // deletion of a leaf that was never in our accumulator.
+        let (proof, del_hashes) = bogus_proof();
+        gaps.extend(compare(
+            "proof of a leaf we don't have",
+            BlockValidationErrors::InvalidUtreexoProof,
+            chain.feed(&block, proof, HashMap::new(), del_hashes),
+        ));
+
+        // Repair: the hash of a leaf we do hold. It's one of the two the BIP30 violation
+        // overwrote, which a Utreexo node can still prove and still may not spend.
+        let (proof, _) = bogus_proof();
+        gaps.extend(compare(
+            "spending a BIP30 leftover",
+            BlockValidationErrors::UnspendableUTXO,
+            chain.feed(
+                &block,
+                proof,
+                HashMap::new(),
+                vec![sha256::Hash::from_byte_array(UNSPENDABLE_BIP30_UTXO_91722)],
+            ),
+        ));
+
+        // ---- 7. The transactions, against the UTXOs they spend ----
+        // Repair: a proof of nothing, which verifies. The UTXOs this block spends are missing,
+        // and the first input of the first transaction that spends anything is the one we hear
+        // about.
+        gaps.extend(compare(
+            "the spent UTXOs are missing",
+            BlockValidationErrors::UtxoNotFound(test_outpoint(0)),
+            chain.feed(&block, Proof::default(), HashMap::new(), Vec::new()),
+        ));
+
+        // Repair: hand the UTXOs over. They come from a coinbase of this very block's height,
+        // which can't be spent for another hundred blocks.
+        let mut utxo = UtxoData {
+            txout: txout!(0, ScriptBuf::new_op_return([0x0, 0x1])),
+            is_coinbase: true,
+            creation_height: 12,
+            creation_time: 0,
+        };
+        gaps.extend(compare(
+            "an immature coinbase",
+            BlockValidationErrors::CoinbaseNotMatured,
+            chain.feed(&block, Proof::default(), spent_utxos(&utxo), Vec::new()),
+        ));
+
+        // Repair: UTXOs that aren't a coinbase's. Their script can't be spent by anyone.
+        utxo.is_coinbase = false;
+        gaps.extend(compare(
+            "an unspendable script",
+            BlockValidationErrors::ScriptError,
+            chain.feed(&block, Proof::default(), spent_utxos(&utxo), Vec::new()),
+        ));
+
+        // Repair: a script anyone can spend. They hold nothing, and the spend pays out a coin.
+        utxo.txout.script_pubkey = anyone_can_spend_bytes(1);
+        gaps.extend(compare(
+            "spending more than it holds",
+            BlockValidationErrors::NotEnoughMoney,
+            chain.feed(&block, Proof::default(), spent_utxos(&utxo), Vec::new()),
+        ));
+
+        // Repair: enough value to cover what it pays out. The inputs still claim a relative
+        // lock time that this height doesn't satisfy.
+        utxo.txout.value = Amount::ONE_SAT;
+        gaps.extend(compare(
+            "a relative lock time",
+            BlockValidationErrors::UnsatisfiedSequenceLocks,
+            chain.feed(&block, Proof::default(), spent_utxos(&utxo), Vec::new()),
+        ));
+
+        // Repair: inputs that claim no lock time. The coinbase still claims more than the
+        // block pays it.
+        for input in txdata[1].input.iter_mut() {
+            input.sequence = Sequence::MAX;
+        }
+        block = rebuild(&txdata, block.header);
+
+        gaps.extend(compare(
+            "the coinbase claims too much",
+            BlockValidationErrors::BadCoinbaseOutValue,
+            chain.feed(&block, Proof::default(), spent_utxos(&utxo), Vec::new()),
+        ));
+
+        // Repair: a coinbase that claims what the block pays it. There's nothing wrong with
+        // this block anymore, so it connects and becomes our tip.
+        txdata[0].output[0].value = Amount::ZERO;
+        block = rebuild(&txdata, block.header);
+
+        match chain.feed(&block, Proof::default(), spent_utxos(&utxo), Vec::new()) {
+            Ok(12) => assert_eq!(chain.height(), 12),
+            Ok(height) => gaps.push(format!("valid block: connected at height {height}, not 12")),
+            Err(e) => gaps.push(format!("valid block: expected it to connect, got {e:?}")),
+        }
+
+        assert!(
+            gaps.is_empty(),
+            "the validation pipeline diverges from Bitcoin Core:\n{}",
+            gaps.join("\n")
+        );
+    }
+
+    /// Mines `count` valid regtest blocks on top of the genesis. Their timestamps grow by one
+    /// second per block, so the chain has a Median Time Past to check candidates against.
+    fn mine_chain(count: u32) -> Vec<Block> {
+        let mut blocks: Vec<Block> = Vec::new();
+
+        for height in 1..=count {
+            let coinbase = test_coinbase(height, Sequence::MAX, LockTime::ZERO);
+            let mut block = block_with_transactions(height, vec![coinbase]);
+            block.header.version = REQUIRED_BLOCK_VERSION;
+
+            if let Some(parent) = blocks.last() {
+                block.header.prev_blockhash = parent.block_hash();
+            }
+
+            blocks.push(mine(block));
+        }
+
+        blocks
+    }
+
+    /// Rebuilds a block from `txdata`, keeping `header`'s fields, recomputing the merkle root
+    /// and mining it: what a miner does after changing what goes into the block.
+    fn rebuild(txdata: &[Transaction], header: BlockHeader) -> Block {
+        let mut block = Block {
+            header,
+            txdata: txdata.to_vec(),
+        };
+        // Bitcoin Core defines the merkle root of an empty payload as zero
+        block.header.merkle_root = block
+            .compute_merkle_root()
+            .unwrap_or(TxMerkleNode::all_zeros());
+
+        mine(block)
+    }
+
+    /// The Median Time Past that a header building on the last of `blocks` has to beat.
+    ///
+    /// This is [`HeaderExt::median_time_past_with`], the same code the chain runs against its
+    /// own headers, so the walk asks for exactly the timestamp the chain will compare against,
+    /// down to how far back it looks and where it stops.
+    fn median_time_past(blocks: &[Block]) -> u32 {
+        let genesis = genesis_block(Network::Regtest).header;
+        let mut ancestors = blocks
+            .iter()
+            .rev()
+            .skip(1)
+            .map(|block| block.header)
+            .chain(core::iter::once(genesis));
+
+        blocks
+            .last()
+            .expect("the walk always has a parent to build on")
+            .header
+            .median_time_past_with(|_| ancestors.next().ok_or(()))
+            .expect("the ancestors reach the genesis, where the walk stops")
+    }
+
+    /// A proof and a deletion hash that don't verify against any accumulator we could have.
+    fn bogus_proof() -> (Proof, Vec<sha256::Hash>) {
+        let proof = Proof {
+            targets: vec![UNPROVEN_LEAF_POSITION],
+            hashes: Vec::new(),
+        };
+
+        (proof, vec![sha256::Hash::hash(UNPROVEN_LEAF)])
+    }
+
+    /// An output script that spends more than the whole block's sigop budget.
+    fn sigop_script() -> ScriptBuf {
+        let mut script = ScriptBuf::new();
+        for _ in 0..SIGOPS_OVER_THE_BLOCK_LIMIT {
+            script.push_opcode(OP_CHECKSIG);
+        }
+
+        script
+    }
+
+    /// A transaction that serializes to exactly [`MERKLE_NODE_TX_SIZE`] bytes. It spends an
+    /// outpoint of its own, so that it isn't confused with what the block's real spend uses.
+    fn sixty_four_byte_transaction() -> Transaction {
+        let mut transaction = Transaction {
+            version: TransactionVersion::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![txin!(test_outpoint(9), ScriptBuf::new(), Sequence::MAX)],
+            output: vec![txout!(1, ScriptBuf::new())],
+        };
+
+        // Everything but the output script is fixed, so that's what we pad with
+        let padding = MERKLE_NODE_TX_SIZE - transaction.base_size();
+        transaction.output[0].script_pubkey = anyone_can_spend_bytes(padding);
+        assert_eq!(transaction.base_size(), MERKLE_NODE_TX_SIZE);
+
+        transaction
+    }
+
+    /// The UTXOs the block's spend claims, both of them `utxo`.
+    fn spent_utxos(utxo: &UtxoData) -> HashMap<OutPoint, UtxoData> {
+        HashMap::from([
+            (test_outpoint(0), utxo.clone()),
+            (test_outpoint(1), utxo.clone()),
+        ])
+    }
+
+    /// A script of `len` bytes that anyone can spend, for padding a transaction to a size.
+    fn anyone_can_spend_bytes(len: usize) -> ScriptBuf {
+        ScriptBuf::from_bytes(vec![OP_TRUE.to_u8(); len])
+    }
+
+    /// A coinbase output carrying `commitment` as the BIP141 witness commitment: the
+    /// `OP_RETURN OP_PUSHBYTES_36 aa21a9ed` header followed by the 32 committed bytes.
+    fn witness_commitment_output(commitment: [u8; 32]) -> TxOut {
+        let mut script = WITNESS_COMMITMENT_HEADER.to_vec();
+        script.extend_from_slice(&commitment);
+
+        txout!(0, ScriptBuf::from_bytes(script))
+    }
+
+    /// Compares one step of the walk against the error Bitcoin Core reports for it: this is
+    /// where both the ordering and the parity of that step are decided, and it describes the
+    /// mismatch when there is one.
+    ///
+    /// A [`crate::TransactionError`] is a [`BlockValidationErrors`] with the txid of whoever
+    /// caused it attached, so a step states the error it expects without caring which of the
+    /// two it comes back in.
+    fn compare<T: core::fmt::Debug>(
+        step: &str,
+        expected: BlockValidationErrors,
+        got: Result<T, BlockchainError>,
+    ) -> Option<String> {
+        let actual = match &got {
+            Err(BlockchainError::BlockValidation(error)) => Some(error),
+            Err(BlockchainError::TransactionError(error)) => Some(&error.error),
+            _ => None,
+        };
+
+        match actual {
+            Some(actual) if *actual == expected => None,
+            _ => Some(format!(
+                "{step}: expected the validation error {expected:?}, got {got:?}"
+            )),
+        }
+    }
+}

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -206,9 +206,12 @@ impl PartialChainStateInner {
     ) -> Result<(), BlockchainError> {
         self.consensus.check_block(block, height)?;
 
+        // We do have this height's ancestor, it's in the range we've been handed. If this
+        // block doesn't build on it, it simply isn't the block we have to validate next, which
+        // is what a full chainstate reports for the same mistake.
         let prev_block = self.get_ancestor(height)?;
         if block.header.prev_blockhash != prev_block.block_hash() {
-            Err(BlockValidationErrors::BlockExtendsAnOrphanChain)?;
+            Err(BlockValidationErrors::BlockDoesntExtendTip)?;
         }
 
         // Validate block transactions
@@ -557,7 +560,7 @@ mod tests {
         }
         run(
             "0000002000226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f39adbcd7823048d34357bdca86cd47172afe2a4af8366b5b34db36df89386d49b23ec964ffff7f20000000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff165108feddb99c6b8435060b2f503253482f627463642fffffffff0100f2052a01000000160014806cef41295922d32ddfca09c26cc4acd36c3ed000000000",
-            BlockValidationErrors::BlockExtendsAnOrphanChain,
+            BlockValidationErrors::BlockDoesntExtendTip,
             true,
         );
         run(

--- a/crates/floresta-wire/src/p2p_wire/node/blocks.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/blocks.rs
@@ -365,7 +365,8 @@ where
         let hash = block.block_hash();
         match e {
             // The utreexo peer sent us an invalid utreexo proof. Block is not yet processed.
-            BlockValidationErrors::InvalidUtreexoProof => {
+            BlockValidationErrors::InvalidUtreexoProof
+            | BlockValidationErrors::MalformedUtreexoProof => {
                 self.blocks
                     .insert(hash, InflightBlock::new(block, block_peer));
 
@@ -399,8 +400,17 @@ where
             | BlockValidationErrors::EmptyBlock
             | BlockValidationErrors::BadBip34
             | BlockValidationErrors::BIP94TimeWarp
+            | BlockValidationErrors::TimeTooOld
+            | BlockValidationErrors::DuplicateInvalidBlock
+            | BlockValidationErrors::BadPrevBlock
+            | BlockValidationErrors::BadDifficultyBits
+            | BlockValidationErrors::BadBlockVersion
+            | BlockValidationErrors::BadSignetBlockSignature
+            | BlockValidationErrors::TooManySigOps
+            | BlockValidationErrors::MultipleCoinbase
             | BlockValidationErrors::UnspendableUTXO
             | BlockValidationErrors::NonFinalTransaction
+            | BlockValidationErrors::UnsatisfiedSequenceLocks
             | BlockValidationErrors::CoinbaseNotMatured => {
                 try_and_log!(self.chain.invalidate_block(hash));
 
@@ -410,12 +420,23 @@ where
 
             // This block's txdata doesn't match the txid or wtxid merkle root. This can be a
             // mutated block, so we can't invalidate it since the original txdata may be valid.
-            BlockValidationErrors::BadMerkleRoot | BlockValidationErrors::BadWitnessCommitment => {
-                Some(block_peer)
-            }
+            BlockValidationErrors::BadMerkleRoot
+            | BlockValidationErrors::BadWitnessCommitment
+            | BlockValidationErrors::DuplicateTransactions
+            | BlockValidationErrors::SixtyFourByteTransaction
+            | BlockValidationErrors::BadWitnessNonceSize
+            | BlockValidationErrors::UnexpectedWitness => Some(block_peer),
+
+            // The block may become valid as our clock advances, so it isn't invalid and the
+            // peer isn't misbehaving.
+            BlockValidationErrors::TimeTooNew => None,
+
+            // We already know this block, so there's nothing to invalidate and nobody to blame
+            BlockValidationErrors::DuplicateBlock => None,
 
             // We've tried to connect a block that doesn't extend the tip.
             BlockValidationErrors::BlockExtendsAnOrphanChain
+            | BlockValidationErrors::PrevBlockNotFound
             | BlockValidationErrors::BlockDoesntExtendTip => {
                 self.last_block_request = self.chain.get_validation_index().unwrap_or(0);
 


### PR DESCRIPTION
Adds a general acceptance test that drives fabricated blocks through the public entry points (`accept_header` then `connect_block`) and asserts that the reported error always comes from the earliest validation stage:

This test is EXPECTED TO FAIL on the current ordering: `connect_block` validates the block transactions before verifying the utreexo proof, so at stage 4 it reports a transaction error (the missing UTXO) instead of the accumulator error. Verifying the proof before transaction/script validation is what makes this pass.


