### PR TITLE
improve mempool initialization and transaction admission logging

### DIFF
--- a/crates/floresta-mempool/src/mempool.rs
+++ b/crates/floresta-mempool/src/mempool.rs
@@ -23,6 +23,7 @@ use floresta_chain::pruned_utreexo::consensus::Consensus;
 use floresta_domain::mempool::MempoolBase;
 use floresta_domain::mempool::MempoolError;
 use tracing::debug;
+use tracing::info;
 
 /// A short transaction id that we use to identify transactions in the mempool.
 ///
@@ -184,31 +185,36 @@ impl MempoolBase for Mempool {
     ///  - If either vIn or vOut are empty
     ///  - If any script is larger than the maximum allowed size
     fn accept_to_mempool(&mut self, transaction: Transaction) -> Result<(), MempoolError> {
-        debug!(
-            "Accepting {} to mempool {:?}",
-            transaction.compute_txid(),
-            self.transactions
-        );
+        let txid = transaction.compute_txid();
+        debug!("Received transaction for mempool admission txid={txid}");
+
+        let log_rejection = |error: MempoolError| {
+            debug!("Transaction rejected from mempool txid={txid} reason={error}");
+            error
+        };
+
+        let short_txid = self.hasher.hash_one(txid);
+
+        // Duplicate submissions are successful no-ops, even when the mempool is full.
+        if self.transactions.contains_key(&short_txid) {
+            debug!("Transaction already present in mempool txid={txid}");
+            return Ok(());
+        }
 
         // Make sure our mempool has space
         let tx_size = transaction.total_size();
         if self.mempool_size + tx_size > self.max_mempool_size {
-            return Err(MempoolError::FullMempool);
-        }
-
-        let short_txid = self.hasher.hash_one(transaction.compute_txid());
-
-        // Checks if we don't have this tx already
-        if self.transactions.contains_key(&short_txid) {
-            return Ok(());
+            return Err(log_rejection(MempoolError::FullMempool));
         }
 
         // Perform context-free consensus checks
         Consensus::check_transaction_context_free(&transaction)
-            .map_err(MempoolError::ConsensusValidation)?;
+            .map_err(MempoolError::ConsensusValidation)
+            .map_err(&log_rejection)?;
 
         // Make sure transaction won't conflict with other mempool transaction
-        self.check_for_conflicts(&transaction)?;
+        self.check_for_conflicts(&transaction)
+            .map_err(&log_rejection)?;
 
         // List dependants for this transaction
         let depends = self.find_mempool_depends(&transaction);
@@ -228,6 +234,7 @@ impl MempoolBase for Mempool {
             },
         );
         self.mempool_size += tx_size;
+        debug!("Transaction accepted into mempool txid={txid} transaction_size={tx_size}");
 
         Ok(())
     }
