### PR TITLE
fix(chain): drop the assumeutreexo assumption when a reorg makes it wrong

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -2526,4 +2526,69 @@ mod test {
             "a reorg above the validation index must not change the accumulator",
         );
     }
+
+    #[test]
+    fn a_failed_reorg_leaves_the_chain_state_untouched() {
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+
+        let parse_blocks = |blocks: &[&str]| {
+            blocks
+                .iter()
+                .map(|s| deserialize_hex(s).unwrap())
+                .collect::<Vec<Block>>()
+        };
+
+        let short_chain = parse_blocks(&blocks[0]);
+        let long_chain = parse_blocks(&blocks[1]);
+
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded, None);
+
+        for block in &short_chain {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        for block in short_chain.iter().take(4) {
+            chain
+                .connect_block(block, Proof::default(), HashMap::new(), Vec::new())
+                .unwrap();
+        }
+
+        // `mark_chain_as_assumed` takes a whole range as `FullyValid` but only saves the roots
+        // for genesis, so every assumed block above our validation index has none. This is the
+        // state an assume-utreexo node runs in, and a reorg landing on one of those blocks
+        // can't find the accumulator it has to publish.
+        let acc = chain.acc();
+        chain
+            .mark_chain_as_assumed(acc.clone(), short_chain[9].block_hash())
+            .unwrap();
+
+        assert!(chain.get_roots_for_block(5).unwrap().is_none());
+
+        let best_block = chain.get_best_block().unwrap();
+        let validation_index = chain.get_validation_index().unwrap();
+        let block_after_fork = chain.get_block_hash(6).unwrap();
+
+        // The long chain forks at block 5, one of the assumed blocks, so this reorg fails when
+        // it looks for the accumulator that goes with the new validation index.
+        let error = long_chain
+            .iter()
+            .find_map(|block| chain.accept_header(block.header).err());
+
+        assert!(
+            matches!(error, Some(BlockchainError::BadValidationIndex)),
+            "expected the reorg to fail with BadValidationIndex, got {error:?}",
+        );
+
+        // A reorg that fails must not leave half of itself behind: the branches keep the state
+        // they had, and the tip, validation index and accumulator still describe the old chain.
+        assert_eq!(chain.get_best_block().unwrap(), best_block);
+        assert_eq!(
+            chain.get_validation_index().ok(),
+            Some(validation_index),
+            "the validation index must still point to a block we validated",
+        );
+        assert_eq!(chain.get_block_hash(6).unwrap(), block_after_fork);
+        assert_eq!(chain.acc(), acc);
+    }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1298,16 +1298,15 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
         assumed_hash: BlockHash,
     ) -> Result<bool, BlockchainError> {
         let assumed_header = self.get_disk_block_header(&assumed_hash)?;
-        let mut curr_header = assumed_header;
+        let mut curr_header = self.get_ancestor(&assumed_header)?;
 
-        while let Ok(header) = self.get_disk_block_header(&curr_header.block_hash()) {
-            if self.is_genesis(&header) {
-                break;
-            }
-
-            let height = header.try_height()?;
-            self.update_header(&DiskBlockHeader::FullyValid(*header, height))?;
-            curr_header = self.get_ancestor(&header)?;
+        // Every block below the assumed one is `AssumedValid`, not `FullyValid`: we take it as
+        // valid, but we never validated it and we hold no roots for it. That difference is what
+        // tells an invalidated assumption apart from a store that drifted.
+        while !self.is_genesis(&curr_header) {
+            let height = curr_header.try_height()?;
+            self.update_header(&DiskBlockHeader::AssumedValid(*curr_header, height))?;
+            curr_header = self.get_ancestor(&curr_header)?;
         }
 
         self.update_view(assumed_header.try_height()?, &assumed_header, acc.clone())?;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -428,13 +428,20 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         ))
     }
 
