### PR TITLE
fix(wire): report block download progress on a time interval

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -31,7 +31,6 @@ use bitcoin::block::Header as BlockHeader;
 use floresta_common::prelude::*;
 use rustreexo::node_hash::BitcoinNodeHash;
 use rustreexo::stump::Stump;
-use tracing::info;
 
 use super::BlockchainInterface;
 use super::UpdatableChainstate;
@@ -184,13 +183,6 @@ impl PartialChainStateInner {
         };
 
         // ... If we came this far, we consider this block valid ...
-
-        if height % 10_000 == 0 {
-            info!(
-                "Downloading blocks: height={height} hash={}",
-                block.block_hash()
-            );
-        }
 
         self.update_state(height, acc);
 

--- a/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/running_ctx.rs
@@ -242,7 +242,7 @@ where
             }
         };
 
-        let backfill = UtreexoNode::<PartialChainState, SyncNode>::new(
+        let mut backfill = UtreexoNode::<PartialChainState, SyncNode>::new(
             self.config.clone(),
             chain,
             self.mempool.clone(),
@@ -251,6 +251,8 @@ where
             self.address_man.clone(),
         )
         .unwrap();
+
+        backfill.context.is_backfill = true;
 
         let datadir = self.config.datadir.clone();
         let outer_chain = self.chain.clone();

--- a/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
@@ -33,7 +33,22 @@ use crate::p2p_wire::peer::PeerMessages;
 ///
 /// see [node_context](crates/floresta-wire/src/p2p_wire/node_context.rs) and [node.rs](crates/floresta-wire/src/p2p_wire/node.rs) for more information.
 #[derive(Clone, Debug, Default)]
-pub struct SyncNode {}
+pub struct SyncNode {
+    /// The time of the last progress report. `None` before the first maintenance tick.
+    last_progress: Option<Instant>,
+
+    /// `true` if this node backfills the blocks that a previous run assumed valid.
+    ///
+    /// The IBD node and the backfill node download blocks at the same time, from different
+    /// ranges. The progress report must show which node sent it.
+    pub(crate) is_backfill: bool,
+}
+
+/// How often we report block download progress.
+///
+/// This interval is time-based, rather than height-based, so that we keep reporting even when
+/// throughput drops, which is exactly when a user needs to know whether we are stuck.
+const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 
 impl NodeContext for SyncNode {
     /// Get the required [services](ServiceFlags) for the [`SyncNode`].
@@ -132,6 +147,28 @@ where
         }
 
         self.request_blocks(range_blocks)
+    }
+
+    fn log_progress(&mut self, height: u32, target: u32) {
+        let now = Instant::now();
+
+        // Half a tick of tolerance, otherwise timer jitter often defers us to the next tick.
+        let interval = PROGRESS_LOG_INTERVAL - SyncNode::MAINTENANCE_TICK / 2;
+
+        let too_soon = self
+            .context
+            .last_progress
+            .is_some_and(|last| now.duration_since(last) < interval);
+
+        if too_soon {
+            return;
+        }
+        self.context.last_progress = Some(now);
+
+        match self.context.is_backfill {
+            true => info!(height, target, "Backfilling blocks"),
+            false => info!(height, target, "Downloading blocks"),
+        }
     }
 
     /// This function will periodically check our connections, to ensure that:
@@ -246,6 +283,8 @@ where
             self.chain.update_ibd(IBDState::Done);
             return LoopControl::Break;
         }
+
+        self.log_progress(validation_index, best_block);
 
         periodic_job!(
             self.last_connection => self.check_connections(),

--- a/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
+++ b/crates/floresta-wire/src/p2p_wire/node/sync_ctx.rs
@@ -34,21 +34,15 @@ use crate::p2p_wire::peer::PeerMessages;
 /// see [node_context](crates/floresta-wire/src/p2p_wire/node_context.rs) and [node.rs](crates/floresta-wire/src/p2p_wire/node.rs) for more information.
 #[derive(Clone, Debug, Default)]
 pub struct SyncNode {
-    /// The time of the last progress report. `None` before the first maintenance tick.
-    last_progress: Option<Instant>,
+    /// The time of the last progress report.
+    last_progress_report: Option<Instant>,
 
-    /// `true` if this node backfills the blocks that a previous run assumed valid.
-    ///
-    /// The IBD node and the backfill node download blocks at the same time, from different
-    /// ranges. The progress report must show which node sent it.
+    /// `true` if backfilling assumed valid blocks, `false` otherwise.
     pub(crate) is_backfill: bool,
 }
 
 /// How often we report block download progress.
-///
-/// This interval is time-based, rather than height-based, so that we keep reporting even when
-/// throughput drops, which is exactly when a user needs to know whether we are stuck.
-const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
+const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
 impl NodeContext for SyncNode {
     /// Get the required [services](ServiceFlags) for the [`SyncNode`].
@@ -152,23 +146,23 @@ where
     fn log_progress(&mut self, height: u32, target: u32) {
         let now = Instant::now();
 
-        // Half a tick of tolerance, otherwise timer jitter often defers us to the next tick.
-        let interval = PROGRESS_LOG_INTERVAL - SyncNode::MAINTENANCE_TICK / 2;
-
-        let too_soon = self
+        if self
             .context
-            .last_progress
-            .is_some_and(|last| now.duration_since(last) < interval);
-
-        if too_soon {
+            .last_progress_report
+            .is_some_and(|last| now.duration_since(last) < PROGRESS_LOG_INTERVAL)
+        {
             return;
         }
-        self.context.last_progress = Some(now);
 
-        match self.context.is_backfill {
-            true => info!(height, target, "Backfilling blocks"),
-            false => info!(height, target, "Downloading blocks"),
-        }
+        self.context.last_progress_report = Some(now);
+
+        let verb = if self.context.is_backfill {
+            "Backfilled"
+        } else {
+            "Downloaded"
+        };
+
+        info!(height, target, "{verb} blocks");
     }
 
     /// This function will periodically check our connections, to ensure that:


### PR DESCRIPTION
This PR introduces interval based **structured** logging to block download. Block download now reports on a **time** interval instead of **block** interval. This was raised by @jaoleal on the thread. It makes a stuck node easier to spot.

But more important then **when** to log it also changes the **how**: It uses structured logging instead of plain strings. The body becomes a stable low-cardinality string you can group by and the variable part becomes typed attributes you can filter and aggregate on.

```
INFO wire: Downloading blocks height=297004 target=321248
INFO wire: Backfilling blocks height=8751 target=296870
```

See https://github.com/getfloresta/Floresta/issues/167
