### PR TITLE
test: wallet idempotency (fail-intended)

### DIFF
--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -872,6 +872,14 @@ mod test {
     const BLOCK_FIRST_UTXO: &str = "00000020b4f594a390823c53557c5a449fa12413cbbae02be529c11c4eb320ff8e000000dd1211eb35ca09dc0ee519b0f79319fae6ed32c66f8bbf353c38513e2132c435474d81633c4b011e195a220002010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0403edce01feffffff028df2052a0100000016001481113cad52683679a83e76f76f84a4cfe36f75010000000000000000776a24aa21a9ed67863b4f356b7b9f3aab7a2037615989ef844a0917fb0a1dcd6c23a383ee346b4c4fecc7daa2490047304402203768ff10a948a2dd1825cc5a3b0d336d819ea68b5711add1390b290bf3b1cba202201d15e73791b2df4c0904fc3f7c7b2f22ab77762958e9bc76c625138ad3a04d290100012000000000000000000000000000000000000000000000000000000000000000000000000002000000000101be07b18750559a418d144f1530be380aa5f28a68a0269d6b2d0e6ff3ff25f3200000000000feffffff0240420f00000000001600142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a326f55d94c060000160014c2ed86a626ee74d854a12c9bb6a9b72a80c0ddc50247304402204c47f6783800831bd2c75f44d8430bf4d962175349dc04d690a617de6c1eaed502200ffe70188a6e5ad89871b2acb4d0f732c2256c7ed641d2934c6e84069c792abc012103ba174d9c66078cf813d0ac54f5b19b5fe75104596bdd6c1731d9436ad8776f41ecce0100";
     const BLOCK_SPEND: &str = "000000203ea734fa2c8dee7d3194878c9eaf6e83a629f79b3076ec857793995e01010000eb99c679c0305a1ac0f5eb2a07a9f080616105e605b92b8c06129a2451899225ab5481633c4b011e0b26720102020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0403efce01feffffff026ef2052a01000000225120a1a1b1376d5165617a50a6d2f59abc984ead8a92df2b25f94b53dbc2151824730000000000000000776a24aa21a9ed1b4c48a7220572ff3ab3d2d1c9231854cb62542fbb1e0a4b21ebbbcde8d652bc4c4fecc7daa2490047304402204b37c41fce11918df010cea4151737868111575df07f7f2945d372e32a6d11dd02201658873a8228d7982df6bdbfff5d0cad1d6f07ee400e2179e8eaad8d115b7ed001000120000000000000000000000000000000000000000000000000000000000000000000000000020000000001017ca523c5e6df0c014e837279ab49be1676a9fe7571c3989aeba1e5d534f4054a0000000000fdffffff01d2410f00000000001600142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a02473044022071b8583ba1f10531b68cb5bd269fb0e75714c20c5a8bce49d8a2307d27a082df022069a978dac00dd9d5761aa48c7acc881617fa4d2573476b11685596b17d437595012103b193d06bd0533d053f959b50e3132861527e5a7a49ad59c5e80a265ff6a77605eece0100";
 
+    /// The p2wpkh scriptPubKey of `tb1q9d4zjf92nvd3zhg6cvyckzaqumk4zre26x02q9`, the
+    /// address [get_test_address] hands out.
+    ///
+    /// It is the address both fixtures above pay: `BLOCK_FIRST_UTXO` creates its
+    /// 1_000_000 sats utxo, and `BLOCK_SPEND` spends that utxo and pays 999_890
+    /// sats back to it.
+    const TEST_ADDRESS_SPK: &str = "00142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a";
+
     fn deserialize_from_str<T: Decodable>(thing: &str) -> T {
         let hex = Vec::from_hex(thing).unwrap();
         deserialize(&hex).unwrap()
@@ -1059,8 +1067,7 @@ mod test {
         let block1 = deserialize_from_str(BLOCK_FIRST_UTXO);
         let block2 = deserialize_from_str(BLOCK_SPEND);
 
-        let spk = ScriptBuf::from_hex("00142b6a2924aa9b1b115d1ac3098b0ba0e6ed510f2a")
-            .expect("Valid address");
+        let spk = ScriptBuf::from_hex(TEST_ADDRESS_SPK).expect("Valid address");
         let script_hash = get_spk_hash(&spk);
         let cache = get_test_cache();
 
@@ -1074,5 +1081,61 @@ mod test {
 
         assert_eq!(address.transactions.len(), 2);
         assert_eq!(address.utxos.len(), 1);
+    }
+
+    /// Applying the same block twice must leave the cache exactly as one pass did.
+    ///
+    /// This is not hypothetical: a rescan walking over a block the wallet already
+    /// saw hands the very same block to [AddressCache::block_process] again.
+    #[test]
+    fn test_process_same_block_twice_is_idempotent() {
+        let block = deserialize_from_str(BLOCK_FIRST_UTXO);
+
+        let spk = ScriptBuf::from_hex(TEST_ADDRESS_SPK).expect("Valid address");
+        let script_hash = get_spk_hash(&spk);
+        let cache = get_test_cache();
+
+        cache.cache_address(spk);
+
+        cache.block_process(&block, 118510);
+
+        // The block pays us a single 1_000_000 sats output.
+        assert_eq!(cache.get_address_balance(&script_hash), Some(1_000_000));
+        assert_eq!(cache.get_address_utxos(&script_hash).unwrap().len(), 1);
+
+        cache.block_process(&block, 118510);
+
+        assert_eq!(cache.get_address_balance(&script_hash), Some(1_000_000));
+        assert_eq!(cache.get_address_utxos(&script_hash).unwrap().len(), 1);
+        assert_eq!(cache.get_address_history(&script_hash).unwrap().len(), 1);
+    }
+
+    /// A replayed block must not corrupt the utxo set for the blocks that follow it.
+    ///
+    /// `BLOCK_FIRST_UTXO` pays us 1_000_000 sats and `BLOCK_SPEND` spends that utxo,
+    /// paying 999_890 sats back to us. Replaying the first block must not change
+    /// where we land after the second one.
+    #[test]
+    fn test_replayed_block_does_not_corrupt_a_later_spend() {
+        let block1 = deserialize_from_str(BLOCK_FIRST_UTXO);
+        let block2 = deserialize_from_str(BLOCK_SPEND);
+
+        let spk = ScriptBuf::from_hex(TEST_ADDRESS_SPK).expect("Valid address");
+        let script_hash = get_spk_hash(&spk);
+        let cache = get_test_cache();
+
+        cache.cache_address(spk);
+
+        cache.block_process(&block1, 118510);
+        cache.block_process(&block1, 118510);
+        cache.block_process(&block2, 118511);
+
+        assert_eq!(cache.get_address_balance(&script_hash), Some(999_890));
+
+        // Only the output created by `BLOCK_SPEND` is still unspent. The utxo from
+        // `BLOCK_FIRST_UTXO` was spent and must not be listed anymore.
+        let utxos = cache.get_address_utxos(&script_hash).unwrap();
+        assert_eq!(utxos.len(), 1);
+        assert_eq!(utxos[0].0.value.to_sat(), 999_890);
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ markers = [
     "florestad: marks tests specific to the Florestad daemon",
     "rpc: marks tests focused on RPC calls",
     "p2p: marks tests related to peer-to-peer interactions",
+    "wallet: marks tests focused on the watch only wallet",
     "expensive: marks heavy-weight tests that only run when --run-expensive is passed",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,56 @@ def florestad_bitcoind_utreexod_with_chain(
     return _create_nodes_with_chain
 
 
+@pytest.fixture
+def florestad_bitcoind_utreexod_with_filters(
+    node_manager,
+) -> Callable[..., tuple[Node, Node, Node]]:
+    """
+    Factory fixture that builds a three node network able to serve compact block filters.
+
+    florestad keeps its default configuration, which already enables the filters, but
+    it downloads them from a peer and no daemon here serves them out of the box, so
+    bitcoind is started with its block filter index on. utreexod mines every block to
+    `WALLET_ADDRESS` and serves the utreexo proofs florestad needs in order to sync.
+
+    No descriptor is loaded, so florestad's wallet starts out empty.
+    """
+
+    def _create_nodes_with_filters(blocks: int = 20) -> tuple[Node, Node, Node]:
+        florestad_node = node_manager.add_node_default_args(variant=NodeType.FLORESTAD)
+        node_manager.run_node(florestad_node)
+
+        bitcoind_node = node_manager.add_node_extra_args(
+            variant=NodeType.BITCOIND,
+            extra_args=["-blockfilterindex=1", "-peerblockfilters=1"],
+        )
+        node_manager.run_node(bitcoind_node)
+
+        utreexod_node = node_manager.add_node_extra_args(
+            variant=NodeType.UTREEXOD,
+            extra_args=[
+                f"--miningaddr={WALLET_ADDRESS}",
+                "--utreexoproofindex",
+                "--prune=0",
+            ],
+        )
+        node_manager.run_node(utreexod_node)
+
+        utreexod_node.rpc.generate(blocks)
+
+        node_manager.connect_nodes(florestad_node, utreexod_node)
+        time.sleep(3)
+        node_manager.connect_nodes(bitcoind_node, utreexod_node)
+        time.sleep(1)
+        node_manager.connect_nodes(florestad_node, bitcoind_node)
+
+        node_manager.wait_for_sync_nodes()
+
+        return florestad_node, bitcoind_node, utreexod_node
+
+    return _create_nodes_with_filters
+
+
 @pytest.fixture(scope="class")
 def shared_florestad_bitcoind_utreexod_with_chain(
     shared_florestad_node,

--- a/tests/test_framework/electrum/base.py
+++ b/tests/test_framework/electrum/base.py
@@ -89,6 +89,24 @@ class BaseClient:
         else:
             self._conn = s
 
+    def read_line(self) -> str:
+        """
+        Read a single newline terminated message from the server.
+        """
+        response = b""
+        while True:
+            chunk = self.conn.recv(1)
+            if not chunk:
+                break
+            response += chunk
+            if b"\n" in response:
+                break
+
+        response = response.decode("utf-8").strip()
+        self.log.debug(response)
+
+        return response
+
     def request(self, method, params) -> object:
         """
         Request something to Floresta server
@@ -106,18 +124,19 @@ class BaseClient:
         self.log.debug(f"GET electrum://{mnt_point}?params={params}")
         self.conn.sendall(request.encode("utf-8") + b"\n")
 
-        response = b""
+        # The server pushes unsolicited notifications (a new block header, an
+        # updated script hash) over this same socket, so skip anything that is
+        # not a response before handing one back.
         while True:
-            chunk = self.conn.recv(1)
-            if not chunk:
-                break
-            response += chunk
-            if b"\n" in response:
-                break
-        response = response.decode("utf-8").strip()
-        self.log.debug(response)
+            response = self.read_line()
+            if not response:
+                raise ConnectionError("Electrum server closed the connection")
 
-        return json.loads(response)
+            message = json.loads(response)
+            if isinstance(message, dict) and "id" in message:
+                return message
+
+            self.log.debug(f"Skipping electrum notification: {response}")
 
     def batch_request(self, calls: List[Tuple[str, List[Any]]]) -> object:
         """
@@ -137,15 +156,14 @@ class BaseClient:
         )
         self.conn.sendall(json.dumps(request_list).encode("utf-8") + b"\n")
 
-        response = b""
+        # As in `request`, drop any notification that lands before the batch
+        # response, which is the only message coming back as a list.
         while True:
-            chunk = self.conn.recv(1)
-            if not chunk:
-                break
-            response += chunk
-            if b"\n" in response:
-                break
+            response = self.read_line()
+            if not response:
+                raise ConnectionError("Electrum server closed the connection")
 
-        response = response.decode("utf-8").strip()
-        self.log.debug(response)
-        return response
+            if isinstance(json.loads(response), list):
+                return response
+
+            self.log.debug(f"Skipping electrum notification: {response}")

--- a/tests/test_framework/electrum/client.py
+++ b/tests/test_framework/electrum/client.py
@@ -9,7 +9,14 @@ This should be conformant to the ElectrumX specs.
 More here: https://electrumx.readthedocs.io/en/latest/protocol-methods.html
 """
 
+import hashlib
+import time
+
 from test_framework.electrum.base import BaseClient
+from test_framework.util import wait_until
+
+# How often the wallet is polled while waiting for a rescan to land.
+WALLET_POLL_INTERVAL = 1
 
 
 # pylint: disable=too-many-public-methods
@@ -165,3 +172,55 @@ class ElectrumClient(BaseClient):
         Only the first server.version() message is accepted.
         """
         return self.request("server.version", ["test-client", "1.2"])
+
+    @staticmethod
+    def script_hash(script_pubkey: str) -> str:
+        """
+        Build the Electrum script hash of a scriptPubKey: its sha256, byte reversed.
+        """
+        return hashlib.sha256(bytes.fromhex(script_pubkey)).digest()[::-1].hex()
+
+    def wallet_state(self, script_hash: str) -> tuple:
+        """
+        Return the confirmed balance and the utxo count held for a script hash.
+
+        The balance is `None` while the address is not cached by the wallet.
+        """
+        balance = self.get_balance(script_hash)["result"]["confirmed"]
+        utxos = self.list_unspent(script_hash)["result"]
+
+        return balance, len(utxos)
+
+    def wait_for_wallet_funded(self, script_hash: str, timeout: int = 60) -> tuple:
+        """
+        Poll the wallet until it holds a positive balance for a script hash.
+
+        Raises a `TimeoutError` when the balance never shows up.
+        """
+        wait_until(
+            lambda: self.wallet_state(script_hash)[0],
+            timeout=timeout,
+            interval=WALLET_POLL_INTERVAL,
+            error_msg=f"wallet was never funded for script hash {script_hash}",
+        )
+
+        return self.wallet_state(script_hash)
+
+    def wait_for_wallet_change(
+        self, script_hash: str, state: tuple, timeout: int = 30
+    ) -> tuple:
+        """
+        Poll the wallet until its state for a script hash moves away from `state`.
+
+        Returns `state` untouched when nothing ever moved, which is what lets a
+        caller assert that some operation left the wallet alone.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            current = self.wallet_state(script_hash)
+            if current != state:
+                return current
+
+            time.sleep(WALLET_POLL_INTERVAL)
+
+        return state

--- a/tests/wallet/wallet_idempotency.py
+++ b/tests/wallet/wallet_idempotency.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+wallet_idempotency.py
+
+This functional test checks that handing the wallet blocks it already processed
+does not credit them twice, driving the replay through `rescanblockchain`.
+"""
+
+import pytest
+
+from test_framework.constants import WALLET_ADDRESS, WALLET_DESCRIPTOR_EXTERNAL
+from test_framework.electrum.client import ElectrumClient
+
+BLOCKS = 20
+
+
+@pytest.mark.wallet
+def test_rescanblockchain_does_not_double_count(
+    setup_logging, florestad_bitcoind_utreexod_with_filters
+):
+    """
+    Rescanning blocks the wallet already knows must leave its balance untouched.
+    """
+    log = setup_logging
+    florestad, bitcoind, _ = florestad_bitcoind_utreexod_with_filters(BLOCKS)
+
+    script_pubkey = bitcoind.rpc.perform_request("validateaddress", [WALLET_ADDRESS])[
+        "scriptPubKey"
+    ]
+    script_hash = ElectrumClient.script_hash(script_pubkey)
+
+    # No descriptor was loaded, so the wallet ignored every block it just saw.
+    assert florestad.electrum.wallet_state(script_hash) == (None, 0)
+
+    # Loading the descriptor kicks off a rescan driven by the block filters. The
+    # balance showing up proves the filters are in place, which is what makes the
+    # second half of this test meaningful instead of vacuously green.
+    log.info("Loading the wallet descriptor and waiting for the filter rescan...")
+    florestad.rpc.load_descriptor(WALLET_DESCRIPTOR_EXTERNAL)
+
+    balance, utxo_count = florestad.electrum.wait_for_wallet_funded(script_hash)
+    log.info(f"Wallet found {utxo_count} utxos worth {balance} sats")
+
+    # Rescanning the same range hands the wallet blocks it already processed.
+    log.info("Rescanning the very same range...")
+    assert florestad.rpc.perform_request("rescanblockchain", [1, BLOCKS]) is True
+
+    state = (balance, utxo_count)
+    assert florestad.electrum.wait_for_wallet_change(script_hash, state) == state


### PR DESCRIPTION
### Description and Notes

This PR adds a new test exercising a bug.

If we have funds on a block and we process it twice, the funds get doubled. 

This pr exercises it both on watch-only side and integration side.

On the floresta-watch-only side: unit test exercising directly via process_block.

On the integration side: Integration test exercising it with rescan, the path were a block is expected to be processed twice.

### How to verify the changes you have done?

```bash
$ cargo test -p floresta-watch-only test_replayed_block_does_not_corrupt_a_later_spend

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/floresta_watch_only-a6ec68b1667898df)

running 1 test
test test::test_replayed_block_does_not_corrupt_a_later_spend ... FAILED

failures:

---- test::test_replayed_block_does_not_corrupt_a_later_spend stdout ----

thread 'test::test_replayed_block_does_not_corrupt_a_later_spend' (6119272) panicked at crates/floresta-watch-only/src/lib.rs:1133:9:
assertion `left == right` failed
  left: Some(1999890)
 right: Some(999890)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test::test_replayed_block_does_not_corrupt_a_later_spend

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 25 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p floresta-watch-only --lib`

$ cargo test -p floresta-watch-only test_process_same_block_twice_is_idempotent
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/debug/deps/floresta_watch_only-a6ec68b1667898df)

running 1 test
test test::test_process_same_block_twice_is_idempotent ... FAILED

failures:

---- test::test_process_same_block_twice_is_idempotent stdout ----

thread 'test::test_process_same_block_twice_is_idempotent' (6119139) panicked at crates/floresta-watch-only/src/lib.rs:1108:9:
assertion `left == right` failed
  left: Some(2000000)
 right: Some(1000000)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test::test_process_same_block_twice_is_idempotent

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 25 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p floresta-watch-only --lib`
```

And

```bash
$ just test-functional-run '-k wallet'

bash tests/run.sh -k wallet
Cleaning up test directories before running tests...
      Built floresta-functional-tests @ file:///Users/jaoleal/Floresta
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
================================================================= test session starts =================================================================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/jaoleal/Floresta
configfile: pyproject.toml
testpaths: tests/
plugins: xdist-3.8.0
4 workers [3 items]
scheduling tests via LoadScopeScheduling

tests/wallet/wallet_idempotency.py::test_rescanblockchain_does_not_double_count
tests/florestad/wallet.py::test_wallet_conf
[gw1] [ 33%] FAILED tests/wallet/wallet_idempotency.py::test_rescanblockchain_does_not_double_count
[gw0] [ 66%] PASSED tests/florestad/wallet.py::test_wallet_conf
tests/florestad/wallet.py::test_wallet_flags
[gw0] [100%] PASSED tests/florestad/wallet.py::test_wallet_flags

====================================================================== FAILURES =======================================================================
_____________________________________________________ test_rescanblockchain_does_not_double_count _____________________________________________________
[gw1] darwin -- Python 3.12.13 /Users/jaoleal/Floresta/.venv/bin/python3
tests/wallet/wallet_idempotency.py:50: in test_rescanblockchain_does_not_double_count
    assert florestad.electrum.wait_for_wallet_change(script_hash, state) == state
E   AssertionError: assert (200000000000, 40) == (100000000000, 20)
E
E     At index 0 diff: 200000000000 != 100000000000
E
E     Full diff:
E       (
E     -     100000000000,
E     ?     ^...
E
E     ...Full output truncated (7 lines hidden), use '-vv' to show
=============================================================== short test summary info ===============================================================
FAILED tests/wallet/wallet_idempotency.py::test_rescanblockchain_does_not_double_count - AssertionError: assert (200000000000, 40) == (100000000000, 20)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! xdist.dsession.Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================= 1 failed, 2 passed in 146.00s (0:02:25) =======================================================
error: recipe `test-functional-run` failed on line 58 with exit code 2
```

~~Will write a issue pointing the culprit, until there, the bug is confirmed.~~

We already have a issue for it #1216 