@@ -242,6 +249,8 @@ impl Mempool {
         let d = rand::random();
 
         let hasher = ahash::RandomState::with_seeds(a, b, c, d);
+
+        info!("Mempool initialized max_size_bytes={max_mempool_size}");
 
         Self {
             transactions: HashMap::new(),
@@ -477,6 +486,25 @@ mod tests {
         }
 
         assert_eq!(mempool.transactions.len(), len);
+    }
+
+    #[test]
+    fn test_duplicate_is_accepted_when_mempool_is_full() {
+        let transaction = build_transactions(1, false)
+            .pop()
+            .expect("expected one transaction");
+        let transaction_size = transaction.total_size();
+        let mut mempool = Mempool::new(transaction_size);
+
+        mempool
+            .accept_to_mempool(transaction.clone())
+            .expect("first submission should fill the mempool");
+        mempool
+            .accept_to_mempool(transaction)
+            .expect("duplicate submission should be a successful no-op");
+
+        assert_eq!(mempool.transactions.len(), 1);
+        assert_eq!(mempool.mempool_size, transaction_size);
     }
 
     #[test]

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -33,6 +33,7 @@ use floresta_common::try_and_log;
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
 #[cfg(feature = "compact-filters")]
 use floresta_compact_filters::network_filters::NetworkFilters;
+use floresta_domain::mempool::MempoolBase;
 use floresta_electrum::electrum_protocol::ElectrumServer;
 use floresta_electrum::electrum_protocol::client_accept_loop;
 use floresta_mempool::Mempool;
@@ -356,11 +357,16 @@ impl Florestad {
         Ok(sock)
     }
 
-    /// Actually runs florestad, spawning all modules and waiting until
-    /// someone asks to stop.
+    /// Initializes the daemon and starts its background services.
     ///
-    /// This function will return an error if the configured data directory path is not an
-    /// **existing and writable directory**, or cannot be validated as such.
+    /// This loads the wallet and chain state, constructs the P2P and Electrum services and spawns
+    /// their asynchronous tasks. The method returns after startup completes and the services continue
+    /// running until a shutdown is requested.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data directory is invalid or if a required database, service,
+    /// listener or TLS configuration cannot be initialized.
     pub async fn start(&self) -> Result<(), FlorestadError> {
         let datadir: &Path = self.config.datadir.as_ref();
 
@@ -370,6 +376,8 @@ impl Florestad {
         info!("Loading watch-only wallet");
         let wallet = self.setup_wallet()?;
 
+        // Restore the validated chainstate from persistent storage.
+        // The `Arc` allows the P2P and API services to share the same chainstate.
         info!("Loading blockchain database");
         let blockchain_state = Arc::new(Self::load_chain_state(
             datadir,
@@ -427,13 +435,19 @@ impl Florestad {
 
         let kill_signal = self.stop_signal.clone();
 
-        // Chain Provider (p2p)
+        // Create a single in-memory mempool shared by the node and its peer tasks.
+        // The asynchronous mutex provides exclusive mutable access,
+        // while the `Arc` provides shared ownership.
+        let mempool: Arc<tokio::sync::Mutex<dyn MempoolBase>> = Arc::new(tokio::sync::Mutex::new(
+            Mempool::new(DEFAULT_MEMPOOL_MAX_SIZE_BYTES),
+        ));
+
+        // Construct the P2P node with shared access to the chain state and mempool so it can
+        // validate blocks and serve or broadcast unconfirmed transactions.
         let chain_provider = UtreexoNode::<_, RunningNode>::new(
             config,
             blockchain_state.clone(),
-            Arc::new(tokio::sync::Mutex::new(Mempool::new(
-                DEFAULT_MEMPOOL_MAX_SIZE_BYTES,
-            ))),
+            mempool,
             cfilters.clone(),
             kill_signal.clone(),
             AddressMan::new(None, &ReachableNetworks::SUPPORTED),
@@ -595,12 +609,13 @@ impl Florestad {
         // Electrum Server's main loop.
         task::spawn(electrum_server.main_loop());
 
-        // Chain provider
         let (sender, receiver) = tokio::sync::oneshot::channel();
 
         let mut recv = self.stop_notify.lock().unwrap();
         *recv = Some(receiver);
 
+        // Spawn the primary node task, which manages peer connections, chain synchronization,
+        // block processing and transaction relay.
         task::spawn(chain_provider.run(sender));
 
         // Metrics

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -295,6 +295,16 @@ where
         Ok(true)
     }
 
+    /// Runs the P2P node through initial synchronization and normal operation.
+    ///
+    /// The node initializes its peers, selects the best header chain, optionally starts historical
+    /// block backfill and catches the validated chain state up to the network tip. It then enters
+    /// the [`RunningNode`] event loop, where it processes peer and user messages and performs
+    /// periodic maintenance until shutdown is requested.
+    ///
+    /// On an orderly shutdown, the node closes its peer connections, persists its state and uses
+    /// `stop_signal` to notify the owner that shutdown is complete. If startup terminates early,
+    /// the sender is dropped and the corresponding receiver is closed.
     pub async fn run(mut self, stop_signal: tokio::sync::oneshot::Sender<()>) {
         try_and_warn!(self.init_peers());
 


### PR DESCRIPTION
Improves mempool initialization and observability by making the daemon’s shared mempool dependency explicit and documenting its ownership across node and peer tasks. It also adds focused logging for transaction admission attempts, duplicates, rejection reasons and successful admissions with size information, replacing the previous full-mempool dump.

Closes #1312 