-    /// Returns the acc we must validate from after reorging to `fork_point`.
-    fn reorg_acc(&self, fork_point: &BlockHeader) -> Result<Stump, BlockchainError> {
+    /// Returns the acc we must validate from after reorging, given the new `validation_index`.
+    fn reorg_acc(&self, validation_index: BlockHash) -> Result<Stump, BlockchainError> {
         let height = self
-            .get_block_height(&fork_point.block_hash())?
+            .get_block_height(&validation_index)?
             .ok_or(BlockchainError::BlockNotPresent)?;
 
-        Ok(self.get_roots_for_block(height)?.unwrap_or_default())
+        // Genesis is the only block we take as valid without ever validating it, so it's the only
+        // one that legitimately has no roots saved. Its accumulator is the empty one.
+        if height == 0 {
+            return Ok(Stump::new());
+        }
+
+        self.get_roots_for_block(height)?
+            .ok_or(BlockchainError::BadValidationIndex)
     }
 
     // This method should only be called after we validate the new branch
@@ -447,7 +454,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
 
         let validation_index = self.get_last_valid_block(&new_tip)?;
         let depth = self.get_chain_depth(&new_tip)?;
-        let acc = self.reorg_acc(&fork_point)?;
+        let acc = self.reorg_acc(validation_index)?;
 
         self.change_active_chain(&new_tip, validation_index, depth, acc);
 

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -449,12 +449,12 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let current_best_block = self.get_block_header(&self.get_best_block()?.1)?;
         let fork_point = self.find_fork_point(&new_tip)?;
 
-        self.mark_chain_as_inactive(&current_best_block, fork_point.block_hash())?;
-        self.mark_chain_as_active(&new_tip, fork_point.block_hash())?;
-
         let validation_index = self.get_last_valid_block(&new_tip)?;
         let depth = self.get_chain_depth(&new_tip)?;
         let acc = self.reorg_acc(validation_index)?;
+
+        self.mark_chain_as_inactive(&current_best_block, fork_point.block_hash())?;
+        self.mark_chain_as_active(&new_tip, fork_point.block_hash())?;
 
         self.change_active_chain(&new_tip, validation_index, depth, acc);
 

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1609,6 +1609,7 @@ mod test {
     use crate::FlatChainStoreConfig;
     use crate::extensions::WorkExt;
     use crate::prelude::HashMap;
+    use crate::pruned_utreexo::IBDState;
     use crate::pruned_utreexo::consensus::Consensus;
     use crate::pruned_utreexo::error::BlockValidationErrors;
     use crate::pruned_utreexo::utxo_data::UtxoData;
@@ -2701,5 +2702,72 @@ mod test {
             acc,
             "a restart must not throw the assumed accumulator away",
         );
+    }
+
+    #[test]
+    fn a_reorg_into_the_assumed_range_drops_the_assumption() {
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+
+        let parse_blocks = |blocks: &[&str]| {
+            blocks
+                .iter()
+                .map(|s| deserialize_hex(s).unwrap())
+                .collect::<Vec<Block>>()
+        };
+
+        let short_chain = parse_blocks(&blocks[0]);
+        let long_chain = parse_blocks(&blocks[1]);
+
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded, None);
+
+        for block in &short_chain {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        // Assume the chain up to block 10, the way a node with `assumeutreexo` starts.
+        let acc = Stump {
+            leaves: 42,
+            roots: vec![BitcoinNodeHash::Some([1; 32])],
+        };
+        chain
+            .mark_chain_as_assumed(acc.clone(), short_chain[9].block_hash())
+            .unwrap();
+
+        assert_eq!(chain.get_validation_index().unwrap(), 10);
+        assert_eq!(chain.acc(), acc);
+
+        // The long chain forks at block 5, inside the assumed range. That accumulator describes
+        // a chain that is not the best one anymore, and we validated nothing below block 10, so
+        // the assumption is void.
+        for block in &long_chain {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        // We follow the new chain, but we validate it from genesis with the empty accumulator.
+        assert_eq!(
+            chain.get_best_block().unwrap().1,
+            long_chain.last().unwrap().block_hash(),
+            "the new chain has more work, so it has to win",
+        );
+        assert_eq!(chain.get_validation_index().unwrap(), 0);
+        assert_eq!(
+            chain.acc(),
+            Stump::new(),
+            "the assumed accumulator belongs to a chain we abandoned",
+        );
+        assert_eq!(chain.ibd_state(), IBDState::DownloadingBlocks);
+
+        // No block of the new chain may claim to be valid or assumed, so the node downloads and
+        // validates every one of them again.
+        for height in 1..=chain.get_best_block().unwrap().0 {
+            let hash = chain.get_block_hash(height).unwrap();
+            let header = chain.get_disk_block_header(&hash).unwrap();
+
+            assert!(
+                matches!(header, DiskBlockHeader::HeadersOnly(_, _)),
+                "block {height} has to go back to `HeadersOnly`, but is stored as {header:?}",
+            );
+        }
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1297,7 +1297,8 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
         acc: Stump,
         assumed_hash: BlockHash,
     ) -> Result<bool, BlockchainError> {
-        let mut curr_header = self.get_disk_block_header(&assumed_hash)?;
+        let assumed_header = self.get_disk_block_header(&assumed_hash)?;
+        let mut curr_header = assumed_header;
 
         while let Ok(header) = self.get_disk_block_header(&curr_header.block_hash()) {
             if self.is_genesis(&header) {
@@ -1309,7 +1310,7 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
             curr_header = self.get_ancestor(&header)?;
         }
 
-        self.update_view(curr_header.try_height()?, &curr_header, acc.clone())?;
+        self.update_view(assumed_header.try_height()?, &assumed_header, acc.clone())?;
 
         let mut guard = write_lock!(self);
         guard.best_block.validation_index = assumed_hash;

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1593,6 +1593,7 @@ mod test {
     use floresta_common::assert_ok;
     use floresta_common::bhash;
     use rand::RngExt;
+    use rustreexo::node_hash::BitcoinNodeHash;
     use rustreexo::proof::Proof;
     use rustreexo::stump::Stump;
 
@@ -2590,5 +2591,73 @@ mod test {
         );
         assert_eq!(chain.get_block_hash(6).unwrap(), block_after_fork);
         assert_eq!(chain.acc(), acc);
+    }
+
+    #[test]
+    fn an_assumed_chain_finds_its_accumulator_again_after_a_restart() {
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+        let chain_blocks: Vec<Block> = blocks[0]
+            .iter()
+            .map(|s| deserialize_hex(s).unwrap())
+            .collect();
+
+        let test_id = rand::random::<u64>();
+        let path = format!("./tmp-db/{test_id}/");
+        let config = || FlatChainStoreConfig {
+            block_index_size: Some(DEFAULT_TEST_CHAINSTORE_SIZE),
+            headers_file_size: Some(DEFAULT_TEST_CHAINSTORE_SIZE),
+            fork_file_size: Some(TEST_FORK_FILE_SIZE),
+            cache_size: Some(10),
+            file_permission: Some(0o660),
+            path: path.clone().into(),
+        };
+
+        let acc = Stump {
+            leaves: 42,
+            roots: vec![BitcoinNodeHash::Some([1; 32])],
+        };
+
+        let chain = ChainState::open(
+            FlatChainStore::new(config()).unwrap(),
+            Network::Regtest,
+            AssumeValidArg::Hardcoded,
+        )
+        .unwrap();
+
+        for block in &chain_blocks {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        let assumed_hash = chain_blocks[9].block_hash();
+        chain
+            .mark_chain_as_assumed(acc.clone(), assumed_hash)
+            .unwrap();
+
+        // The roots have to sit at the height the validation index points to, because that's
+        // where `open` looks for them.
+        let assumed_height = chain.get_validation_index().unwrap();
+        assert_eq!(assumed_height, 10);
+        assert_eq!(
+            chain.get_roots_for_block(assumed_height).unwrap(),
+            Some(acc.clone())
+        );
+
+        chain.flush().unwrap();
+        drop(chain);
+
+        let chain = ChainState::open(
+            FlatChainStore::new(config()).unwrap(),
+            Network::Regtest,
+            AssumeValidArg::Hardcoded,
+        )
+        .unwrap();
+
+        assert_eq!(chain.get_validation_index().unwrap(), assumed_height);
+        assert_eq!(
+            chain.acc(),
+            acc,
+            "a restart must not throw the assumed accumulator away",
+        );
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -2595,6 +2595,49 @@ mod test {
     }
 
     #[test]
+    fn assuming_a_chain_marks_the_blocks_we_did_not_validate() {
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+        let chain_blocks: Vec<Block> = blocks[0]
+            .iter()
+            .map(|s| deserialize_hex(s).unwrap())
+            .collect();
+
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded, None);
+
+        for block in &chain_blocks {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        let acc = Stump {
+            leaves: 42,
+            roots: vec![BitcoinNodeHash::Some([1; 32])],
+        };
+        chain
+            .mark_chain_as_assumed(acc, chain_blocks[9].block_hash())
+            .unwrap();
+
+        // The assumed block is the only one we hold an accumulator for, so it is the one block
+        // of the range that is `FullyValid`.
+        let assumed = chain.get_block_hash(10).unwrap();
+        assert!(matches!(
+            chain.get_disk_block_header(&assumed).unwrap(),
+            DiskBlockHeader::FullyValid(_, 10)
+        ));
+
+        // We never validated the blocks below it, so none of them may claim we did.
+        for height in 1..10 {
+            let hash = chain.get_block_hash(height).unwrap();
+            let header = chain.get_disk_block_header(&hash).unwrap();
+
+            assert!(
+                matches!(header, DiskBlockHeader::AssumedValid(_, _)),
+                "block {height} is assumed, not validated, but is stored as {header:?}",
+            );
+        }
+    }
+
+    #[test]
     fn an_assumed_chain_finds_its_accumulator_again_after_a_restart() {
         let json_blocks = include_str!("../../testdata/test_reorg.json");
         let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -451,12 +451,67 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
 
         let validation_index = self.get_last_valid_block(&new_tip)?;
         let depth = self.get_chain_depth(&new_tip)?;
+
+        // A reorg that lands inside the assumed range makes the assumption wrong: we hold no
+        // accumulator that goes with the new validation index, and we never validated a block
+        // below it. So we drop the assumption instead of the reorg.
+        if self.is_assumed(&validation_index)? {
+            return self.drop_assumption(&new_tip, &current_best_block, &fork_point, depth);
+        }
+
         let acc = self.reorg_acc(validation_index)?;
 
         self.mark_chain_as_inactive(&current_best_block, fork_point.block_hash())?;
         self.mark_chain_as_active(&new_tip, fork_point.block_hash())?;
 
         self.change_active_chain(&new_tip, validation_index, depth, acc);
+
+        Ok(())
+    }
+
+    /// Whether we took this block as valid without ever validating it, as `assumeutreexo` does.
+    fn is_assumed(&self, block: &BlockHash) -> Result<bool, BlockchainError> {
+        Ok(matches!(
+            self.get_disk_block_header(block)?,
+            DiskBlockHeader::AssumedValid(_, _)
+        ))
+    }
+
+    /// Gives up an `assumeutreexo` assumption that a reorg made wrong.
+    ///
+    /// The assumed accumulator describes a chain we abandoned, and no block below the assumed
+    /// one holds roots of its own. The empty accumulator at genesis is the only state left that
+    /// we can trust, so we go back to it and validate the new chain from there.
+    fn drop_assumption(
+        &self,
+        new_tip: &BlockHeader,
+        old_tip: &BlockHeader,
+        fork_point: &BlockHeader,
+        depth: u32,
+    ) -> Result<(), BlockchainError> {
+        warn!(
+            "A reorg to {} made our assumeutreexo state wrong, validating from genesis",
+            new_tip.block_hash()
+        );
+
+        self.mark_chain_as_inactive(old_tip, fork_point.block_hash())?;
+        self.mark_chain_as_active(new_tip, fork_point.block_hash())?;
+
+        // `mark_chain_as_active` takes the new branch down to the fork point. Below it both
+        // branches share the assumed blocks, and those need the same treatment.
+        let mut header = *fork_point;
+        while !self.is_genesis(&header) {
+            let height = self
+                .get_block_height(&header.block_hash())?
+                .ok_or(BlockchainError::BlockNotPresent)?;
+
+            self.update_header(&DiskBlockHeader::HeadersOnly(header, height))?;
+            header = *self.get_ancestor(&header)?;
+        }
+
+        let genesis = self.get_block_hash(0)?;
+        self.change_active_chain(new_tip, genesis, depth, Stump::new());
+        self.update_ibd(IBDState::DownloadingBlocks);
 
         Ok(())
     }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -2394,6 +2394,7 @@ mod test {
         assert_eq!(fork_work, work);
         assert_eq!(work, expected_work);
     }
+
     fn connect_reorg_chains(
         chain: &ChainState<FlatChainStore>,
         short_chain: &[Block],
@@ -2468,5 +2469,54 @@ mod test {
         });
 
         assert_eq!(chain.get_validation_index().unwrap(), 16);
+    }
+
+    #[test]
+    fn reorg_above_the_validation_index_keeps_the_accumulator() {
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
+
+        let parse_blocks = |blocks: &[&str]| {
+            blocks
+                .iter()
+                .map(|s| deserialize_hex(s).unwrap())
+                .collect::<Vec<Block>>()
+        };
+
+        let short_chain = parse_blocks(&blocks[0]);
+        let long_chain = parse_blocks(&blocks[1]);
+
+        let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded, None);
+
+        // Take the headers all the way to the tip of the short chain, but only validate the
+        // first four blocks. The fork point, block 5, is left as `HeadersOnly`, which is the
+        // ordinary state during IBD: headers run ahead of block validation.
+        for block in &short_chain {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        for block in short_chain.iter().take(4) {
+            chain
+                .connect_block(block, Proof::default(), HashMap::new(), Vec::new())
+                .unwrap();
+        }
+
+        assert_eq!(chain.get_validation_index().unwrap(), 4);
+
+        let acc = chain.acc();
+        assert_ne!(acc, Stump::new(), "we validated four blocks");
+
+        // The long chain forks at block 5, above our validation index, so the reorg doesn't
+        // undo any validated block and must leave the accumulator alone.
+        for block in &long_chain {
+            chain.accept_header(block.header).unwrap();
+        }
+
+        assert_eq!(chain.get_validation_index().unwrap(), 4);
+        assert_eq!(
+            chain.acc(),
+            acc,
+            "a reorg above the validation index must not change the accumulator",
+        );
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -2555,13 +2555,12 @@ mod test {
                 .unwrap();
         }
 
-        // `mark_chain_as_assumed` takes a whole range as `FullyValid` but only saves the roots
-        // for genesis, so every assumed block above our validation index has none. This is the
-        // state an assume-utreexo node runs in, and a reorg landing on one of those blocks
-        // can't find the accumulator it has to publish.
+        // Mark the fork point as validated without saving any roots for it. A store can only
+        // reach this shape if it drifted, and it is the shape that makes `reorg_acc` fail: a
+        // reorg lands on a block that claims to be validated but has no accumulator to publish.
         let acc = chain.acc();
         chain
-            .mark_chain_as_assumed(acc.clone(), short_chain[9].block_hash())
+            .mark_block_as_valid(short_chain[4].block_hash())
             .unwrap();
 
         assert!(chain.get_roots_for_block(5).unwrap().is_none());
@@ -2570,8 +2569,8 @@ mod test {
         let validation_index = chain.get_validation_index().unwrap();
         let block_after_fork = chain.get_block_hash(6).unwrap();
 
-        // The long chain forks at block 5, one of the assumed blocks, so this reorg fails when
-        // it looks for the accumulator that goes with the new validation index.
+        // The long chain forks at block 5, so that broken header becomes the new validation
+        // index, and the reorg fails when it looks for the accumulator that goes with it.
         let error = long_chain
             .iter()
             .find_map(|block| chain.accept_header(block.header).err());


### PR DESCRIPTION
### Description and Notes

Fixes #1326.

**Draft: this PR stacks on #1320 and #1325.** The first six commits are theirs, and they drop out when those two merge. The last five commits are the ones to review here.

An `assumeutreexo` node holds no accumulator for any block below the assumed one. A reorg that forks below that block thus finds no roots for the new validation index, and `reorg_acc` fails with `BadValidationIndex`. The node keeps the chain with less work, and it bans each peer that sends the better chain.

`BadValidationIndex` is the wrong answer for that case. The store did not drift. The assumption became wrong. So:

- `mark_chain_as_assumed` marks the assumed range as `AssumedValid` instead of `FullyValid`. The variant already exists, and each reader handles it, but nothing wrote it. The assumed block itself stays `FullyValid`, because we do hold its accumulator.
- `reorg` checks whether the new validation index is `AssumedValid`. If it is, `drop_assumption` takes the new chain and puts each of its blocks back to `HeadersOnly`. It then points the validation index at genesis with the empty accumulator, and goes back to `IBDState::DownloadingBlocks`. The node then validates the new chain for itself.

`BadValidationIndex` keeps the case it is correct for: a `FullyValid` header with no roots. The test that covered that case, `a_failed_reorg_leaves_the_chain_state_untouched`, used the `assumeutreexo` shape to make `reorg_acc` fail, so it now builds that shape with `mark_block_as_valid` instead.

Suggest review per commit.

### How to verify the changes you have done?

Two new tests. Each one comes in the commit before the fix that it covers, and each one fails without that fix.

`assuming_a_chain_marks_the_blocks_we_did_not_validate` assumes a chain up to block 10, then makes sure that blocks 1 to 9 are `AssumedValid` and that block 10 is `FullyValid`. Without the fix, the test fails at block 1, which is `FullyValid`.

`a_reorg_into_the_assumed_range_drops_the_assumption` assumes a chain up to block 10, then accepts a chain that forks at block 5 and has more work. It makes sure that:

- the new chain is the best chain
- the validation index is 0 and the accumulator is empty
- the IBD state is `DownloadingBlocks`
- each block of the new chain is `HeadersOnly`

Without the fix, `accept_header` fails with `BadValidationIndex`.

I ran these commands:

```
cargo test -p floresta-chain --features flat-chainstore --lib
cargo clippy -p floresta-chain --features flat-chainstore --all-targets
cargo fmt --check
```

The tests give 100 passed and 0 failed. Clippy gives no warnings, and `cargo fmt --check` gives no changes.

### What this does not do

- No migration. A node that assumed a chain before this change has `FullyValid` blocks with no roots on disk. `is_assumed` is false for those, so a reorg into that range still ends in `BadValidationIndex`.
- `backfill` marks the assumed range with `mark_block_as_valid` after it validates it. That writes `FullyValid` and saves no roots, so a node with `backfill` on goes back to the same shape once the backfill task finishes.
- Root sets are keyed by height, and `reindex_chain` searches by height. After a reorg it can take roots that a block we abandoned left behind. That is a separate problem and needs its own issue.
